### PR TITLE
svc: Clarify enum values for AddressSpaceBaseAddr and AddressSpaceSiz…

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -448,25 +448,12 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     case GetInfoType::RandomEntropy:
         *result = 0;
         break;
-    case GetInfoType::AddressSpaceBaseAddr:
-        *result = vm_manager.GetCodeRegionBaseAddress();
+    case GetInfoType::ASLRRegionBaseAddr:
+        *result = vm_manager.GetASLRRegionBaseAddress();
         break;
-    case GetInfoType::AddressSpaceSize: {
-        const u64 width = vm_manager.GetAddressSpaceWidth();
-
-        switch (width) {
-        case 32:
-            *result = 0xFFE00000;
-            break;
-        case 36:
-            *result = 0xFF8000000;
-            break;
-        case 39:
-            *result = 0x7FF8000000;
-            break;
-        }
+    case GetInfoType::ASLRRegionSize:
+        *result = vm_manager.GetASLRRegionSize();
         break;
-    }
     case GetInfoType::NewMapRegionBaseAddr:
         *result = vm_manager.GetNewMapRegionBaseAddress();
         break;

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -41,8 +41,8 @@ enum class GetInfoType : u64 {
     RandomEntropy = 11,
     PerformanceCounter = 0xF0000002,
     // 2.0.0+
-    AddressSpaceBaseAddr = 12,
-    AddressSpaceSize = 13,
+    ASLRRegionBaseAddr = 12,
+    ASLRRegionSize = 13,
     NewMapRegionBaseAddr = 14,
     NewMapRegionSize = 15,
     // 3.0.0+

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -393,30 +393,35 @@ void VMManager::InitializeMemoryRegionRanges(FileSys::ProgramAddressSpaceType ty
 
     switch (type) {
     case FileSys::ProgramAddressSpaceType::Is32Bit:
+    case FileSys::ProgramAddressSpaceType::Is32BitNoMap:
         address_space_width = 32;
         code_region_base = 0x200000;
         code_region_end = code_region_base + 0x3FE00000;
-        map_region_size = 0x40000000;
-        heap_region_size = 0x40000000;
+        aslr_region_base = 0x200000;
+        aslr_region_end = aslr_region_base + 0xFFE00000;
+        if (type == FileSys::ProgramAddressSpaceType::Is32Bit) {
+            map_region_size = 0x40000000;
+            heap_region_size = 0x40000000;
+        } else {
+            map_region_size = 0;
+            heap_region_size = 0x80000000;
+        }
         break;
     case FileSys::ProgramAddressSpaceType::Is36Bit:
         address_space_width = 36;
         code_region_base = 0x8000000;
         code_region_end = code_region_base + 0x78000000;
+        aslr_region_base = 0x8000000;
+        aslr_region_end = aslr_region_base + 0xFF8000000;
         map_region_size = 0x180000000;
         heap_region_size = 0x180000000;
-        break;
-    case FileSys::ProgramAddressSpaceType::Is32BitNoMap:
-        address_space_width = 32;
-        code_region_base = 0x200000;
-        code_region_end = code_region_base + 0x3FE00000;
-        map_region_size = 0;
-        heap_region_size = 0x80000000;
         break;
     case FileSys::ProgramAddressSpaceType::Is39Bit:
         address_space_width = 39;
         code_region_base = 0x8000000;
         code_region_end = code_region_base + 0x80000000;
+        aslr_region_base = 0x8000000;
+        aslr_region_end = aslr_region_base + 0x7FF8000000;
         map_region_size = 0x1000000000;
         heap_region_size = 0x180000000;
         new_map_region_size = 0x80000000;
@@ -488,6 +493,18 @@ u64 VMManager::GetAddressSpaceSize() const {
 
 u64 VMManager::GetAddressSpaceWidth() const {
     return address_space_width;
+}
+
+VAddr VMManager::GetASLRRegionBaseAddress() const {
+    return aslr_region_base;
+}
+
+VAddr VMManager::GetASLRRegionEndAddress() const {
+    return aslr_region_end;
+}
+
+u64 VMManager::GetASLRRegionSize() const {
+    return aslr_region_end - aslr_region_base;
 }
 
 VAddr VMManager::GetCodeRegionBaseAddress() const {

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -205,6 +205,15 @@ public:
     /// Gets the address space width in bits.
     u64 GetAddressSpaceWidth() const;
 
+    /// Gets the base address of the ASLR region.
+    VAddr GetASLRRegionBaseAddress() const;
+
+    /// Gets the end address of the ASLR region.
+    VAddr GetASLRRegionEndAddress() const;
+
+    /// Gets the size of the ASLR region
+    u64 GetASLRRegionSize() const;
+
     /// Gets the base address of the code region.
     VAddr GetCodeRegionBaseAddress() const;
 
@@ -305,6 +314,9 @@ private:
     u32 address_space_width = 0;
     VAddr address_space_base = 0;
     VAddr address_space_end = 0;
+
+    VAddr aslr_region_base = 0;
+    VAddr aslr_region_end = 0;
 
     VAddr code_region_base = 0;
     VAddr code_region_end = 0;


### PR DESCRIPTION
…e in svcGetInfo()

So, one thing that's puzzled me is why the kernel seemed to *not* use
the direct code address ranges in some cases for some service functions.
For example, in svcMapMemory, the full address space width is compared
against for validity, but for svcMapSharedMemory, it compares against
0xFFE00000, 0xFF8000000, and 0x7FF8000000 as upper bounds, and uses
either 0x200000 or 0x8000000 as the lower-bounds as the beginning of the
compared range. Coincidentally, these exact same values are also used in
svcGetInfo, and also when initializing the user address space, so this
is actually retrieving the ASLR extents, not the extents of the address
space in general.