### PR TITLE
Fixed Layered Textures Loading and Cubemaps

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -124,6 +124,7 @@ void SurfaceParams::InitCacheParameters(Tegra::GPUVAddr gpu_addr_) {
         break;
     }
 
+    params.is_layered = SurfaceTargetIsLayered(params.target);
     params.max_mip_level = config.tic.max_mip_level + 1;
     params.rt = {};
 
@@ -150,6 +151,7 @@ void SurfaceParams::InitCacheParameters(Tegra::GPUVAddr gpu_addr_) {
     params.target = SurfaceTarget::Texture2D;
     params.depth = 1;
     params.max_mip_level = 0;
+    params.is_layered = false;
 
     // Render target specific parameters, not used for caching
     params.rt.index = static_cast<u32>(index);
@@ -182,6 +184,7 @@ void SurfaceParams::InitCacheParameters(Tegra::GPUVAddr gpu_addr_) {
     params.target = SurfaceTarget::Texture2D;
     params.depth = 1;
     params.max_mip_level = 0;
+    params.is_layered = false;
     params.rt = {};
 
     params.InitCacheParameters(zeta_address);
@@ -890,12 +893,25 @@ void CachedSurface::LoadGLBuffer() {
         if (params.target == SurfaceParams::SurfaceTarget::Texture2D) {
             // TODO(Blinkhawk): Eliminate this condition once all texture types are implemented.
             depth = 1U;
-            block_depth = 1U;
         }
 
-        morton_to_gl_fns[static_cast<std::size_t>(params.pixel_format)](
-            params.width, params.block_height, params.height, block_depth, depth, gl_buffer.data(),
-            gl_buffer.size(), params.addr);
+        if (params.is_layered) {
+            u64 offset = 0;
+            u64 offset_gl = 0;
+            u64 layer_size = params.LayerMemorySize();
+            u64 gl_size = params.LayerSizeGL();
+            for (u32 i = 0; i < depth; i++) {
+                morton_to_gl_fns[static_cast<std::size_t>(params.pixel_format)](
+                    params.width, params.block_height, params.height, block_depth, 1,
+                    gl_buffer.data() + offset_gl, gl_size, params.addr + offset);
+                offset += layer_size;
+                offset_gl += gl_size;
+            }
+        } else {
+            morton_to_gl_fns[static_cast<std::size_t>(params.pixel_format)](
+                params.width, params.block_height, params.height, block_depth, depth,
+                gl_buffer.data(), gl_buffer.size(), params.addr);
+        }
     } else {
         const auto texture_src_data{Memory::GetPointer(params.addr)};
         const auto texture_src_data_end{texture_src_data + params.size_in_bytes_gl};
@@ -939,9 +955,23 @@ void CachedSurface::FlushGLBuffer() {
             // TODO(Blinkhawk): Eliminate this condition once all texture types are implemented.
             depth = 1U;
         }
-        gl_to_morton_fns[static_cast<size_t>(params.pixel_format)](
-            params.width, params.block_height, params.height, block_depth, depth, gl_buffer.data(),
-            gl_buffer.size(), GetAddr());
+        if (params.is_layered) {
+            u64 offset = 0;
+            u64 offset_gl = 0;
+            u64 layer_size = params.LayerMemorySize();
+            u64 gl_size = params.LayerSizeGL();
+            for (u32 i = 0; i < depth; i++) {
+                gl_to_morton_fns[static_cast<std::size_t>(params.pixel_format)](
+                    params.width, params.block_height, params.height, block_depth, 1,
+                    gl_buffer.data() + offset_gl, gl_size, GetAddr() + offset);
+                offset += layer_size;
+                offset_gl += gl_size;
+            }
+        } else {
+            gl_to_morton_fns[static_cast<size_t>(params.pixel_format)](
+                params.width, params.block_height, params.height, block_depth, depth,
+                gl_buffer.data(), gl_buffer.size(), GetAddr());
+        }
     } else {
         std::memcpy(Memory::GetPointer(GetAddr()), gl_buffer.data(), GetSizeInBytes());
     }
@@ -1179,7 +1209,7 @@ void RasterizerCacheOpenGL::AccurateCopySurface(const Surface& src_surface,
                                                 const Surface& dst_surface) {
     const auto& src_params{src_surface->GetSurfaceParams()};
     const auto& dst_params{dst_surface->GetSurfaceParams()};
-    FlushRegion(src_params.addr, dst_params.size_in_bytes);
+    FlushRegion(src_params.addr, dst_params.MemorySize());
     LoadSurface(dst_surface);
 }
 
@@ -1221,44 +1251,10 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& old_surface,
             CopySurface(old_surface, new_surface, copy_pbo.handle);
         }
         break;
+    case SurfaceParams::SurfaceTarget::TextureCubemap:
     case SurfaceParams::SurfaceTarget::Texture3D:
         AccurateCopySurface(old_surface, new_surface);
         break;
-    case SurfaceParams::SurfaceTarget::TextureCubemap: {
-        if (old_params.rt.array_mode != 1) {
-            // TODO(bunnei): This is used by Breath of the Wild, I'm not sure how to implement this
-            // yet (array rendering used as a cubemap texture).
-            LOG_CRITICAL(HW_GPU, "Unhandled rendertarget array_mode {}", old_params.rt.array_mode);
-            UNREACHABLE();
-            return new_surface;
-        }
-
-        // This seems to be used for render-to-cubemap texture
-        ASSERT_MSG(old_params.target == SurfaceParams::SurfaceTarget::Texture2D, "Unexpected");
-        ASSERT_MSG(old_params.pixel_format == new_params.pixel_format, "Unexpected");
-        ASSERT_MSG(old_params.rt.base_layer == 0, "Unimplemented");
-
-        // TODO(bunnei): Verify the below - this stride seems to be in 32-bit words, not pixels.
-        // Tested with Splatoon 2, Super Mario Odyssey, and Breath of the Wild.
-        const std::size_t byte_stride{old_params.rt.layer_stride * sizeof(u32)};
-
-        for (std::size_t index = 0; index < new_params.depth; ++index) {
-            Surface face_surface{TryGetReservedSurface(old_params)};
-            ASSERT_MSG(face_surface, "Unexpected");
-
-            if (is_blit) {
-                BlitSurface(face_surface, new_surface, read_framebuffer.handle,
-                            draw_framebuffer.handle, face_surface->GetSurfaceParams().rt.index,
-                            new_params.rt.index, index);
-            } else {
-                CopySurface(face_surface, new_surface, copy_pbo.handle,
-                            face_surface->GetSurfaceParams().rt.index, new_params.rt.index, index);
-            }
-
-            old_params.addr += byte_stride;
-        }
-        break;
-    }
     default:
         LOG_CRITICAL(Render_OpenGL, "Unimplemented surface target={}",
                      static_cast<u32>(new_params.target));
@@ -1266,7 +1262,7 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& old_surface,
     }
 
     return new_surface;
-}
+} // namespace OpenGL
 
 Surface RasterizerCacheOpenGL::TryFindFramebufferSurface(VAddr addr) const {
     return TryGet(addr);

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -280,13 +280,13 @@ std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat
 std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height, u32 depth,
                           u32 block_height, u32 block_depth) {
     if (tiled) {
-        const u32 gobs_in_x = 64 / bytes_per_pixel;
+        const u32 gobs_in_x = 64;
         const u32 gobs_in_y = 8;
         const u32 gobs_in_z = 1;
-        const u32 aligned_width = Common::AlignUp(width, gobs_in_x);
+        const u32 aligned_width = Common::AlignUp(width * bytes_per_pixel, gobs_in_x);
         const u32 aligned_height = Common::AlignUp(height, gobs_in_y * block_height);
         const u32 aligned_depth = Common::AlignUp(depth, gobs_in_z * block_depth);
-        return aligned_width * aligned_height * aligned_depth * bytes_per_pixel;
+        return aligned_width * aligned_height * aligned_depth;
     } else {
         return width * height * depth * bytes_per_pixel;
     }


### PR DESCRIPTION
This pull request fixes several issues concerning texture arrays and cubemaps. Before we were reading this types of textures naively without calculating the spacing between them (the mipmaps). With this PR, we correct this issue and add the ability to interpret cubemaps correctly.

As many issues this fixes, it may also bring to light new issues as this textures weren't working correctly and things not shown before will now be shown.