### PR TITLE
gl_shader_decompiler: Move position varying declaration back to gl_shader_gen 

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -30,8 +30,6 @@ using Tegra::Shader::SubOp;
 constexpr u32 PROGRAM_END = MAX_PROGRAM_CODE_LENGTH;
 constexpr u32 PROGRAM_HEADER_SIZE = sizeof(Tegra::Shader::Header);
 
-enum : u32 { POSITION_VARYING_LOCATION = 0, GENERIC_VARYING_START_LOCATION = 1 };
-
 constexpr u32 MAX_GEOMETRY_BUFFERS = 6;
 constexpr u32 MAX_ATTRIBUTES = 0x100; // Size in vec4s, this value is untested
 
@@ -591,13 +589,6 @@ private:
 
     /// Generates declarations for input attributes.
     void GenerateInputAttrs() {
-        if (stage != Maxwell3D::Regs::ShaderStage::Vertex) {
-            const std::string attr =
-                stage == Maxwell3D::Regs::ShaderStage::Geometry ? "gs_position[]" : "position";
-            declarations.AddLine("layout (location = " + std::to_string(POSITION_VARYING_LOCATION) +
-                                 ") in vec4 " + attr + ';');
-        }
-
         for (const auto element : declr_input_attribute) {
             // TODO(bunnei): Use proper number of elements for these
             u32 idx =
@@ -620,10 +611,6 @@ private:
 
     /// Generates declarations for output attributes.
     void GenerateOutputAttrs() {
-        if (stage != Maxwell3D::Regs::ShaderStage::Fragment) {
-            declarations.AddLine("layout (location = " + std::to_string(POSITION_VARYING_LOCATION) +
-                                 ") out vec4 position;");
-        }
         for (const auto& index : declr_output_attribute) {
             // TODO(bunnei): Use proper number of elements for these
             const u32 idx = static_cast<u32>(index) -

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -23,6 +23,8 @@ out gl_PerVertex {
     vec4 gl_Position;
 };
 
+layout (location = 0) out vec4 position;
+
 layout(std140) uniform vs_config {
     vec4 viewport_flip;
     uvec4 instance_id;
@@ -96,6 +98,9 @@ out gl_PerVertex {
     vec4 gl_Position;
 };
 
+layout (location = 0) in vec4 gs_position[];
+layout (location = 0) out vec4 position;
+
 layout (std140) uniform gs_config {
     vec4 viewport_flip;
     uvec4 instance_id;
@@ -130,6 +135,8 @@ layout(location = 4) out vec4 FragColor4;
 layout(location = 5) out vec4 FragColor5;
 layout(location = 6) out vec4 FragColor6;
 layout(location = 7) out vec4 FragColor7;
+
+layout (location = 0) in vec4 position;
 
 layout (std140) uniform fs_config {
     vec4 viewport_flip;

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -16,6 +16,8 @@ namespace OpenGL::GLShader {
 constexpr std::size_t MAX_PROGRAM_CODE_LENGTH{0x1000};
 using ProgramCode = std::vector<u64>;
 
+enum : u32 { POSITION_VARYING_LOCATION = 0, GENERIC_VARYING_START_LOCATION = 1 };
+
 class ConstBufferEntry {
     using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 


### PR DESCRIPTION
The intention of declaring them in gl_shader_decompiler was to be able to use blocks to implement geometry shaders. But that wasn't needed in the end and it caused issues when both vertex stages were being used, resulting in a redeclaration of "position".