### PR TITLE
svc: Fix vma boundary check in svcQueryMemory 

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -654,7 +654,7 @@ static ResultCode QueryProcessMemory(MemoryInfo* memory_info, PageInfo* /*page_i
     }
     auto vma = process->VMManager().FindVMA(addr);
     memory_info->attributes = 0;
-    if (vma == Core::CurrentProcess()->VMManager().vma_map.end()) {
+    if (vma == process->VMManager().vma_map.end()) {
         memory_info->base_address = 0;
         memory_info->permission = static_cast<u32>(VMAPermission::None);
         memory_info->size = 0;


### PR DESCRIPTION
This should be comparing against the queried process' vma_map, not the current process'. The only reason this hasn't become an issue yet is we currently only handle one process being active at any time.