### PR TITLE
kernel/process: Make the handle table per-process 

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -24,10 +24,10 @@ class ServiceFrameworkBase;
 namespace Kernel {
 
 class Domain;
+class Event;
 class HandleTable;
 class HLERequestContext;
 class Process;
-class Event;
 
 /**
  * Interface implemented by HLE Session handlers.
@@ -126,13 +126,12 @@ public:
                                        u64 timeout, WakeupCallback&& callback,
                                        Kernel::SharedPtr<Kernel::Event> event = nullptr);
 
-    void ParseCommandBuffer(u32_le* src_cmdbuf, bool incoming);
-
     /// Populates this context with data from the requesting process/thread.
-    ResultCode PopulateFromIncomingCommandBuffer(u32_le* src_cmdbuf, Process& src_process,
-                                                 HandleTable& src_table);
+    ResultCode PopulateFromIncomingCommandBuffer(const HandleTable& handle_table,
+                                                 u32_le* src_cmdbuf);
+
     /// Writes data from this context back to the requesting process/thread.
-    ResultCode WriteToOutgoingCommandBuffer(const Thread& thread);
+    ResultCode WriteToOutgoingCommandBuffer(Thread& thread);
 
     u32_le GetCommand() const {
         return command;
@@ -255,6 +254,8 @@ public:
     std::string Description() const;
 
 private:
+    void ParseCommandBuffer(const HandleTable& handle_table, u32_le* src_cmdbuf, bool incoming);
+
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH> cmd_buf;
     SharedPtr<Kernel::ServerSession> server_session;
     // TODO(yuriks): Check common usage of this and optimize size accordingly

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -118,7 +118,6 @@ struct KernelCore::Impl {
         process_list.clear();
         current_process = nullptr;
 
-        handle_table.Clear();
         resource_limits.fill(nullptr);
 
         thread_wakeup_callback_handle_table.Clear();
@@ -209,7 +208,6 @@ struct KernelCore::Impl {
     std::vector<SharedPtr<Process>> process_list;
     Process* current_process = nullptr;
 
-    Kernel::HandleTable handle_table;
     std::array<SharedPtr<ResourceLimit>, 4> resource_limits;
 
     /// The event type of the generic timer callback event
@@ -239,14 +237,6 @@ void KernelCore::Initialize() {
 
 void KernelCore::Shutdown() {
     impl->Shutdown();
-}
-
-Kernel::HandleTable& KernelCore::HandleTable() {
-    return impl->handle_table;
-}
-
-const Kernel::HandleTable& KernelCore::HandleTable() const {
-    return impl->handle_table;
 }
 
 SharedPtr<ResourceLimit> KernelCore::ResourceLimitForCategory(

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -47,12 +47,6 @@ public:
     /// Clears all resources in use by the kernel instance.
     void Shutdown();
 
-    /// Provides a reference to the handle table.
-    Kernel::HandleTable& HandleTable();
-
-    /// Provides a const reference to the handle table.
-    const Kernel::HandleTable& HandleTable() const;
-
     /// Retrieves a shared pointer to a ResourceLimit identified by the given category.
     SharedPtr<ResourceLimit> ResourceLimitForCategory(ResourceLimitCategory category) const;
 

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -13,6 +13,7 @@
 #include <boost/container/static_vector.hpp>
 #include "common/bit_field.h"
 #include "common/common_types.h"
+#include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/vm_manager.h"
@@ -140,6 +141,16 @@ public:
     /// Gets a const reference to the process' memory manager.
     const Kernel::VMManager& VMManager() const {
         return vm_manager;
+    }
+
+    /// Gets a reference to the process' handle table.
+    HandleTable& GetHandleTable() {
+        return handle_table;
+    }
+
+    /// Gets a const reference to the process' handle table.
+    const HandleTable& GetHandleTable() const {
+        return handle_table;
     }
 
     /// Gets the current status of the process
@@ -293,6 +304,9 @@ private:
     /// By default, we currently assume this is true, unless otherwise
     /// specified by metadata provided to the process during loading.
     bool is_64bit_process = true;
+
+    /// Per-process handle table for storing created object handles in.
+    HandleTable handle_table;
 
     std::string name;
 };

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -107,8 +107,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
     // similar.
     Kernel::HLERequestContext context(this);
     u32* cmd_buf = (u32*)Memory::GetPointer(thread->GetTLSAddress());
-    context.PopulateFromIncomingCommandBuffer(cmd_buf, *Core::CurrentProcess(),
-                                              kernel.HandleTable());
+    context.PopulateFromIncomingCommandBuffer(kernel.CurrentProcess()->GetHandleTable(), cmd_buf);
 
     ResultCode result = RESULT_SUCCESS;
     // If the session has been converted to a domain, handle the domain request

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -266,7 +266,7 @@ SharedPtr<Thread> SetupMainThread(KernelCore& kernel, VAddr entry_point, u32 pri
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 
     // Register 1 must be a handle to the main thread
-    const Handle guest_handle = kernel.HandleTable().Create(thread).Unwrap();
+    const Handle guest_handle = owner_process.GetHandleTable().Create(thread).Unwrap();
     thread->SetGuestHandle(guest_handle);
     thread->GetContext().cpu_registers[1] = guest_handle;
 

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -9,8 +9,8 @@
 #include "core/core.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
-#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/mutex.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/timer.h"
@@ -83,7 +83,7 @@ QString WaitTreeText::GetText() const {
 }
 
 WaitTreeMutexInfo::WaitTreeMutexInfo(VAddr mutex_address) : mutex_address(mutex_address) {
-    auto& handle_table = Core::System::GetInstance().Kernel().HandleTable();
+    const auto& handle_table = Core::CurrentProcess()->GetHandleTable();
 
     mutex_value = Memory::Read32(mutex_address);
     owner_handle = static_cast<Kernel::Handle>(mutex_value & Kernel::Mutex::MutexOwnerMask);


### PR DESCRIPTION
In the kernel, there isn't a singular handle table that everything gets tossed into or used, rather, each process gets its own handle table that it uses. This currently isn't an issue for us, since we only execute one process at the moment, but we may as well get this out of the way so it's not a headache later on.

Coincidentally, this way makes it much easier to eliminate accessing some of the Core namespace functions directly in kernel code, which is a nice benefit.