### PR TITLE
CMakeLists: Use target_compile_definitions instead of add_definitions to define YUZU_ENABLE_COMPATIBILITY_REPORTING

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(yuzu PRIVATE Boost::boost glad Qt5::OpenGL Qt5::Widgets)
 target_link_libraries(yuzu PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if (YUZU_ENABLE_COMPATIBILITY_REPORTING)
-    add_definitions(-DYUZU_ENABLE_COMPATIBILITY_REPORTING)
+    target_compile_definitions(yuzu PRIVATE -DYUZU_ENABLE_COMPATIBILITY_REPORTING)
 endif()
 
 if (USE_DISCORD_PRESENCE)


### PR DESCRIPTION
Keeps the definition constrained to the yuzu target and prevents polluting anything else in the same directory (should that ever happen). It also keeps it consistent with how the USE_DISCORD_PRESENCE definition is introduced below it.