### PR TITLE
service: Update service function tables 

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -156,6 +156,8 @@ add_library(core STATIC
     hle/service/am/omm.h
     hle/service/am/spsm.cpp
     hle/service/am/spsm.h
+    hle/service/am/tcap.cpp
+    hle/service/am/tcap.h
     hle/service/aoc/aoc_u.cpp
     hle/service/aoc/aoc_u.h
     hle/service/apm/apm.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -282,6 +282,8 @@ add_library(core STATIC
     hle/service/nifm/nifm.h
     hle/service/nim/nim.cpp
     hle/service/nim/nim.h
+    hle/service/npns/npns.cpp
+    hle/service/npns/npns.h
     hle/service/ns/ns.cpp
     hle/service/ns/ns.h
     hle/service/ns/pl_u.cpp

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -15,6 +15,7 @@
 #include "core/hle/service/am/idle.h"
 #include "core/hle/service/am/omm.h"
 #include "core/hle/service/am/spsm.h"
+#include "core/hle/service/am/tcap.h"
 #include "core/hle/service/apm/apm.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
@@ -829,6 +830,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager,
     std::make_shared<IdleSys>()->InstallAsService(service_manager);
     std::make_shared<OMM>()->InstallAsService(service_manager);
     std::make_shared<SPSM>()->InstallAsService(service_manager);
+    std::make_shared<TCAP>()->InstallAsService(service_manager);
 }
 
 IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions") {

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -26,13 +26,18 @@
 namespace Service::AM {
 
 IWindowController::IWindowController() : ServiceFramework("IWindowController") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "CreateWindow"},
         {1, &IWindowController::GetAppletResourceUserId, "GetAppletResourceUserId"},
         {10, &IWindowController::AcquireForegroundRights, "AcquireForegroundRights"},
         {11, nullptr, "ReleaseForegroundRights"},
         {12, nullptr, "RejectToChangeIntoBackground"},
+        {20, nullptr, "SetAppletWindowVisibility"},
+        {21, nullptr, "SetAppletGpuTimeSlice"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 
@@ -87,6 +92,7 @@ void IAudioController::GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestCo
 }
 
 IDisplayController::IDisplayController() : ServiceFramework("IDisplayController") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetLastForegroundCaptureImage"},
         {1, nullptr, "UpdateLastForegroundCaptureImage"},
@@ -117,7 +123,11 @@ IDisplayController::IDisplayController() : ServiceFramework("IDisplayController"
         {25, nullptr, "ReleaseLastForegroundCaptureSharedBuffer"},
         {26, nullptr, "AcquireCallerAppletCaptureSharedBuffer"},
         {27, nullptr, "ReleaseCallerAppletCaptureSharedBuffer"},
+        // 6.0.0+
+        {28, nullptr, "TakeScreenShotOfOwnLayerEx"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 
@@ -128,6 +138,7 @@ IDebugFunctions::~IDebugFunctions() = default;
 
 ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
     : ServiceFramework("ISelfController"), nvflinger(std::move(nvflinger)) {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "Exit"},
         {1, &ISelfController::LockExit, "LockExit"},
@@ -136,10 +147,8 @@ ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger
         {4, nullptr, "LeaveFatalSection"},
         {9, &ISelfController::GetLibraryAppletLaunchableEvent, "GetLibraryAppletLaunchableEvent"},
         {10, &ISelfController::SetScreenShotPermission, "SetScreenShotPermission"},
-        {11, &ISelfController::SetOperationModeChangedNotification,
-         "SetOperationModeChangedNotification"},
-        {12, &ISelfController::SetPerformanceModeChangedNotification,
-         "SetPerformanceModeChangedNotification"},
+        {11, &ISelfController::SetOperationModeChangedNotification, "SetOperationModeChangedNotification"},
+        {12, &ISelfController::SetPerformanceModeChangedNotification, "SetPerformanceModeChangedNotification"},
         {13, &ISelfController::SetFocusHandlingMode, "SetFocusHandlingMode"},
         {14, &ISelfController::SetRestartMessageEnabled, "SetRestartMessageEnabled"},
         {15, nullptr, "SetScreenShotAppletIdentityInfo"},
@@ -165,7 +174,12 @@ ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger
         {69, nullptr, "IsAutoSleepDisabled"},
         {70, nullptr, "ReportMultimediaError"},
         {80, nullptr, "SetWirelessPriorityMode"},
+        {90, nullptr, "GetAccumulatedSuspendedTickValue"},
+        {91, nullptr, "GetAccumulatedSuspendedTickChangedEvent"},
+        {1000, nullptr, "GetDebugStorageChannel"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 
     auto& kernel = Core::System::GetInstance().Kernel();
@@ -312,6 +326,7 @@ void ISelfController::GetIdleTimeDetectionExtension(Kernel::HLERequestContext& c
 }
 
 ICommonStateGetter::ICommonStateGetter() : ServiceFramework("ICommonStateGetter") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, &ICommonStateGetter::GetEventHandle, "GetEventHandle"},
         {1, &ICommonStateGetter::ReceiveMessage, "ReceiveMessage"},
@@ -336,11 +351,12 @@ ICommonStateGetter::ICommonStateGetter() : ServiceFramework("ICommonStateGetter"
         {52, nullptr, "SwitchLcdBacklight"},
         {55, nullptr, "IsInControllerFirmwareUpdateSection"},
         {60, &ICommonStateGetter::GetDefaultDisplayResolution, "GetDefaultDisplayResolution"},
-        {61, &ICommonStateGetter::GetDefaultDisplayResolutionChangeEvent,
-         "GetDefaultDisplayResolutionChangeEvent"},
+        {61, &ICommonStateGetter::GetDefaultDisplayResolutionChangeEvent, "GetDefaultDisplayResolutionChangeEvent"},
         {62, nullptr, "GetHdcpAuthenticationState"},
         {63, nullptr, "GetHdcpAuthenticationStateChangeEvent"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 
     auto& kernel = Core::System::GetInstance().Kernel();
@@ -432,11 +448,14 @@ class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
 public:
     explicit IStorageAccessor(std::vector<u8> buffer)
         : ServiceFramework("IStorageAccessor"), buffer(std::move(buffer)) {
+        // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IStorageAccessor::GetSize, "GetSize"},
             {10, &IStorageAccessor::Write, "Write"},
             {11, &IStorageAccessor::Read, "Read"},
         };
+        // clang-format on
+
         RegisterHandlers(functions);
     }
 
@@ -489,10 +508,13 @@ class IStorage final : public ServiceFramework<IStorage> {
 public:
     explicit IStorage(std::vector<u8> buffer)
         : ServiceFramework("IStorage"), buffer(std::move(buffer)) {
+        // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IStorage::Open, "Open"},
             {1, nullptr, "OpenTransferStorage"},
         };
+        // clang-format on
+
         RegisterHandlers(functions);
     }
 
@@ -512,6 +534,7 @@ private:
 class ILibraryAppletAccessor final : public ServiceFramework<ILibraryAppletAccessor> {
 public:
     explicit ILibraryAppletAccessor() : ServiceFramework("ILibraryAppletAccessor") {
+        // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ILibraryAppletAccessor::GetAppletStateChangedEvent, "GetAppletStateChangedEvent"},
             {1, nullptr, "IsCompleted"},
@@ -532,6 +555,8 @@ public:
             {150, nullptr, "RequestForAppletToGetForeground"},
             {160, nullptr, "GetIndirectLayerConsumerHandle"},
         };
+        // clang-format on
+
         RegisterHandlers(functions);
 
         auto& kernel = Core::System::GetInstance().Kernel();
@@ -624,13 +649,13 @@ void ILibraryAppletCreator::CreateStorage(Kernel::HLERequestContext& ctx) {
 }
 
 IApplicationFunctions::IApplicationFunctions() : ServiceFramework("IApplicationFunctions") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {1, &IApplicationFunctions::PopLaunchParameter, "PopLaunchParameter"},
         {10, nullptr, "CreateApplicationAndPushAndRequestToStart"},
         {11, nullptr, "CreateApplicationAndPushAndRequestToStartForQuest"},
         {12, nullptr, "CreateApplicationAndRequestToStart"},
-        {13, &IApplicationFunctions::CreateApplicationAndRequestToStartForQuest,
-         "CreateApplicationAndRequestToStartForQuest"},
+        {13, &IApplicationFunctions::CreateApplicationAndRequestToStartForQuest, "CreateApplicationAndRequestToStartForQuest"},
         {20, &IApplicationFunctions::EnsureSaveData, "EnsureSaveData"},
         {21, &IApplicationFunctions::GetDesiredLanguage, "GetDesiredLanguage"},
         {22, &IApplicationFunctions::SetTerminateResult, "SetTerminateResult"},
@@ -638,10 +663,8 @@ IApplicationFunctions::IApplicationFunctions() : ServiceFramework("IApplicationF
         {24, nullptr, "GetLaunchStorageInfoForDebug"},
         {25, nullptr, "ExtendSaveData"},
         {26, nullptr, "GetSaveDataSize"},
-        {30, &IApplicationFunctions::BeginBlockingHomeButtonShortAndLongPressed,
-         "BeginBlockingHomeButtonShortAndLongPressed"},
-        {31, &IApplicationFunctions::EndBlockingHomeButtonShortAndLongPressed,
-         "EndBlockingHomeButtonShortAndLongPressed"},
+        {30, &IApplicationFunctions::BeginBlockingHomeButtonShortAndLongPressed, "BeginBlockingHomeButtonShortAndLongPressed"},
+        {31, &IApplicationFunctions::EndBlockingHomeButtonShortAndLongPressed, "EndBlockingHomeButtonShortAndLongPressed"},
         {32, &IApplicationFunctions::BeginBlockingHomeButton, "BeginBlockingHomeButton"},
         {33, &IApplicationFunctions::EndBlockingHomeButton, "EndBlockingHomeButton"},
         {40, &IApplicationFunctions::NotifyRunning, "NotifyRunning"},
@@ -666,6 +689,8 @@ IApplicationFunctions::IApplicationFunctions() : ServiceFramework("IApplicationF
         {1000, nullptr, "CreateMovieMaker"},
         {1001, nullptr, "PrepareForJit"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 
@@ -807,6 +832,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager,
 }
 
 IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {10, &IHomeMenuFunctions::RequestToGetForeground, "RequestToGetForeground"},
         {11, nullptr, "LockForeground"},
@@ -815,7 +841,10 @@ IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions"
         {21, nullptr, "GetPopFromGeneralChannelEvent"},
         {30, nullptr, "GetHomeButtonWriterLockAccessor"},
         {31, nullptr, "GetWriterLockAccessorEx"},
+        {100, nullptr, "PopRequestLaunchApplicationForDebug"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 
@@ -828,6 +857,7 @@ void IHomeMenuFunctions::RequestToGetForeground(Kernel::HLERequestContext& ctx) 
 }
 
 IGlobalStateController::IGlobalStateController() : ServiceFramework("IGlobalStateController") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestToEnterSleep"},
         {1, nullptr, "EnterSleep"},
@@ -841,18 +871,23 @@ IGlobalStateController::IGlobalStateController() : ServiceFramework("IGlobalStat
         {14, nullptr, "ShouldSleepOnBoot"},
         {15, nullptr, "GetHdcpAuthenticationFailedEvent"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 
 IGlobalStateController::~IGlobalStateController() = default;
 
 IApplicationCreator::IApplicationCreator() : ServiceFramework("IApplicationCreator") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "CreateApplication"},
         {1, nullptr, "PopLaunchRequestedApplication"},
         {10, nullptr, "CreateSystemApplication"},
         {100, nullptr, "PopFloatingApplicationForDevelopment"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 
@@ -860,6 +895,7 @@ IApplicationCreator::~IApplicationCreator() = default;
 
 IProcessWindingController::IProcessWindingController()
     : ServiceFramework("IProcessWindingController") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetLaunchReason"},
         {11, nullptr, "OpenCallingLibraryApplet"},
@@ -870,6 +906,8 @@ IProcessWindingController::IProcessWindingController()
         {40, nullptr, "ReserveToStartAndWaitAndUnwindThis"},
         {41, nullptr, "ReserveToStartAndWait"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -211,6 +211,7 @@ void AppletAE::OpenLibraryAppletProxyOld(Kernel::HLERequestContext& ctx) {
 
 AppletAE::AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
     : ServiceFramework("appletAE"), nvflinger(std::move(nvflinger)) {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {100, &AppletAE::OpenSystemAppletProxy, "OpenSystemAppletProxy"},
         {200, &AppletAE::OpenLibraryAppletProxyOld, "OpenLibraryAppletProxyOld"},
@@ -218,7 +219,10 @@ AppletAE::AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
         {300, nullptr, "OpenOverlayAppletProxy"},
         {350, nullptr, "OpenSystemApplicationProxy"},
         {400, nullptr, "CreateSelfLibraryAppletCreatorForDevelop"},
+        {401, nullptr, "GetSystemAppletControllerForDebug"},
     };
+    // clang-format on
+
     RegisterHandlers(functions);
 }
 

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -14,6 +14,7 @@ class IApplicationProxy final : public ServiceFramework<IApplicationProxy> {
 public:
     explicit IApplicationProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
         : ServiceFramework("IApplicationProxy"), nvflinger(std::move(nvflinger)) {
+        // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IApplicationProxy::GetCommonStateGetter, "GetCommonStateGetter"},
             {1, &IApplicationProxy::GetSelfController, "GetSelfController"},
@@ -25,6 +26,8 @@ public:
             {20, &IApplicationProxy::GetApplicationFunctions, "GetApplicationFunctions"},
             {1000, &IApplicationProxy::GetDebugFunctions, "GetDebugFunctions"},
         };
+        // clang-format on
+
         RegisterHandlers(functions);
     }
 

--- a/src/core/hle/service/am/idle.cpp
+++ b/src/core/hle/service/am/idle.cpp
@@ -12,9 +12,9 @@ IdleSys::IdleSys() : ServiceFramework{"idle:sys"} {
         {0, nullptr, "GetAutoPowerDownEvent"},
         {1, nullptr, "Unknown1"},
         {2, nullptr, "Unknown2"},
-        {3, nullptr, "Unknown3"},
-        {4, nullptr, "Unknown4"},
-        {5, nullptr, "Unknown5"},
+        {3, nullptr, "SetHandlingContext"},
+        {4, nullptr, "LoadAndApplySettings"},
+        {5, nullptr, "ReportUserIsActive"},
     };
     // clang-format on
 

--- a/src/core/hle/service/am/tcap.cpp
+++ b/src/core/hle/service/am/tcap.cpp
@@ -1,0 +1,23 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/am/tcap.h"
+
+namespace Service::AM {
+
+TCAP::TCAP() : ServiceFramework{"tcap"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetContinuousHighSkinTemperatureEvent"},
+        {1, nullptr, "SetOperationMode"},
+        {2, nullptr, "LoadAndApplySettings"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+TCAP::~TCAP() = default;
+
+} // namespace Service::AM

--- a/src/core/hle/service/am/tcap.h
+++ b/src/core/hle/service/am/tcap.h
@@ -1,0 +1,17 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::AM {
+
+class TCAP final : public ServiceFramework<TCAP> {
+public:
+    explicit TCAP();
+    ~TCAP() override;
+};
+
+} // namespace Service::AM

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -827,6 +827,7 @@ public:
             {11, nullptr, "EnableJoyPollingReceiveMode"},
             {12, nullptr, "DisableJoyPollingReceiveMode"},
             {13, nullptr, "GetPollingData"},
+            {14, nullptr, "SetStatusManagerType"},
         };
         // clang-format on
 

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -18,35 +18,35 @@ public:
     explicit LBL() : ServiceFramework{"lbl"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "Unknown1"},
-            {1, nullptr, "Unknown2"},
-            {2, nullptr, "Unknown3"},
-            {3, nullptr, "GetCurrentBacklightLevel"},
-            {4, nullptr, "Unknown4"},
-            {5, nullptr, "GetAlsComputedBacklightLevel"},
-            {6, nullptr, "TurnOffBacklight"},
-            {7, nullptr, "TurnOnBacklight"},
-            {8, nullptr, "GetBacklightStatus"},
-            {9, nullptr, "Unknown5"},
-            {10, nullptr, "Unknown6"},
-            {11, nullptr, "Unknown7"},
-            {12, nullptr, "Unknown8"},
-            {13, nullptr, "Unknown9"},
-            {14, nullptr, "Unknown10"},
-            {15, nullptr, "GetAutoBrightnessSetting"},
-            {16, nullptr, "ReadRawLightSensor"},
-            {17, nullptr, "Unknown11"},
-            {18, nullptr, "Unknown12"},
-            {19, nullptr, "Unknown13"},
-            {20, nullptr, "Unknown14"},
-            {21, nullptr, "Unknown15"},
-            {22, nullptr, "Unknown16"},
-            {23, nullptr, "Unknown17"},
-            {24, nullptr, "Unknown18"},
-            {25, nullptr, "Unknown19"},
+            {0, nullptr, "SaveCurrentSetting"},
+            {1, nullptr, "LoadCurrentSetting"},
+            {2, nullptr, "SetCurrentBrightnessSetting"},
+            {3, nullptr, "GetCurrentBrightnessSetting"},
+            {4, nullptr, "ApplyCurrentBrightnessSettingToBacklight"},
+            {5, nullptr, "GetBrightnessSettingAppliedToBacklight"},
+            {6, nullptr, "SwitchBacklightOn"},
+            {7, nullptr, "SwitchBacklightOff"},
+            {8, nullptr, "GetBacklightSwitchStatus"},
+            {9, nullptr, "EnableDimming"},
+            {10, nullptr, "DisableDimming"},
+            {11, nullptr, "IsDimmingEnabled"},
+            {12, nullptr, "EnableAutoBrightnessControl"},
+            {13, nullptr, "DisableAutoBrightnessControl"},
+            {14, nullptr, "IsAutoBrightnessControlEnabled"},
+            {15, nullptr, "SetAmbientLightSensorValue"},
+            {16, nullptr, "GetAmbientLightSensorValue"},
+            {17, nullptr, "SetBrightnessReflectionDelayLevel"},
+            {18, nullptr, "GetBrightnessReflectionDelayLevel"},
+            {19, nullptr, "SetCurrentBrightnessMapping"},
+            {20, nullptr, "GetCurrentBrightnessMapping"},
+            {21, nullptr, "SetCurrentAmbientLightSensorMapping"},
+            {22, nullptr, "GetCurrentAmbientLightSensorMapping"},
+            {23, nullptr, "IsAmbientLightSensorAvailable"},
+            {24, nullptr, "SetCurrentBrightnessSettingForVrMode"},
+            {25, nullptr, "GetCurrentBrightnessSettingForVrMode"},
             {26, &LBL::EnableVrMode, "EnableVrMode"},
             {27, &LBL::DisableVrMode, "DisableVrMode"},
-            {28, &LBL::GetVrMode, "GetVrMode"},
+            {28, &LBL::IsVrModeEnabled, "IsVrModeEnabled"},
         };
         // clang-format on
 
@@ -72,7 +72,7 @@ private:
         LOG_DEBUG(Service_LBL, "called");
     }
 
-    void GetVrMode(Kernel::HLERequestContext& ctx) {
+    void IsVrModeEnabled(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push(vr_mode_enabled);

--- a/src/core/hle/service/npns/npns.cpp
+++ b/src/core/hle/service/npns/npns.cpp
@@ -1,0 +1,88 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/npns/npns.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::NPNS {
+
+class NPNS_S final : public ServiceFramework<NPNS_S> {
+public:
+    explicit NPNS_S() : ServiceFramework{"npns:s"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {1, nullptr, "ListenAll"},
+            {2, nullptr, "ListenTo"},
+            {3, nullptr, "Receive"},
+            {4, nullptr, "ReceiveRaw"},
+            {5, nullptr, "GetReceiveEvent"},
+            {6, nullptr, "ListenUndelivered"},
+            {7, nullptr, "GetStateChangeEVent"},
+            {11, nullptr, "SubscribeTopic"},
+            {12, nullptr, "UnsubscribeTopic"},
+            {13, nullptr, "QueryIsTopicExist"},
+            {21, nullptr, "CreateToken"},
+            {22, nullptr, "CreateTokenWithApplicationId"},
+            {23, nullptr, "DestroyToken"},
+            {24, nullptr, "DestroyTokenWithApplicationId"},
+            {25, nullptr, "QueryIsTokenValid"},
+            {31, nullptr, "UploadTokenToBaaS"},
+            {32, nullptr, "DestroyTokenForBaaS"},
+            {33, nullptr, "CreateTokenForBaaS"},
+            {34, nullptr, "SetBaaSDeviceAccountIdList"},
+            {101, nullptr, "Suspend"},
+            {102, nullptr, "Resume"},
+            {103, nullptr, "GetState"},
+            {104, nullptr, "GetStatistics"},
+            {105, nullptr, "GetPlayReportRequestEvent"},
+            {111, nullptr, "GetJid"},
+            {112, nullptr, "CreateJid"},
+            {113, nullptr, "DestroyJid"},
+            {114, nullptr, "AttachJid"},
+            {115, nullptr, "DetachJid"},
+            {201, nullptr, "RequestChangeStateForceTimed"},
+            {102, nullptr, "RequestChangeStateForceAsync"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class NPNS_U final : public ServiceFramework<NPNS_U> {
+public:
+    explicit NPNS_U() : ServiceFramework{"npns:u"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {1, nullptr, "ListenAll"},
+            {2, nullptr, "ListenTo"},
+            {3, nullptr, "Receive"},
+            {4, nullptr, "ReceiveRaw"},
+            {5, nullptr, "GetReceiveEvent"},
+            {7, nullptr, "GetStateChangeEVent"},
+            {21, nullptr, "CreateToken"},
+            {23, nullptr, "DestroyToken"},
+            {25, nullptr, "QueryIsTokenValid"},
+            {26, nullptr, "ListenToMyApplicationId"},
+            {101, nullptr, "Suspend"},
+            {102, nullptr, "Resume"},
+            {103, nullptr, "GetState"},
+            {104, nullptr, "GetStatistics"},
+            {111, nullptr, "GetJid"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<NPNS_S>()->InstallAsService(sm);
+    std::make_shared<NPNS_U>()->InstallAsService(sm);
+}
+
+} // namespace Service::NPNS

--- a/src/core/hle/service/npns/npns.h
+++ b/src/core/hle/service/npns/npns.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::NPNS {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::NPNS

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -14,20 +14,24 @@ public:
     explicit PlayReport(const char* name) : ServiceFramework{name} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {10100, nullptr, "SaveReport"},
-            {10101, &PlayReport::SaveReportWithUser, "SaveReportWithUser"},
+            {10100, nullptr, "SaveReportOld"},
+            {10101, &PlayReport::SaveReportWithUserOld, "SaveReportWithUserOld"},
+            {10102, nullptr, "SaveReport"},
+            {10103, nullptr, "SaveReportWithUser"},
             {10200, nullptr, "RequestImmediateTransmission"},
             {10300, nullptr, "GetTransmissionStatus"},
             {20100, nullptr, "SaveSystemReport"},
-            {20200, nullptr, "SetOperationMode"},
             {20101, nullptr, "SaveSystemReportWithUser"},
+            {20200, nullptr, "SetOperationMode"},
             {30100, nullptr, "ClearStorage"},
+            {30200, nullptr, "ClearStatistics"},
+            {30300, nullptr, "GetStorageUsage"},
+            {30400, nullptr, "GetStatistics"},
+            {30401, nullptr, "GetThroughputHistory"},
+            {30500, nullptr, "GetLastUploadError"},
             {40100, nullptr, "IsUserAgreementCheckEnabled"},
             {40101, nullptr, "SetUserAgreementCheckEnabled"},
-            {90100, nullptr, "GetStorageUsage"},
-            {90200, nullptr, "GetStatistics"},
-            {90201, nullptr, "GetThroughputHistory"},
-            {90300, nullptr, "GetLastUploadError"},
+            {90100, nullptr, "ReadAllReportFiles"},
         };
         // clang-format on
 
@@ -35,7 +39,7 @@ public:
     }
 
 private:
-    void SaveReportWithUser(Kernel::HLERequestContext& ctx) {
+    void SaveReportWithUserOld(Kernel::HLERequestContext& ctx) {
         // TODO(ogniK): Do we want to add play report?
         LOG_WARNING(Service_PREPO, "(STUBBED) called");
 
@@ -46,6 +50,7 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<PlayReport>("prepo:a")->InstallAsService(service_manager);
+    std::make_shared<PlayReport>("prepo:a2")->InstallAsService(service_manager);
     std::make_shared<PlayReport>("prepo:m")->InstallAsService(service_manager);
     std::make_shared<PlayReport>("prepo:s")->InstallAsService(service_manager);
     std::make_shared<PlayReport>("prepo:u")->InstallAsService(service_manager);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -22,7 +22,7 @@
 #include "core/hle/service/apm/apm.h"
 #include "core/hle/service/arp/arp.h"
 #include "core/hle/service/audio/audio.h"
-#include "core/hle/service/bcat/bcat.h"
+#include "core/hle/service/bcat/module.h"
 #include "core/hle/service/bpc/bpc.h"
 #include "core/hle/service/btdrv/btdrv.h"
 #include "core/hle/service/btm/btm.h"
@@ -48,11 +48,12 @@
 #include "core/hle/service/nfp/nfp.h"
 #include "core/hle/service/nifm/nifm.h"
 #include "core/hle/service/nim/nim.h"
+#include "core/hle/service/npns/npns.h"
 #include "core/hle/service/ns/ns.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
 #include "core/hle/service/pcie/pcie.h"
-#include "core/hle/service/pctl/pctl.h"
+#include "core/hle/service/pctl/module.h"
 #include "core/hle/service/pcv/pcv.h"
 #include "core/hle/service/pm/pm.h"
 #include "core/hle/service/prepo/prepo.h"
@@ -236,6 +237,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, FileSys::VfsFilesystem& vfs) 
     NFP::InstallInterfaces(*sm);
     NIFM::InstallInterfaces(*sm);
     NIM::InstallInterfaces(*sm);
+    NPNS::InstallInterfaces(*sm);
     NS::InstallInterfaces(*sm);
     Nvidia::InstallInterfaces(*sm, *nv_flinger);
     PCIe::InstallInterfaces(*sm);


### PR DESCRIPTION
Keeps the service function table names in sync with the recent updates made to Switchbrew (shoutouts to Hexkyz). Also adds the shells for the npns and tcap services.