### PR TITLE
Added break types to svcBreak 

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -374,8 +374,9 @@ static ResultCode ArbitrateUnlock(VAddr mutex_addr) {
     return Mutex::Release(mutex_addr);
 }
 
-enum BreakType : u32 {
+enum class BreakType : u32 {
     Panic = 0,
+    AssertionFailed = 1,
     PreNROLoad = 3,
     PostNROLoad = 4,
     PreNROUnload = 5,
@@ -396,34 +397,41 @@ static void Break(u32 reason, u64 info1, u64 info2) {
 
     switch (break_reason.break_type) {
     case BreakType::Panic:
-        LOG_ERROR(Debug_Emulated, "Signalling debugger, PANIC! info1=0x{:016X}, info2=0x{:016X}",
-                  info1, info2);
+        LOG_CRITICAL(Debug_Emulated, "Signalling debugger, PANIC! info1=0x{:016X}, info2=0x{:016X}",
+                     info1, info2);
+        break;
+    case BreakType::AssertionFailed:
+        LOG_CRITICAL(Debug_Emulated,
+                     "Signalling debugger, Assertion failed! info1=0x{:016X}, info2=0x{:016X}",
+                     info1, info2);
         break;
     case BreakType::PreNROLoad:
-        LOG_ERROR(Debug_Emulated,
-                  "Signalling debugger, Attempting to load an NRO at 0x{:016X} with size 0x{:016X}",
-                  info1, info2);
+        LOG_WARNING(
+            Debug_Emulated,
+            "Signalling debugger, Attempting to load an NRO at 0x{:016X} with size 0x{:016X}",
+            info1, info2);
         break;
     case BreakType::PostNROLoad:
-        LOG_ERROR(Debug_Emulated,
-                  "Signalling debugger, Loaded an NRO at 0x{:016X} with size 0x{:016X}", info1,
-                  info2);
+        LOG_WARNING(Debug_Emulated,
+                    "Signalling debugger, Loaded an NRO at 0x{:016X} with size 0x{:016X}", info1,
+                    info2);
         break;
     case BreakType::PreNROUnload:
-        LOG_ERROR(
+        LOG_WARNING(
             Debug_Emulated,
             "Signalling debugger, Attempting to unload an NRO at 0x{:016X} with size 0x{:016X}",
             info1, info2);
         break;
     case BreakType::PostNROUnload:
-        LOG_ERROR(Debug_Emulated,
-                  "Signalling debugger, Unloaded an NRO at 0x{:016X} with size 0x{:016X}", info1,
-                  info2);
+        LOG_WARNING(Debug_Emulated,
+                    "Signalling debugger, Unloaded an NRO at 0x{:016X} with size 0x{:016X}", info1,
+                    info2);
         break;
     default:
-        LOG_ERROR(Debug_Emulated,
-                  "Signalling debugger, Unknown break reason {}, info1=0x{:016X}, info2=0x{:016X}",
-                  static_cast<u32>(break_reason.break_type), info1, info2);
+        LOG_WARNING(
+            Debug_Emulated,
+            "Signalling debugger, Unknown break reason {}, info1=0x{:016X}, info2=0x{:016X}",
+            static_cast<u32>(break_reason.break_type.Value()), info1, info2);
         break;
     }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -374,9 +374,18 @@ static ResultCode ArbitrateUnlock(VAddr mutex_addr) {
     return Mutex::Release(mutex_addr);
 }
 
+enum BreakType : u32 {
+    Panic = 0,
+    PreNROLoad = 3,
+    PostNROLoad = 4,
+    PreNROUnload = 5,
+    PostNROUnload = 6,
+};
+
 struct BreakReason {
     union {
         u32 raw;
+        BitField<0, 30, BreakType> break_type;
         BitField<31, 1, u32> signal_debugger;
     };
 };
@@ -384,12 +393,41 @@ struct BreakReason {
 /// Break program execution
 static void Break(u32 reason, u64 info1, u64 info2) {
     BreakReason break_reason{reason};
-    if (break_reason.signal_debugger) {
+
+    switch (break_reason.break_type) {
+    case BreakType::Panic:
+        LOG_ERROR(Debug_Emulated, "Signalling debugger, PANIC! info1=0x{:016X}, info2=0x{:016X}",
+                  info1, info2);
+        break;
+    case BreakType::PreNROLoad:
+        LOG_ERROR(Debug_Emulated,
+                  "Signalling debugger, Attempting to load an NRO at 0x{:016X} with size 0x{:016X}",
+                  info1, info2);
+        break;
+    case BreakType::PostNROLoad:
+        LOG_ERROR(Debug_Emulated,
+                  "Signalling debugger, Loaded an NRO at 0x{:016X} with size 0x{:016X}", info1,
+                  info2);
+        break;
+    case BreakType::PreNROUnload:
         LOG_ERROR(
             Debug_Emulated,
-            "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
-            reason, info1, info2);
-    } else {
+            "Signalling debugger, Attempting to unload an NRO at 0x{:016X} with size 0x{:016X}",
+            info1, info2);
+        break;
+    case BreakType::PostNROUnload:
+        LOG_ERROR(Debug_Emulated,
+                  "Signalling debugger, Unloaded an NRO at 0x{:016X} with size 0x{:016X}", info1,
+                  info2);
+        break;
+    default:
+        LOG_ERROR(Debug_Emulated,
+                  "Signalling debugger, Unknown break reason {}, info1=0x{:016X}, info2=0x{:016X}",
+                  static_cast<u32>(break_reason.break_type), info1, info2);
+        break;
+    }
+
+    if (!break_reason.signal_debugger) {
         LOG_CRITICAL(
             Debug_Emulated,
             "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",


### PR DESCRIPTION
There seems to be more such as type 1, and 2. Unsure what these currently are but when a game hits them we can investigate and add the rest. Info 1 and Info 2 seems to also provide extra information based on the break. Info 1 usually looks like an address and info 2 looks like a size, however, this also can be zeroed out so the info can be different each type? More research needed but this is a start on better-debugging information.