### PR TITLE
Implement the LoadNro functions from the ldr:ro service. 

### DIFF
--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -99,7 +99,7 @@ VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips) {
             u16 rle_size{};
             if (ips->ReadObject(&rle_size, offset) != sizeof(u16))
                 return nullptr;
-            rle_size = Common::swap16(data_size);
+            rle_size = Common::swap16(rle_size);
             offset += sizeof(u16);
 
             const auto data = ips->ReadByte(offset++);

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -232,6 +232,12 @@ void Process::LoadModule(CodeSet module_, VAddr base_addr) {
     MapSegment(module_.CodeSegment(), VMAPermission::ReadExecute, MemoryState::CodeStatic);
     MapSegment(module_.RODataSegment(), VMAPermission::Read, MemoryState::CodeMutable);
     MapSegment(module_.DataSegment(), VMAPermission::ReadWrite, MemoryState::CodeMutable);
+
+    // Clear instruction cache in CPU JIT
+    Core::System::GetInstance().ArmInterface(0).ClearInstructionCache();
+    Core::System::GetInstance().ArmInterface(1).ClearInstructionCache();
+    Core::System::GetInstance().ArmInterface(2).ClearInstructionCache();
+    Core::System::GetInstance().ArmInterface(3).ClearInstructionCache();
 }
 
 ResultVal<VAddr> Process::HeapAllocate(VAddr target, u64 size, VMAPermission perms) {

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -158,6 +158,14 @@ public:
     ResultVal<VMAHandle> MapBackingMemory(VAddr target, u8* memory, u64 size, MemoryState state);
 
     /**
+     * Finds the first free address that can hold a region of the desired size.
+     *
+     * @param size Size of the desired region.
+     * @return The found free address.
+     */
+    ResultVal<VAddr> FindFreeRegion(u64 size) const;
+
+    /**
      * Maps a memory-mapped IO region at a given address.
      *
      * @param target The guest address to start the mapping at.

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -3,9 +3,13 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <fmt/format.h>
 
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/service/ldr/ldr.h"
 #include "core/hle/service/service.h"
+#include "core/loader/nro.h"
 
 namespace Service::LDR {
 
@@ -59,15 +63,57 @@ public:
     explicit RelocatableObject() : ServiceFramework{"ldr:ro"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "LoadNro"},
+            {0, &RelocatableObject::LoadNro, "LoadNro"},
             {1, nullptr, "UnloadNro"},
-            {2, nullptr, "LoadNrr"},
+            {2, &RelocatableObject::LoadNrr, "LoadNrr"},
             {3, nullptr, "UnloadNrr"},
-            {4, nullptr, "Initialize"},
+            {4, &RelocatableObject::Initialize, "Initialize"},
         };
         // clang-format on
 
         RegisterHandlers(functions);
+    }
+
+    void LoadNrr(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service_LDR, "(STUBBED) called");
+    }
+
+    void LoadNro(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        rp.Skip(2, false);
+        const VAddr nro_addr{rp.Pop<VAddr>()};
+        const u64 nro_size{rp.Pop<u64>()};
+        const VAddr bss_addr{rp.Pop<VAddr>()};
+        const u64 bss_size{rp.Pop<u64>()};
+
+        // Read NRO data from memory
+        std::vector<u8> nro_data(nro_size);
+        Memory::ReadBlock(nro_addr, nro_data.data(), nro_size);
+
+        // Load NRO as new executable module
+        const VAddr addr{*Core::CurrentProcess()->VMManager().FindFreeRegion(nro_size + bss_size)};
+        Loader::AppLoader_NRO::LoadNro(nro_data, fmt::format("nro-{:08x}", addr), addr);
+
+        // TODO(bunnei): This is an incomplete implementation. It was tested with Super Mario Party.
+        // It is currently missing:
+        // - Signature checks with LoadNRR
+        // - Checking if a module has already been loaded
+        // - Using/validating BSS, etc. params (these are used from NRO header instead)
+        // - Error checking
+        // - ...Probably other things
+
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(addr);
+        LOG_WARNING(Service_LDR, "(STUBBED) called");
+    }
+
+    void Initialize(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service_LDR, "(STUBBED) called");
     }
 };
 

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include "common/common_types.h"
 #include "core/loader/linker.h"
 #include "core/loader/loader.h"
@@ -39,6 +40,8 @@ public:
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadTitle(std::string& title) override;
     bool IsRomFSUpdatable() const override;
+
+    static bool LoadNro(const std::vector<u8>& data, const std::string& name, VAddr load_base);
 
 private:
     bool LoadNro(const FileSys::VfsFile& file, VAddr load_base);


### PR DESCRIPTION
Implements LoadNro function using the existing loader code that we have. This is a really simple and somewhat incomplete implementation, but is enough for basic use cases. With this change and #1556, Super Mario Party now boots.
Partially supersedes #1471