### PR TITLE
maxwell_3d/decoders: Remove unused variables

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -155,7 +155,6 @@ void Maxwell3D::ProcessQueryGet() {
     ASSERT_MSG(regs.query.query_get.unit == Regs::QueryUnit::Crop,
                "Units other than CROP are unimplemented");
 
-    u32 value = Memory::Read32(*address);
     u64 result = 0;
 
     // TODO(Subv): Support the other query variables

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -142,7 +142,6 @@ void SwizzledData(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle, 
     const u32 blocks_on_x = div_ceil(width, block_x_elements);
     const u32 blocks_on_y = div_ceil(height, block_y_elements);
     const u32 blocks_on_z = div_ceil(depth, block_z_elements);
-    const u32 blocks = blocks_on_x * blocks_on_y * blocks_on_z;
     const u32 gob_size = gob_x_bytes * gob_elements_y * gob_elements_z;
     const u32 xy_block_size = gob_size * block_height;
     const u32 block_size = xy_block_size * block_depth;


### PR DESCRIPTION
These are both unused, so we can get rid of them.