### PR TITLE
yuzu/configuration/config: Use a std::unique_ptr for qt_config instead of a raw pointer 

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -12,9 +12,14 @@ Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
     qt_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "qt-config.ini";
     FileUtil::CreateFullPath(qt_config_loc);
-    qt_config = new QSettings(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
+    qt_config =
+        std::make_unique<QSettings>(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
 
     Reload();
+}
+
+Config::~Config() {
+    Save();
 }
 
 const std::array<int, Settings::NativeButton::NumButtons> Config::default_buttons = {
@@ -336,10 +341,4 @@ void Config::Reload() {
 
 void Config::Save() {
     SaveValues();
-}
-
-Config::~Config() {
-    Save();
-
-    delete qt_config;
 }

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -12,12 +12,6 @@
 class QSettings;
 
 class Config {
-    QSettings* qt_config;
-    std::string qt_config_loc;
-
-    void ReadValues();
-    void SaveValues();
-
 public:
     Config();
     ~Config();
@@ -27,4 +21,11 @@ public:
 
     static const std::array<int, Settings::NativeButton::NumButtons> default_buttons;
     static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs;
+
+private:
+    void ReadValues();
+    void SaveValues();
+
+    QSettings* qt_config;
+    std::string qt_config_loc;
 };

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <string>
 #include <QVariant>
 #include "core/settings.h"
@@ -26,6 +27,6 @@ private:
     void ReadValues();
     void SaveValues();
 
-    QSettings* qt_config;
+    std::unique_ptr<QSettings> qt_config;
     std::string qt_config_loc;
 };


### PR DESCRIPTION
Same behavior, less code