### PR TITLE
bootmanager: Use QStringLiteral instead of std::string to represent the window title.

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -8,7 +8,6 @@
 
 #include "common/microprofile.h"
 #include "common/scm_rev.h"
-#include "common/string_util.h"
 #include "core/core.h"
 #include "core/frontend/framebuffer_layout.h"
 #include "core/settings.h"
@@ -107,9 +106,8 @@ private:
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
     : QWidget(parent), child(nullptr), emu_thread(emu_thread) {
 
-    std::string window_title = fmt::format("yuzu {} | {}-{}", Common::g_build_name,
-                                           Common::g_scm_branch, Common::g_scm_desc);
-    setWindowTitle(QString::fromStdString(window_title));
+    setWindowTitle(QStringLiteral("yuzu %1 | %2-%3")
+                       .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
     setAttribute(Qt::WA_AcceptTouchEvents);
 
     InputCommon::Init();


### PR DESCRIPTION
This gets rid of an unnecessary type conversion. We can just use the regular QStringLiteral to already format the string as the type setWindowTitle accepts instead of converting from a std::string instance.