### PR TITLE
kernel/error: Amend error return code values 

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -14,11 +14,6 @@ namespace IPC {
 /// Size of the command buffer area, in 32-bit words.
 constexpr std::size_t COMMAND_BUFFER_LENGTH = 0x100 / sizeof(u32);
 
-// These errors are commonly returned by invalid IPC translations, so alias them here for
-// convenience.
-// TODO(yuriks): These will probably go away once translation is implemented inside the kernel.
-constexpr auto ERR_INVALID_HANDLE = Kernel::ERR_INVALID_HANDLE_OS;
-
 enum class ControlCommand : u32 {
     ConvertSessionToDomain = 0,
     ConvertDomainToSession = 1,

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -69,7 +69,5 @@ constexpr ResultCode ERR_NOT_AUTHORIZED(-1);
 constexpr ResultCode ERR_INVALID_HANDLE_OS(-1);
 constexpr ResultCode ERR_NOT_FOUND(ErrorModule::Kernel, ErrCodes::NoSuchEntry);
 constexpr ResultCode RESULT_TIMEOUT(ErrorModule::Kernel, ErrCodes::Timeout);
-/// Returned when Accept() is called on a port with no sessions to be accepted.
-constexpr ResultCode ERR_NO_PENDING_SESSIONS(-1);
 
 } // namespace Kernel

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -10,11 +10,6 @@ namespace Kernel {
 
 namespace ErrCodes {
 enum {
-    // TODO(Subv): Remove these 3DS OS error codes.
-    SessionClosedByRemote = 26,
-    NoPendingSessions = 35,
-    InvalidBufferDescriptor = 48,
-
     // Confirmed Switch OS error codes
     MaxConnectionsReached = 7,
     InvalidSize = 101,

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -67,7 +67,7 @@ constexpr ResultCode ERR_ALREADY_REGISTERED(ErrorModule::Kernel, ErrCodes::Alrea
 constexpr ResultCode ERR_INVALID_STATE(ErrorModule::Kernel, ErrCodes::InvalidState);
 constexpr ResultCode ERR_INVALID_THREAD_PRIORITY(ErrorModule::Kernel,
                                                  ErrCodes::InvalidThreadPriority);
-constexpr ResultCode ERR_INVALID_POINTER(-1);
+constexpr ResultCode ERR_INVALID_POINTER(ErrorModule::Kernel, ErrCodes::InvalidPointer);
 constexpr ResultCode ERR_INVALID_OBJECT_ADDR(-1);
 constexpr ResultCode ERR_NOT_AUTHORIZED(-1);
 /// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -38,18 +38,14 @@ enum {
 // WARNING: The kernel is quite inconsistent in it's usage of errors code. Make sure to always
 // double check that the code matches before re-using the constant.
 
-// TODO(bunnei): Replace -1 with correct errors for Switch OS
 constexpr ResultCode ERR_HANDLE_TABLE_FULL(ErrorModule::Kernel, ErrCodes::HandleTableFull);
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(ErrorModule::Kernel, ErrCodes::SessionClosed);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrorModule::Kernel, ErrCodes::TooLarge);
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(ErrorModule::Kernel,
                                                  ErrCodes::MaxConnectionsReached);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorModule::Kernel, ErrCodes::InvalidEnumValue);
-constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(-1);
-constexpr ResultCode ERR_INVALID_COMBINATION(-1);
 constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(ErrorModule::Kernel,
                                                     ErrCodes::InvalidCombination);
-constexpr ResultCode ERR_OUT_OF_MEMORY(-1);
 constexpr ResultCode ERR_INVALID_ADDRESS(ErrorModule::Kernel, ErrCodes::InvalidAddress);
 constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorModule::Kernel, ErrCodes::InvalidMemoryState);
 constexpr ResultCode ERR_INVALID_MEMORY_PERMISSIONS(ErrorModule::Kernel,
@@ -63,10 +59,6 @@ constexpr ResultCode ERR_INVALID_STATE(ErrorModule::Kernel, ErrCodes::InvalidSta
 constexpr ResultCode ERR_INVALID_THREAD_PRIORITY(ErrorModule::Kernel,
                                                  ErrCodes::InvalidThreadPriority);
 constexpr ResultCode ERR_INVALID_POINTER(ErrorModule::Kernel, ErrCodes::InvalidPointer);
-constexpr ResultCode ERR_INVALID_OBJECT_ADDR(-1);
-constexpr ResultCode ERR_NOT_AUTHORIZED(-1);
-/// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.
-constexpr ResultCode ERR_INVALID_HANDLE_OS(-1);
 constexpr ResultCode ERR_NOT_FOUND(ErrorModule::Kernel, ErrCodes::NoSuchEntry);
 constexpr ResultCode RESULT_TIMEOUT(ErrorModule::Kernel, ErrCodes::Timeout);
 

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -26,6 +26,7 @@ enum {
     InvalidThreadPriority = 112,
     InvalidProcessorId = 113,
     InvalidHandle = 114,
+    InvalidPointer = 115,
     InvalidCombination = 116,
     Timeout = 117,
     SynchronizationCanceled = 118,
@@ -33,6 +34,7 @@ enum {
     InvalidEnumValue = 120,
     NoSuchEntry = 121,
     AlreadyRegistered = 122,
+    SessionClosed = 123,
     InvalidState = 125,
     ResourceLimitExceeded = 132,
 };
@@ -43,7 +45,7 @@ enum {
 
 // TODO(bunnei): Replace -1 with correct errors for Switch OS
 constexpr ResultCode ERR_HANDLE_TABLE_FULL(ErrorModule::Kernel, ErrCodes::HandleTableFull);
-constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
+constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(ErrorModule::Kernel, ErrCodes::SessionClosed);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrorModule::Kernel, ErrCodes::TooLarge);
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(ErrorModule::Kernel,
                                                  ErrCodes::MaxConnectionsReached);

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -28,7 +28,7 @@ ResultVal<SharedPtr<ServerSession>> ServerPort::Accept() {
 
 bool ServerPort::ShouldWait(Thread* thread) const {
     // If there are no pending sessions, we wait until a new one is added.
-    return pending_sessions.size() == 0;
+    return pending_sessions.empty();
 }
 
 void ServerPort::Acquire(Thread* thread) {

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -18,7 +18,7 @@ ServerPort::~ServerPort() = default;
 
 ResultVal<SharedPtr<ServerSession>> ServerPort::Accept() {
     if (pending_sessions.empty()) {
-        return ERR_NO_PENDING_SESSIONS;
+        return ERR_NOT_FOUND;
     }
 
     auto session = std::move(pending_sessions.back());

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -80,20 +80,19 @@ SharedPtr<SharedMemory> SharedMemory::CreateForApplet(
 
 ResultCode SharedMemory::Map(Process* target_process, VAddr address, MemoryPermission permissions,
                              MemoryPermission other_permissions) {
-
-    MemoryPermission own_other_permissions =
+    const MemoryPermission own_other_permissions =
         target_process == owner_process ? this->permissions : this->other_permissions;
 
     // Automatically allocated memory blocks can only be mapped with other_permissions = DontCare
     if (base_address == 0 && other_permissions != MemoryPermission::DontCare) {
-        return ERR_INVALID_COMBINATION;
+        return ERR_INVALID_MEMORY_PERMISSIONS;
     }
 
     // Error out if the requested permissions don't match what the creator process allows.
     if (static_cast<u32>(permissions) & ~static_cast<u32>(own_other_permissions)) {
         LOG_ERROR(Kernel, "cannot map id={}, address=0x{:X} name={}, permissions don't match",
                   GetObjectId(), address, name);
-        return ERR_INVALID_COMBINATION;
+        return ERR_INVALID_MEMORY_PERMISSIONS;
     }
 
     // Error out if the provided permissions are not compatible with what the creator process needs.

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -594,16 +594,17 @@ static ResultCode SetThreadPriority(Handle handle, u32 priority) {
     }
 
     const auto* const current_process = Core::CurrentProcess();
-    SharedPtr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
-    if (!thread) {
-        return ERR_INVALID_HANDLE;
-    }
 
     // Note: The kernel uses the current process's resource limit instead of
     // the one from the thread owner's resource limit.
     const ResourceLimit& resource_limit = current_process->GetResourceLimit();
     if (resource_limit.GetMaxResourceValue(ResourceType::Priority) > priority) {
-        return ERR_NOT_AUTHORIZED;
+        return ERR_INVALID_THREAD_PRIORITY;
+    }
+
+    SharedPtr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
+    if (!thread) {
+        return ERR_INVALID_HANDLE;
     }
 
     thread->SetPriority(priority);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -746,7 +746,7 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
     auto* const current_process = Core::CurrentProcess();
     const ResourceLimit& resource_limit = current_process->GetResourceLimit();
     if (resource_limit.GetMaxResourceValue(ResourceType::Priority) > priority) {
-        return ERR_NOT_AUTHORIZED;
+        return ERR_INVALID_THREAD_PRIORITY;
     }
 
     if (processor_id == THREADPROCESSORID_DEFAULT) {


### PR DESCRIPTION
Amends the holes that we have in our error codes, and gets rid of all the other ones that either aren't used, or don't apply anymore/are holdovers from citra. This knocks out two TODO comments, and keeps the current errors listed to the ones that are actually used within the codebase.