### PR TITLE
svc: Implement svcGetInfo command 0xF0000002 

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -202,6 +202,16 @@ public:
         return is_64bit_process;
     }
 
+    /// Gets the total running time of the process instance in ticks.
+    u64 GetCPUTimeTicks() const {
+        return total_process_running_time_ticks;
+    }
+
+    /// Updates the total running time, adding the given ticks to it.
+    void UpdateCPUTimeTicks(u64 ticks) {
+        total_process_running_time_ticks += ticks;
+    }
+
     /**
      * Loads process-specifics configuration info with metadata provided
      * by an executable.
@@ -304,6 +314,9 @@ private:
     /// By default, we currently assume this is true, unless otherwise
     /// specified by metadata provided to the process during loading.
     bool is_64bit_process = true;
+
+    /// Total running time for the process in ticks.
+    u64 total_process_running_time_ticks = 0;
 
     /// Per-process handle table for storing created object handles in.
     HandleTable handle_table;

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -17,6 +17,8 @@ class ARM_Interface;
 
 namespace Kernel {
 
+class Process;
+
 class Scheduler final {
 public:
     explicit Scheduler(Core::ARM_Interface& cpu_core);
@@ -30,6 +32,9 @@ public:
 
     /// Gets the current running thread
     Thread* GetCurrentThread() const;
+
+    /// Gets the timestamp for the last context switch in ticks.
+    u64 GetLastContextSwitchTicks() const;
 
     /// Adds a new thread to the scheduler
     void AddThread(SharedPtr<Thread> thread, u32 priority);
@@ -64,6 +69,19 @@ private:
      */
     void SwitchContext(Thread* new_thread);
 
+    /**
+     * Called on every context switch to update the internal timestamp
+     * This also updates the running time ticks for the given thread and
+     * process using the following difference:
+     *
+     * ticks += most_recent_ticks - last_context_switch_ticks
+     *
+     * The internal tick timestamp for the scheduler is simply the
+     * most recent tick count retrieved. No special arithmetic is
+     * applied to it.
+     */
+    void UpdateLastContextSwitchTime(Thread* thread, Process* process);
+
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<SharedPtr<Thread>> thread_list;
 
@@ -73,6 +91,7 @@ private:
     SharedPtr<Thread> current_thread = nullptr;
 
     Core::ARM_Interface& cpu_core;
+    u64 last_context_switch_time = 0;
 
     static std::mutex scheduler_mutex;
 };

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -467,6 +467,37 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     LOG_TRACE(Kernel_SVC, "called info_id=0x{:X}, info_sub_id=0x{:X}, handle=0x{:08X}", info_id,
               info_sub_id, handle);
 
+    enum class GetInfoType : u64 {
+        // 1.0.0+
+        AllowedCpuIdBitmask = 0,
+        AllowedThreadPrioBitmask = 1,
+        MapRegionBaseAddr = 2,
+        MapRegionSize = 3,
+        HeapRegionBaseAddr = 4,
+        HeapRegionSize = 5,
+        TotalMemoryUsage = 6,
+        TotalHeapUsage = 7,
+        IsCurrentProcessBeingDebugged = 8,
+        ResourceHandleLimit = 9,
+        IdleTickCount = 10,
+        RandomEntropy = 11,
+        PerformanceCounter = 0xF0000002,
+        // 2.0.0+
+        ASLRRegionBaseAddr = 12,
+        ASLRRegionSize = 13,
+        NewMapRegionBaseAddr = 14,
+        NewMapRegionSize = 15,
+        // 3.0.0+
+        IsVirtualAddressMemoryEnabled = 16,
+        PersonalMmHeapUsage = 17,
+        TitleId = 18,
+        // 4.0.0+
+        PrivilegedProcessId = 19,
+        // 5.0.0+
+        UserExceptionContextAddr = 20,
+        ThreadTickCount = 0xF0000002,
+    };
+
     const auto* current_process = Core::CurrentProcess();
     const auto& vm_manager = current_process->VMManager();
 

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -24,38 +24,6 @@ struct PageInfo {
     u64 flags;
 };
 
-/// Values accepted by svcGetInfo
-enum class GetInfoType : u64 {
-    // 1.0.0+
-    AllowedCpuIdBitmask = 0,
-    AllowedThreadPrioBitmask = 1,
-    MapRegionBaseAddr = 2,
-    MapRegionSize = 3,
-    HeapRegionBaseAddr = 4,
-    HeapRegionSize = 5,
-    TotalMemoryUsage = 6,
-    TotalHeapUsage = 7,
-    IsCurrentProcessBeingDebugged = 8,
-    ResourceHandleLimit = 9,
-    IdleTickCount = 10,
-    RandomEntropy = 11,
-    PerformanceCounter = 0xF0000002,
-    // 2.0.0+
-    ASLRRegionBaseAddr = 12,
-    ASLRRegionSize = 13,
-    NewMapRegionBaseAddr = 14,
-    NewMapRegionSize = 15,
-    // 3.0.0+
-    IsVirtualAddressMemoryEnabled = 16,
-    PersonalMmHeapUsage = 17,
-    TitleId = 18,
-    // 4.0.0+
-    PrivilegedProcessId = 19,
-    // 5.0.0+
-    UserExceptionContextAddr = 20,
-    ThreadTickCount = 0xF0000002,
-};
-
 void CallSVC(u32 immediate);
 
 } // namespace Kernel

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -53,6 +53,7 @@ enum class GetInfoType : u64 {
     PrivilegedProcessId = 19,
     // 5.0.0+
     UserExceptionContextAddr = 20,
+    ThreadTickCount = 0xF0000002,
 };
 
 void CallSVC(u32 immediate);

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -258,6 +258,14 @@ public:
         return last_running_ticks;
     }
 
+    u64 GetTotalCPUTimeTicks() const {
+        return total_cpu_time_ticks;
+    }
+
+    void UpdateCPUTimeTicks(u64 ticks) {
+        total_cpu_time_ticks += ticks;
+    }
+
     s32 GetProcessorID() const {
         return processor_id;
     }
@@ -378,7 +386,8 @@ private:
     u32 nominal_priority = 0; ///< Nominal thread priority, as set by the emulated application
     u32 current_priority = 0; ///< Current thread priority, can be temporarily changed
 
-    u64 last_running_ticks = 0; ///< CPU tick when thread was last running
+    u64 total_cpu_time_ticks = 0; ///< Total CPU running ticks.
+    u64 last_running_ticks = 0;   ///< CPU tick when thread was last running
 
     s32 processor_id = 0;
 


### PR DESCRIPTION
This retrieves:

if (curr_thread == handle_thread) {
   result = total_thread_ticks + (hardware_tick_count - last_context_switch_ticks);
} else if (curr_thread == handle_thread && sub_id == current_core_index) {
   result = hardware_tick_count - last_context_switch_ticks;
}

which is fairly trivial to implement, given mostly everything else is in place already, aside from the tick updating itself