### PR TITLE
service/usb: Update IPdSession's function table 

### DIFF
--- a/src/core/file_sys/fsmitm_romfsbuild.h
+++ b/src/core/file_sys/fsmitm_romfsbuild.h
@@ -27,7 +27,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <boost/detail/container_fwd.hpp>
 #include "common/common_types.h"
 #include "core/file_sys/vfs.h"
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -6,8 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/range/algorithm_ext/erase.hpp>
-
 #include "common/assert.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"

--- a/src/core/hle/service/usb/usb.cpp
+++ b/src/core/hle/service/usb/usb.cpp
@@ -132,11 +132,11 @@ public:
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "BindNoticeEvent"},
-            {1, nullptr, "Unknown1"},
+            {1, nullptr, "UnbindNoticeEvent"},
             {2, nullptr, "GetStatus"},
             {3, nullptr, "GetNotice"},
-            {4, nullptr, "Unknown2"},
-            {5, nullptr, "Unknown3"},
+            {4, nullptr, "EnablePowerRequestNotice"},
+            {5, nullptr, "DisablePowerRequestNotice"},
             {6, nullptr, "ReplyPowerRequest"},
         };
         // clang-format on

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -78,7 +78,7 @@ QPixmap GetIcon(Service::Account::UUID uuid) {
 
     if (!icon) {
         icon.fill(Qt::black);
-        icon.loadFromData(backup_jpeg.data(), backup_jpeg.size());
+        icon.loadFromData(backup_jpeg.data(), static_cast<u32>(backup_jpeg.size()));
     }
 
     return icon.scaled(64, 64, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);

--- a/src/yuzu/debugger/wait_tree.h
+++ b/src/yuzu/debugger/wait_tree.h
@@ -11,7 +11,6 @@
 #include <QAbstractItemModel>
 #include <QDockWidget>
 #include <QTreeView>
-#include <boost/container/flat_set.hpp>
 #include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 


### PR DESCRIPTION
Updated based off information on SwitchBrew. Fills out the remaining unknown entries in the table.