### PR TITLE
sm: Implement RegisterService and UnregisterService

### DIFF
--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -35,6 +35,8 @@ public:
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
     void GetService(Kernel::HLERequestContext& ctx);
+    void RegisterService(Kernel::HLERequestContext& ctx);
+    void UnregisterService(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<ServiceManager> service_manager;
 };
@@ -48,6 +50,7 @@ public:
 
     ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,
                                                                      unsigned int max_sessions);
+    ResultCode UnregisterService(std::string name);
     ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
     ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
 


### PR DESCRIPTION
These are needed by Edizon to boot. They are used to see if a user is using SX OS, as SX OS registers a custom service called 'tx' and attempting to register a service of the same name lets the application know if it is present.