### PR TITLE
game_list: Only reload game list after relevant settings changed

### DIFF
--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -36,6 +36,16 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
     InitializeRowComboBoxes();
 
     this->setConfiguration();
+
+    // Force game list reload if any of the relevant settings are changed.
+    connect(ui->show_unknown, &QCheckBox::stateChanged, this,
+            &ConfigureGameList::RequestGameListUpdate);
+    connect(ui->icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureGameList::RequestGameListUpdate);
+    connect(ui->row_1_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureGameList::RequestGameListUpdate);
+    connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureGameList::RequestGameListUpdate);
 }
 
 ConfigureGameList::~ConfigureGameList() = default;
@@ -46,6 +56,10 @@ void ConfigureGameList::applyConfiguration() {
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
     Settings::Apply();
+}
+
+void ConfigureGameList::RequestGameListUpdate() {
+    UISettings::values.is_game_list_reload_pending.exchange(true);
 }
 
 void ConfigureGameList::setConfiguration() {

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -21,6 +21,8 @@ public:
     void applyConfiguration();
 
 private:
+    void RequestGameListUpdate();
+
     void setConfiguration();
 
     void changeEvent(QEvent*) override;

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -19,6 +19,9 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     this->setConfiguration();
 
+    connect(ui->toggle_deepscan, &QCheckBox::stateChanged, this,
+            [] { UISettings::values.is_game_list_reload_pending.exchange(true); });
+
     ui->use_cpu_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->use_docked_mode->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1328,7 +1328,13 @@ void GMainWindow::OnConfigure() {
             UpdateUITheme();
         if (UISettings::values.enable_discord_presence != old_discord_presence)
             SetDiscordEnabled(UISettings::values.enable_discord_presence);
-        game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+
+        const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
+        if (reload) {
+            game_list->PopulateAsync(UISettings::values.gamedir,
+                                     UISettings::values.gamedir_deepscan);
+        }
+
         config->Save();
     }
 }

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <vector>
 #include <QByteArray>
 #include <QString>
@@ -62,6 +63,7 @@ struct Values {
     uint32_t icon_size;
     uint8_t row_1_text_id;
     uint8_t row_2_text_id;
+    std::atomic_bool is_game_list_reload_pending{false};
 };
 
 extern Values values;


### PR DESCRIPTION
Prevents unnecessary reloads on every configuration operation.



