### PR TITLE
Updated npad styles on holdtype switches

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -392,8 +392,10 @@ std::size_t Controller_NPad::GetSupportedNPadIdTypesSize() const {
 }
 
 void Controller_NPad::SetHoldType(NpadHoldType joy_hold_type) {
+    styleset_changed_event->Signal();
     hold_type = joy_hold_type;
 }
+
 Controller_NPad::NpadHoldType Controller_NPad::GetHoldType() const {
     return hold_type;
 }


### PR DESCRIPTION
Fixes input for megaman
![image](https://user-images.githubusercontent.com/37957125/48136411-bed62380-e286-11e8-986e-42fdd6536586.png)
![image](https://user-images.githubusercontent.com/37957125/48136430-c72e5e80-e286-11e8-835a-273bdd20c6ba.png)
