### PR TITLE
Fixed switching operation modes when not running a game 

### DIFF
--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -47,6 +47,9 @@ void ConfigureGeneral::OnDockedModeChanged(bool last_state, bool new_state) {
     }
 
     Core::System& system{Core::System::GetInstance()};
+    if (!system.IsPoweredOn()) {
+        return;
+    }
     Service::SM::ServiceManager& sm = system.ServiceManager();
 
     // Message queue is shared between these services, we just need to signal an operation


### PR DESCRIPTION
The service manager seems to be a nullptr before a game boots

