### PR TITLE
Implemented CalculateStandardUserSystemClockDifferenceByUser

### DIFF
--- a/src/core/hle/service/time/interface.cpp
+++ b/src/core/hle/service/time/interface.cpp
@@ -23,7 +23,8 @@ Time::Time(std::shared_ptr<Module> time, const char* name)
         {300, nullptr, "CalculateMonotonicSystemClockBaseTimePoint"},
         {400, &Time::GetClockSnapshot, "GetClockSnapshot"},
         {401, nullptr, "GetClockSnapshotFromSystemClockContext"},
-        {500, nullptr, "CalculateStandardUserSystemClockDifferenceByUser"},
+        {500, &Time::CalculateStandardUserSystemClockDifferenceByUser,
+         "CalculateStandardUserSystemClockDifferenceByUser"},
         {501, nullptr, "CalculateSpanBetween"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -299,6 +299,21 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     ctx.WriteBuffer(&clock_snapshot, sizeof(ClockSnapshot));
 }
 
+void Module::Interface::CalculateStandardUserSystemClockDifferenceByUser(
+    Kernel::HLERequestContext& ctx) {
+    LOG_DEBUG(Service_Time, "called");
+
+    IPC::RequestParser rp{ctx};
+    const auto snapshot_a = rp.PopRaw<ClockSnapshot>();
+    const auto snapshot_b = rp.PopRaw<ClockSnapshot>();
+    const u64 difference =
+        snapshot_b.user_clock_context.offset - snapshot_a.user_clock_context.offset;
+
+    IPC::ResponseBuilder rb{ctx, 4};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushRaw<u64>(difference);
+}
+
 Module::Interface::Interface(std::shared_ptr<Module> time, const char* name)
     : ServiceFramework(name), time(std::move(time)) {}
 

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -84,6 +84,7 @@ public:
         void GetTimeZoneService(Kernel::HLERequestContext& ctx);
         void GetStandardLocalSystemClock(Kernel::HLERequestContext& ctx);
         void GetClockSnapshot(Kernel::HLERequestContext& ctx);
+        void CalculateStandardUserSystemClockDifferenceByUser(Kernel::HLERequestContext& ctx);
 
     protected:
         std::shared_ptr<Module> time;


### PR DESCRIPTION
Seems pokemon calls this sometimes and it caused "random crashes"