### PR TITLE
Ignore asserts - DO NOT CHECK IN

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -28,18 +28,12 @@ __declspec(noinline, noreturn)
 }
 
 #define ASSERT(_a_)                                                                                \
-    do                                                                                             \
-        if (!(_a_)) {                                                                              \
-            assert_noinline_call([] { LOG_CRITICAL(Debug, "Assertion Failed!"); });                \
-        }                                                                                          \
-    while (0)
+    if (!(_a_)) {                                                                                  \
+    }
 
 #define ASSERT_MSG(_a_, ...)                                                                       \
-    do                                                                                             \
-        if (!(_a_)) {                                                                              \
-            assert_noinline_call([&] { LOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__); }); \
-        }                                                                                          \
-    while (0)
+    if (!(_a_)) {                                                                                  \
+    }
 
 #define UNREACHABLE() ASSERT_MSG(false, "Unreachable code!")
 #define UNREACHABLE_MSG(...) ASSERT_MSG(false, __VA_ARGS__)


### PR DESCRIPTION
DO NOT MERGE Using this PR to disable assertions in canary builds to make it easier for non-developers to test games. This is more-or-less just a trial, if it goes well, we should probably come up with a more robust solution. This replaces #596, after the merge conflicts of #607.


