### PR TITLE
Texture decoder: Implemented Tile Width Spacing 

### DIFF
--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -68,13 +68,13 @@ void Fermi2D::HandleSurfaceCopy() {
             Texture::CopySwizzledData(regs.src.width, regs.src.height, regs.src.depth,
                                       src_bytes_per_pixel, dst_bytes_per_pixel, src_buffer,
                                       dst_buffer, true, regs.src.BlockHeight(),
-                                      regs.src.BlockDepth());
+                                      regs.src.BlockDepth(), 0);
         } else {
             // If the input is linear and the output is tiled, swizzle the input and copy it over.
             Texture::CopySwizzledData(regs.src.width, regs.src.height, regs.src.depth,
                                       src_bytes_per_pixel, dst_bytes_per_pixel, dst_buffer,
                                       src_buffer, false, regs.dst.BlockHeight(),
-                                      regs.dst.BlockDepth());
+                                      regs.dst.BlockDepth(), 0);
         }
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -208,6 +208,7 @@ struct SurfaceParams {
     u32 block_width;
     u32 block_height;
     u32 block_depth;
+    u32 tile_width_spacing;
     PixelFormat pixel_format;
     ComponentType component_type;
     SurfaceType type;

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -22,19 +22,20 @@ inline std::size_t GetGOBSize() {
 void UnswizzleTexture(u8* unswizzled_data, VAddr address, u32 tile_size_x, u32 tile_size_y,
                       u32 bytes_per_pixel, u32 width, u32 height, u32 depth,
                       u32 block_height = TICEntry::DefaultBlockHeight,
-                      u32 block_depth = TICEntry::DefaultBlockHeight);
+                      u32 block_depth = TICEntry::DefaultBlockHeight, u32 width_spacing = 0);
 /**
  * Unswizzles a swizzled texture without changing its format.
  */
 std::vector<u8> UnswizzleTexture(VAddr address, u32 tile_size_x, u32 tile_size_y,
                                  u32 bytes_per_pixel, u32 width, u32 height, u32 depth,
                                  u32 block_height = TICEntry::DefaultBlockHeight,
-                                 u32 block_depth = TICEntry::DefaultBlockHeight);
+                                 u32 block_depth = TICEntry::DefaultBlockHeight,
+                                 u32 width_spacing = 0);
 
 /// Copies texture data from a buffer and performs swizzling/unswizzling as necessary.
 void CopySwizzledData(u32 width, u32 height, u32 depth, u32 bytes_per_pixel,
                       u32 out_bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data,
-                      bool unswizzle, u32 block_height, u32 block_depth);
+                      bool unswizzle, u32 block_height, u32 block_depth, u32 width_spacing);
 
 /**
  * Decodes an unswizzled texture into a A8R8G8B8 texture.

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -166,6 +166,8 @@ struct TICEntry {
         BitField<3, 3, u32> block_height;
         BitField<6, 3, u32> block_depth;
 
+        BitField<10, 3, u32> tile_width_spacing;
+
         // High 16 bits of the pitch value
         BitField<0, 16, u32> pitch_high;
         BitField<26, 1, u32> use_header_opt_control;


### PR DESCRIPTION
This fixes textures in Octopath and some indie games.