### PR TITLE
am: Implement HLE software keyboard applet 

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -214,6 +214,15 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, std::size_t 
     return std::string(buffer, len);
 }
 
+std::u16string UTF16StringFromFixedZeroTerminatedBuffer(const char16_t* buffer,
+                                                        std::size_t max_len) {
+    std::size_t len = 0;
+    while (len < max_len && buffer[len] != '\0')
+        ++len;
+
+    return std::u16string(buffer, len);
+}
+
 const char* TrimSourcePath(const char* path, const char* root) {
     const char* p = path;
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -214,13 +214,13 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, std::size_t 
     return std::string(buffer, len);
 }
 
-std::u16string UTF16StringFromFixedZeroTerminatedBuffer(const char16_t* buffer,
+std::u16string UTF16StringFromFixedZeroTerminatedBuffer(std::u16string_view buffer,
                                                         std::size_t max_len) {
     std::size_t len = 0;
     while (len < max_len && buffer[len] != '\0')
         ++len;
 
-    return std::u16string(buffer, len);
+    return std::u16string(buffer.begin(), buffer.begin() + len);
 }
 
 const char* TrimSourcePath(const char* path, const char* root) {

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -67,6 +67,14 @@ bool ComparePartialString(InIt begin, InIt end, const char* other) {
 std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, std::size_t max_len);
 
 /**
+ * Creates a UTF-16 std::u16string from a fixed-size NUL-terminated char buffer. If the buffer isn't
+ * NUL-terminated, then the string ends at the greatest multiple of two less then or equal to
+ * max_len_bytes.
+ */
+std::u16string UTF16StringFromFixedZeroTerminatedBuffer(const char16_t* buffer,
+                                                        std::size_t max_len);
+
+/**
  * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
  * intended to be used to strip a system-specific build directory from the `__FILE__` macro,
  * leaving only the path relative to the sources root.

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -68,10 +68,10 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, std::size_t 
 
 /**
  * Creates a UTF-16 std::u16string from a fixed-size NUL-terminated char buffer. If the buffer isn't
- * NUL-terminated, then the string ends at the greatest multiple of two less then or equal to
+ * null-terminated, then the string ends at the greatest multiple of two less then or equal to
  * max_len_bytes.
  */
-std::u16string UTF16StringFromFixedZeroTerminatedBuffer(const char16_t* buffer,
+std::u16string UTF16StringFromFixedZeroTerminatedBuffer(std::u16string_view buffer,
                                                         std::size_t max_len);
 
 /**

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -154,6 +154,8 @@ add_library(core STATIC
     hle/service/am/applet_oe.h
     hle/service/am/applets/applets.cpp
     hle/service/am/applets/applets.h
+    hle/service/am/applets/software_keyboard.cpp
+    hle/service/am/applets/software_keyboard.h
     hle/service/am/idle.cpp
     hle/service/am/idle.h
     hle/service/am/omm.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -150,6 +150,8 @@ add_library(core STATIC
     hle/service/am/applet_ae.h
     hle/service/am/applet_oe.cpp
     hle/service/am/applet_oe.h
+    hle/service/am/applets/applets.cpp
+    hle/service/am/applets/applets.h
     hle/service/am/idle.cpp
     hle/service/am/idle.h
     hle/service/am/omm.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(core STATIC
     file_sys/vfs_vector.h
     file_sys/xts_archive.cpp
     file_sys/xts_archive.h
+    frontend/applets/software_keyboard.cpp
+    frontend/applets/software_keyboard.h
     frontend/emu_window.cpp
     frontend/emu_window.h
     frontend/framebuffer_layout.cpp

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -13,6 +13,7 @@
 
 namespace Core::Frontend {
 class EmuWindow;
+class SoftwareKeyboardApplet;
 } // namespace Core::Frontend
 
 namespace FileSys {
@@ -235,6 +236,10 @@ public:
     void SetFilesystem(std::shared_ptr<FileSys::VfsFilesystem> vfs);
 
     std::shared_ptr<FileSys::VfsFilesystem> GetFilesystem() const;
+
+    void SetSoftwareKeyboard(std::unique_ptr<Core::Frontend::SoftwareKeyboardApplet> applet);
+
+    const Core::Frontend::SoftwareKeyboardApplet& GetSoftwareKeyboard() const;
 
 private:
     System();

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/logging/backend.h"
+#include "common/string_util.h"
 #include "core/frontend/applets/software_keyboard.h"
 
 namespace Frontend {

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -3,16 +3,19 @@
 // Refer to the license.txt file included.
 
 #include "common/logging/backend.h"
-#include "common/string_util.h"
 #include "core/frontend/applets/software_keyboard.h"
 
-namespace Frontend {
-bool DefaultSoftwareKeyboardApplet::GetText(Parameters parameters, std::u16string& text) {
+namespace Core::Frontend {
+SoftwareKeyboardApplet::~SoftwareKeyboardApplet() = default;
+
+bool DefaultSoftwareKeyboardApplet::GetText(SoftwareKeyboardParameters parameters,
+                                            std::u16string& text) const {
     if (parameters.initial_text.empty())
-        text = Common::UTF8ToUTF16("yuzu");
+        text = u"yuzu";
     else
         text = parameters.initial_text;
 
     return true;
 }
-} // namespace Frontend
+
+} // namespace Core::Frontend

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -9,14 +9,12 @@
 namespace Core::Frontend {
 SoftwareKeyboardApplet::~SoftwareKeyboardApplet() = default;
 
-bool DefaultSoftwareKeyboardApplet::GetText(SoftwareKeyboardParameters parameters,
-                                            std::u16string& text) const {
+std::optional<std::u16string> DefaultSoftwareKeyboardApplet::GetText(
+    SoftwareKeyboardParameters parameters) const {
     if (parameters.initial_text.empty())
-        text = u"yuzu";
-    else
-        text = parameters.initial_text;
+        return u"yuzu";
 
-    return true;
+    return parameters.initial_text;
 }
 
 void DefaultSoftwareKeyboardApplet::SendTextCheckDialog(std::u16string error_message) const {

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -18,10 +18,12 @@ void DefaultSoftwareKeyboardApplet::RequestText(
     out(parameters.initial_text);
 }
 
-void DefaultSoftwareKeyboardApplet::SendTextCheckDialog(std::u16string error_message) const {
+void DefaultSoftwareKeyboardApplet::SendTextCheckDialog(
+    std::u16string error_message, std::function<void()> finished_check) const {
     LOG_WARNING(Service_AM,
                 "(STUBBED) called - Default fallback software keyboard does not support text "
                 "check! (error_message={})",
                 Common::UTF16ToUTF8(error_message));
+    finished_check();
 }
 } // namespace Core::Frontend

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -9,12 +9,13 @@
 namespace Core::Frontend {
 SoftwareKeyboardApplet::~SoftwareKeyboardApplet() = default;
 
-std::optional<std::u16string> DefaultSoftwareKeyboardApplet::GetText(
+void DefaultSoftwareKeyboardApplet::RequestText(
+    std::function<void(std::optional<std::u16string>)> out,
     SoftwareKeyboardParameters parameters) const {
     if (parameters.initial_text.empty())
-        return u"yuzu";
+        out(u"yuzu");
 
-    return parameters.initial_text;
+    out(parameters.initial_text);
 }
 
 void DefaultSoftwareKeyboardApplet::SendTextCheckDialog(std::u16string error_message) const {

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -1,0 +1,17 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/logging/backend.h"
+#include "core/frontend/applets/software_keyboard.h"
+
+namespace Frontend {
+bool DefaultSoftwareKeyboardApplet::GetText(Parameters parameters, std::u16string& text) {
+    if (parameters.initial_text.empty())
+        text = Common::UTF8ToUTF16("yuzu");
+    else
+        text = parameters.initial_text;
+
+    return true;
+}
+} // namespace Frontend

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/logging/backend.h"
+#include "common/string_util.h"
 #include "core/frontend/applets/software_keyboard.h"
 
 namespace Core::Frontend {

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -18,4 +18,10 @@ bool DefaultSoftwareKeyboardApplet::GetText(SoftwareKeyboardParameters parameter
     return true;
 }
 
+void DefaultSoftwareKeyboardApplet::SendTextCheckDialog(std::u16string error_message) const {
+    LOG_WARNING(Service_AM,
+                "(STUBBED) called - Default fallback software keyboard does not support text "
+                "check! (error_message={})",
+                Common::UTF16ToUTF8(error_message));
+}
 } // namespace Core::Frontend

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -1,0 +1,44 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include "common/bit_field.h"
+#include "common/common_types.h"
+
+namespace Frontend {
+class SoftwareKeyboardApplet {
+public:
+    struct Parameters {
+        std::u16string submit_text;
+        std::u16string header_text;
+        std::u16string sub_text;
+        std::u16string guide_text;
+        std::u16string initial_text;
+        std::size_t max_length;
+        bool password;
+        bool cursor_at_beginning;
+
+        union {
+            u8 value;
+
+            BitField<1, 1, u8> disable_space;
+            BitField<2, 1, u8> disable_address;
+            BitField<3, 1, u8> disable_percent;
+            BitField<4, 1, u8> disable_slash;
+            BitField<6, 1, u8> disable_number;
+            BitField<7, 1, u8> disable_download_code;
+        };
+    };
+
+    virtual bool GetText(Parameters parameters, std::u16string& text) = 0;
+    virtual ~SoftwareKeyboardApplet() = default;
+};
+
+class DefaultSoftwareKeyboardApplet final : public SoftwareKeyboardApplet {
+    bool GetText(Parameters parameters, std::u16string& text) override;
+};
+
+} // namespace Frontend

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -36,11 +36,13 @@ public:
     virtual ~SoftwareKeyboardApplet();
 
     virtual bool GetText(SoftwareKeyboardParameters parameters, std::u16string& text) const = 0;
+    virtual void SendTextCheckDialog(std::u16string error_message) const = 0;
 };
 
 class DefaultSoftwareKeyboardApplet final : public SoftwareKeyboardApplet {
 public:
     bool GetText(SoftwareKeyboardParameters parameters, std::u16string& text) const override;
+    void SendTextCheckDialog(std::u16string error_message) const override;
 };
 
 } // namespace Core::Frontend

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string>
 #include "common/bit_field.h"
@@ -36,13 +37,15 @@ class SoftwareKeyboardApplet {
 public:
     virtual ~SoftwareKeyboardApplet();
 
-    virtual std::optional<std::u16string> GetText(SoftwareKeyboardParameters parameters) const = 0;
+    virtual void RequestText(std::function<void(std::optional<std::u16string>)> out,
+                             SoftwareKeyboardParameters parameters) const = 0;
     virtual void SendTextCheckDialog(std::u16string error_message) const = 0;
 };
 
 class DefaultSoftwareKeyboardApplet final : public SoftwareKeyboardApplet {
 public:
-    std::optional<std::u16string> GetText(SoftwareKeyboardParameters parameters) const override;
+    void RequestText(std::function<void(std::optional<std::u16string>)> out,
+                     SoftwareKeyboardParameters parameters) const override;
     void SendTextCheckDialog(std::u16string error_message) const override;
 };
 

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -8,37 +8,39 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 
-namespace Frontend {
+namespace Core::Frontend {
+struct SoftwareKeyboardParameters {
+    std::u16string submit_text;
+    std::u16string header_text;
+    std::u16string sub_text;
+    std::u16string guide_text;
+    std::u16string initial_text;
+    std::size_t max_length;
+    bool password;
+    bool cursor_at_beginning;
+
+    union {
+        u8 value;
+
+        BitField<1, 1, u8> disable_space;
+        BitField<2, 1, u8> disable_address;
+        BitField<3, 1, u8> disable_percent;
+        BitField<4, 1, u8> disable_slash;
+        BitField<6, 1, u8> disable_number;
+        BitField<7, 1, u8> disable_download_code;
+    };
+};
+
 class SoftwareKeyboardApplet {
 public:
-    struct Parameters {
-        std::u16string submit_text;
-        std::u16string header_text;
-        std::u16string sub_text;
-        std::u16string guide_text;
-        std::u16string initial_text;
-        std::size_t max_length;
-        bool password;
-        bool cursor_at_beginning;
+    virtual ~SoftwareKeyboardApplet();
 
-        union {
-            u8 value;
-
-            BitField<1, 1, u8> disable_space;
-            BitField<2, 1, u8> disable_address;
-            BitField<3, 1, u8> disable_percent;
-            BitField<4, 1, u8> disable_slash;
-            BitField<6, 1, u8> disable_number;
-            BitField<7, 1, u8> disable_download_code;
-        };
-    };
-
-    virtual bool GetText(Parameters parameters, std::u16string& text) = 0;
-    virtual ~SoftwareKeyboardApplet() = default;
+    virtual bool GetText(SoftwareKeyboardParameters parameters, std::u16string& text) const = 0;
 };
 
 class DefaultSoftwareKeyboardApplet final : public SoftwareKeyboardApplet {
-    bool GetText(Parameters parameters, std::u16string& text) override;
+public:
+    bool GetText(SoftwareKeyboardParameters parameters, std::u16string& text) const override;
 };
 
-} // namespace Frontend
+} // namespace Core::Frontend

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -39,14 +39,16 @@ public:
 
     virtual void RequestText(std::function<void(std::optional<std::u16string>)> out,
                              SoftwareKeyboardParameters parameters) const = 0;
-    virtual void SendTextCheckDialog(std::u16string error_message) const = 0;
+    virtual void SendTextCheckDialog(std::u16string error_message,
+                                     std::function<void()> finished_check) const = 0;
 };
 
 class DefaultSoftwareKeyboardApplet final : public SoftwareKeyboardApplet {
 public:
     void RequestText(std::function<void(std::optional<std::u16string>)> out,
                      SoftwareKeyboardParameters parameters) const override;
-    void SendTextCheckDialog(std::u16string error_message) const override;
+    void SendTextCheckDialog(std::u16string error_message,
+                             std::function<void()> finished_check) const override;
 };
 
 } // namespace Core::Frontend

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include "common/bit_field.h"
 #include "common/common_types.h"
@@ -35,13 +36,13 @@ class SoftwareKeyboardApplet {
 public:
     virtual ~SoftwareKeyboardApplet();
 
-    virtual bool GetText(SoftwareKeyboardParameters parameters, std::u16string& text) const = 0;
+    virtual std::optional<std::u16string> GetText(SoftwareKeyboardParameters parameters) const = 0;
     virtual void SendTextCheckDialog(std::u16string error_message) const = 0;
 };
 
 class DefaultSoftwareKeyboardApplet final : public SoftwareKeyboardApplet {
 public:
-    bool GetText(SoftwareKeyboardParameters parameters, std::u16string& text) const override;
+    std::optional<std::u16string> GetText(SoftwareKeyboardParameters parameters) const override;
     void SendTextCheckDialog(std::u16string error_message) const override;
 };
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1207,14 +1207,15 @@ static ResultCode CreateTransferMemory(Handle* handle, VAddr addr, u64 size, u32
         return ERR_INVALID_ADDRESS;
     }
 
-    if (addr + size <= addr) {
+    if (!IsValidAddressRange(addr, size)) {
         LOG_ERROR(Kernel_SVC, "Address and size cause overflow! (address={:016X}, size={:016X})",
                   addr, size);
         return ERR_INVALID_ADDRESS_STATE;
     }
 
-    if (permissions > static_cast<u32>(MemoryPermission::ReadWrite) ||
-        permissions == static_cast<u32>(MemoryPermission::Write)) {
+    const auto perms = static_cast<MemoryPermission>(permissions);
+    if (perms != MemoryPermission::None && perms != MemoryPermission::Read &&
+        perms != MemoryPermission::ReadWrite) {
         LOG_ERROR(Kernel_SVC, "Invalid memory permissions for transfer memory! (perms={:08X})",
                   permissions);
         return ERR_INVALID_MEMORY_PERMISSIONS;
@@ -1222,7 +1223,6 @@ static ResultCode CreateTransferMemory(Handle* handle, VAddr addr, u64 size, u32
 
     auto& kernel = Core::System::GetInstance().Kernel();
     auto& handle_table = Core::CurrentProcess()->GetHandleTable();
-    const auto perms = static_cast<MemoryPermission>(permissions);
     const auto shared_mem_handle = SharedMemory::Create(
         kernel, handle_table.Get<Process>(CurrentProcess), size, perms, perms, addr);
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -605,8 +605,10 @@ private:
         ASSERT(applet != nullptr);
 
         applet->Initialize(storage_stack);
-        storage_stack.clear();
-        interactive_storage_stack.clear();
+        while (!storage_stack.empty())
+            storage_stack.pop();
+        while (!interactive_storage_stack.empty())
+            interactive_storage_stack.pop();
         applet->Execute([this](IStorage storage) { AppletStorageProxyOutData(storage); },
                         [this](IStorage storage) { AppletStorageProxyOutInteractiveData(storage); },
                         [this] { state_changed_event->Signal(); });

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -533,7 +533,7 @@ public:
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ILibraryAppletAccessor::GetAppletStateChangedEvent, "GetAppletStateChangedEvent"},
-            {1, nullptr, "IsCompleted"},
+            {1, &ILibraryAppletAccessor::IsCompleted, "IsCompleted"},
             {10, &ILibraryAppletAccessor::Start, "Start"},
             {20, nullptr, "RequestExit"},
             {25, nullptr, "Terminate"},
@@ -576,11 +576,15 @@ private:
         LOG_WARNING(Service_AM, "(STUBBED) called");
     }
 
+    void IsCompleted(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(applet->TransactionComplete());
+    }
+
     void GetResult(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
-        rb.Push(RESULT_SUCCESS);
-
-        LOG_WARNING(Service_AM, "(STUBBED) called");
+        rb.Push(applet->GetStatus());
     }
 
     void Start(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -718,7 +718,7 @@ void IStorageAccessor::Write(Kernel::HLERequestContext& ctx) {
     const u64 offset{rp.Pop<u64>()};
     const std::vector<u8> data{ctx.ReadBuffer()};
 
-    const auto size = std::min(data.size(), backing.buffer.size() - offset);
+    const auto size = std::min<std::size_t>(data.size(), backing.buffer.size() - offset);
 
     std::memcpy(&backing.buffer[offset], data.data(), size);
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -481,6 +481,22 @@ void ICommonStateGetter::GetDefaultDisplayResolution(Kernel::HLERequestContext& 
     LOG_DEBUG(Service_AM, "called");
 }
 
+IStorage::IStorage(std::vector<u8> buffer)
+    : ServiceFramework("IStorage"), buffer(std::move(buffer)) {
+    // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, &IStorage::Open, "Open"},
+            {1, nullptr, "OpenTransferStorage"},
+        };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+const std::vector<u8>& IStorage::GetData() const {
+    return buffer;
+}
+
 void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
     const bool use_docked_mode{Settings::values.use_docked_mode};
     IPC::ResponseBuilder rb{ctx, 3};

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -158,13 +158,14 @@ private:
 class IStorage final : public ServiceFramework<IStorage> {
 public:
     explicit IStorage(std::vector<u8> buffer);
+    ~IStorage() override;
 
     const std::vector<u8>& GetData() const;
 
 private:
-    std::vector<u8> buffer;
-
     void Open(Kernel::HLERequestContext& ctx);
+
+    std::vector<u8> buffer;
 
     friend class IStorageAccessor;
 };
@@ -172,13 +173,14 @@ private:
 class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
 public:
     explicit IStorageAccessor(IStorage& backing);
+    ~IStorageAccessor() override;
 
 private:
-    IStorage& backing;
-
     void GetSize(Kernel::HLERequestContext& ctx);
     void Write(Kernel::HLERequestContext& ctx);
     void Read(Kernel::HLERequestContext& ctx);
+
+    IStorage& backing;
 };
 
 class ILibraryAppletCreator final : public ServiceFramework<ILibraryAppletCreator> {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -163,6 +163,7 @@ public:
 private:
     void CreateLibraryApplet(Kernel::HLERequestContext& ctx);
     void CreateStorage(Kernel::HLERequestContext& ctx);
+    void CreateTransferMemoryStorage(Kernel::HLERequestContext& ctx);
 };
 
 class IApplicationFunctions final : public ServiceFramework<IApplicationFunctions> {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -155,6 +155,32 @@ private:
     std::shared_ptr<AppletMessageQueue> msg_queue;
 };
 
+class IStorage final : public ServiceFramework<IStorage> {
+public:
+    explicit IStorage(std::vector<u8> buffer);
+
+    const std::vector<u8>& GetData() const;
+
+private:
+    std::vector<u8> buffer;
+
+    void Open(Kernel::HLERequestContext& ctx);
+
+    friend class IStorageAccessor;
+};
+
+class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
+public:
+    explicit IStorageAccessor(IStorage& backing);
+
+private:
+    IStorage& backing;
+
+    void GetSize(Kernel::HLERequestContext& ctx);
+    void Write(Kernel::HLERequestContext& ctx);
+    void Read(Kernel::HLERequestContext& ctx);
+};
+
 class ILibraryAppletCreator final : public ServiceFramework<ILibraryAppletCreator> {
 public:
     ILibraryAppletCreator();

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -4,21 +4,108 @@
 
 #include <cstring>
 #include "common/assert.h"
+#include "core/core.h"
 #include "core/frontend/applets/software_keyboard.h"
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/server_port.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applets.h"
 
 namespace Service::AM::Applets {
 
+AppletDataBroker::AppletDataBroker() {
+    auto& kernel = Core::System::GetInstance().Kernel();
+    state_changed_event = Kernel::Event::Create(kernel, Kernel::ResetType::OneShot,
+                                                "ILibraryAppletAccessor:StateChangedEvent");
+    pop_out_data_event = Kernel::Event::Create(kernel, Kernel::ResetType::OneShot,
+                                               "ILibraryAppletAccessor:PopDataOutEvent");
+    pop_interactive_out_data_event = Kernel::Event::Create(
+        kernel, Kernel::ResetType::OneShot, "ILibraryAppletAccessor:PopInteractiveDataOutEvent");
+}
+
+AppletDataBroker::~AppletDataBroker() = default;
+
+std::unique_ptr<IStorage> AppletDataBroker::PopNormalDataToGame() {
+    if (out_channel.empty())
+        return nullptr;
+
+    auto out = std::move(out_channel.front());
+    out_channel.pop();
+    return out;
+}
+
+std::unique_ptr<IStorage> AppletDataBroker::PopNormalDataToApplet() {
+    if (in_channel.empty())
+        return nullptr;
+
+    auto out = std::move(in_channel.front());
+    in_channel.pop();
+    return out;
+}
+
+std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToGame() {
+    if (out_interactive_channel.empty())
+        return nullptr;
+
+    auto out = std::move(out_interactive_channel.front());
+    out_interactive_channel.pop();
+    return out;
+}
+
+std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToApplet() {
+    if (in_interactive_channel.empty())
+        return nullptr;
+
+    auto out = std::move(in_interactive_channel.front());
+    in_interactive_channel.pop();
+    return out;
+}
+
+void AppletDataBroker::PushNormalDataFromGame(IStorage storage) {
+    in_channel.push(std::make_unique<IStorage>(storage));
+}
+
+void AppletDataBroker::PushNormalDataFromApplet(IStorage storage) {
+    out_channel.push(std::make_unique<IStorage>(storage));
+    pop_out_data_event->Signal();
+}
+
+void AppletDataBroker::PushInteractiveDataFromGame(IStorage storage) {
+    in_interactive_channel.push(std::make_unique<IStorage>(storage));
+}
+
+void AppletDataBroker::PushInteractiveDataFromApplet(IStorage storage) {
+    out_interactive_channel.push(std::make_unique<IStorage>(storage));
+    pop_interactive_out_data_event->Signal();
+}
+
+void AppletDataBroker::SignalStateChanged() const {
+    state_changed_event->Signal();
+}
+
+Kernel::SharedPtr<Kernel::Event> AppletDataBroker::GetNormalDataEvent() const {
+    return pop_out_data_event;
+}
+
+Kernel::SharedPtr<Kernel::Event> AppletDataBroker::GetInteractiveDataEvent() const {
+    return pop_interactive_out_data_event;
+}
+
+Kernel::SharedPtr<Kernel::Event> AppletDataBroker::GetStateChangedEvent() const {
+    return state_changed_event;
+}
+
 Applet::Applet() = default;
 
 Applet::~Applet() = default;
 
-void Applet::Initialize(std::queue<std::shared_ptr<IStorage>> storage) {
-    storage_stack = std::move(storage);
+void Applet::Initialize(std::shared_ptr<AppletDataBroker> broker_) {
+    broker = std::move(broker_);
 
-    const auto common_data = storage_stack.front()->GetData();
-    storage_stack.pop();
+    const auto common = broker->PopNormalDataToApplet();
+    ASSERT(common != nullptr);
+
+    const auto common_data = common->GetData();
 
     ASSERT(common_data.size() >= sizeof(CommonArguments));
     std::memcpy(&common_args, common_data.data(), sizeof(CommonArguments));

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -7,23 +7,13 @@
 
 namespace Service::AM::Applets {
 
-std::shared_ptr<Frontend::SoftwareKeyboardApplet> software_keyboard =
-    std::make_shared<Frontend::DefaultSoftwareKeyboardApplet>();
+Applet::Applet() = default;
+
+Applet::~Applet() = default;
 
 void Applet::Initialize(std::vector<std::shared_ptr<IStorage>> storage) {
     storage_stack = std::move(storage);
     initialized = true;
-}
-
-void RegisterSoftwareKeyboard(std::shared_ptr<Frontend::SoftwareKeyboardApplet> applet) {
-    if (applet == nullptr)
-        return;
-
-    software_keyboard = std::move(applet);
-}
-
-std::shared_ptr<Frontend::SoftwareKeyboardApplet> GetSoftwareKeyboard() {
-    return software_keyboard;
 }
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -2,7 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
+#include "common/assert.h"
 #include "core/frontend/applets/software_keyboard.h"
+#include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applets.h"
 
 namespace Service::AM::Applets {
@@ -11,8 +14,15 @@ Applet::Applet() = default;
 
 Applet::~Applet() = default;
 
-void Applet::Initialize(std::vector<std::shared_ptr<IStorage>> storage) {
+void Applet::Initialize(std::queue<std::shared_ptr<IStorage>> storage) {
     storage_stack = std::move(storage);
+
+    const auto common_data = storage_stack.front()->GetData();
+    storage_stack.pop();
+
+    ASSERT(common_data.size() >= sizeof(CommonArguments));
+    std::memcpy(&common_args, common_data.data(), sizeof(CommonArguments));
+
     initialized = true;
 }
 

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -5,7 +5,6 @@
 #include <cstring>
 #include "common/assert.h"
 #include "core/core.h"
-#include "core/frontend/applets/software_keyboard.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/service/am/am.h"

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -1,0 +1,29 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/frontend/applets/software_keyboard.h"
+#include "core/hle/service/am/applets/applets.h"
+
+namespace Service::AM::Applets {
+
+std::shared_ptr<Frontend::SoftwareKeyboardApplet> software_keyboard =
+    std::make_shared<Frontend::DefaultSoftwareKeyboardApplet>();
+
+void Applet::Initialize(std::vector<std::shared_ptr<IStorage>> storage) {
+    storage_stack = std::move(storage);
+    initialized = true;
+}
+
+void RegisterSoftwareKeyboard(std::shared_ptr<Frontend::SoftwareKeyboardApplet> applet) {
+    if (applet == nullptr)
+        return;
+
+    software_keyboard = std::move(applet);
+}
+
+std::shared_ptr<Frontend::SoftwareKeyboardApplet> GetSoftwareKeyboard() {
+    return software_keyboard;
+}
+
+} // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -22,6 +22,7 @@ class IStorage;
 namespace Applets {
 
 using AppletStorageProxyFunction = std::function<void(IStorage)>;
+using AppletStateProxyFunction = std::function<void()>;
 
 class Applet {
 public:
@@ -34,7 +35,8 @@ public:
     virtual ResultCode GetStatus() const = 0;
     virtual void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) = 0;
     virtual void Execute(AppletStorageProxyFunction out_data,
-                         AppletStorageProxyFunction out_interactive_data) = 0;
+                         AppletStorageProxyFunction out_interactive_data,
+                         AppletStateProxyFunction state) = 0;
 
     bool IsInitialized() const {
         return initialized;

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include "common/swap.h"
 
+union ResultCode;
+
 namespace Frontend {
 class SoftwareKeyboardApplet;
 }
@@ -25,6 +27,9 @@ public:
 
     virtual void Initialize(std::vector<std::shared_ptr<IStorage>> storage);
 
+    virtual bool TransactionComplete() const = 0;
+    virtual ResultCode GetStatus() const = 0;
+    virtual void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) = 0;
     virtual IStorage Execute() = 0;
 
     bool IsInitialized() const {

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -1,0 +1,46 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "common/swap.h"
+
+namespace Frontend {
+class SoftwareKeyboardApplet;
+}
+
+namespace Service::AM {
+
+class IStorage;
+
+namespace Applets {
+
+class Applet {
+public:
+    virtual void Initialize(std::vector<std::shared_ptr<IStorage>> storage);
+
+    virtual IStorage Execute() = 0;
+
+protected:
+    struct CommonArguments {
+        u32_le arguments_version;
+        u32_le size;
+        u32_le library_version;
+        u32_le theme_color;
+        u8 play_startup_sound;
+        u64_le system_tick;
+    };
+    static_assert(sizeof(CommonArguments) == 0x20, "CommonArguments has incorrect size.");
+
+    std::vector<std::shared_ptr<IStorage>> storage_stack;
+    bool initialized = false;
+};
+
+void RegisterSoftwareKeyboard(std::shared_ptr<Frontend::SoftwareKeyboardApplet> applet);
+std::shared_ptr<Frontend::SoftwareKeyboardApplet> GetSoftwareKeyboard();
+
+} // namespace Applets
+} // namespace Service::AM

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -6,7 +6,7 @@
 
 #include <functional>
 #include <memory>
-#include <vector>
+#include <queue>
 #include "common/swap.h"
 
 union ResultCode;
@@ -29,7 +29,7 @@ public:
     Applet();
     virtual ~Applet();
 
-    virtual void Initialize(std::vector<std::shared_ptr<IStorage>> storage);
+    virtual void Initialize(std::queue<std::shared_ptr<IStorage>> storage);
 
     virtual bool TransactionComplete() const = 0;
     virtual ResultCode GetStatus() const = 0;
@@ -53,7 +53,8 @@ protected:
     };
     static_assert(sizeof(CommonArguments) == 0x20, "CommonArguments has incorrect size.");
 
-    std::vector<std::shared_ptr<IStorage>> storage_stack;
+    CommonArguments common_args;
+    std::queue<std::shared_ptr<IStorage>> storage_stack;
     bool initialized = false;
 };
 

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -20,9 +20,16 @@ namespace Applets {
 
 class Applet {
 public:
+    Applet();
+    virtual ~Applet();
+
     virtual void Initialize(std::vector<std::shared_ptr<IStorage>> storage);
 
     virtual IStorage Execute() = 0;
+
+    bool IsInitialized() const {
+        return initialized;
+    }
 
 protected:
     struct CommonArguments {
@@ -38,9 +45,6 @@ protected:
     std::vector<std::shared_ptr<IStorage>> storage_stack;
     bool initialized = false;
 };
-
-void RegisterSoftwareKeyboard(std::shared_ptr<Frontend::SoftwareKeyboardApplet> applet);
-std::shared_ptr<Frontend::SoftwareKeyboardApplet> GetSoftwareKeyboard();
 
 } // namespace Applets
 } // namespace Service::AM

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <vector>
 #include "common/swap.h"
@@ -20,6 +21,8 @@ class IStorage;
 
 namespace Applets {
 
+using AppletStorageProxyFunction = std::function<void(IStorage)>;
+
 class Applet {
 public:
     Applet();
@@ -30,7 +33,8 @@ public:
     virtual bool TransactionComplete() const = 0;
     virtual ResultCode GetStatus() const = 0;
     virtual void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) = 0;
-    virtual IStorage Execute() = 0;
+    virtual void Execute(AppletStorageProxyFunction out_data,
+                         AppletStorageProxyFunction out_interactive_data) = 0;
 
     bool IsInitialized() const {
         return initialized;

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include "common/assert.h"
 #include "common/string_util.h"
+#include "core/core.h"
 #include "core/frontend/applets/software_keyboard.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/software_keyboard.h"
@@ -11,11 +13,13 @@
 namespace Service::AM::Applets {
 
 constexpr std::size_t SWKBD_OUTPUT_BUFFER_SIZE = 0x7D8;
+constexpr std::size_t SWKBD_OUTPUT_INTERACTIVE_BUFFER_SIZE = 0x7D4;
 constexpr std::size_t DEFAULT_MAX_LENGTH = 500;
+constexpr bool INTERACTIVE_STATUS_OK = false;
 
-static Frontend::SoftwareKeyboardApplet::Parameters ConvertToFrontendParameters(
+static Core::Frontend::SoftwareKeyboardParameters ConvertToFrontendParameters(
     KeyboardConfig config, std::u16string initial_text) {
-    Frontend::SoftwareKeyboardApplet::Parameters params{};
+    Core::Frontend::SoftwareKeyboardParameters params{};
 
     params.submit_text = Common::UTF16StringFromFixedZeroTerminatedBuffer(
         config.submit_text.data(), config.submit_text.size());
@@ -33,6 +37,10 @@ static Frontend::SoftwareKeyboardApplet::Parameters ConvertToFrontendParameters(
 
     return params;
 }
+
+SoftwareKeyboard::SoftwareKeyboard() = default;
+
+SoftwareKeyboard::~SoftwareKeyboard() = default;
 
 void SoftwareKeyboard::Initialize(std::vector<std::shared_ptr<IStorage>> storage_) {
     Applet::Initialize(std::move(storage_));

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -87,7 +87,7 @@ void SoftwareKeyboard::ReceiveInteractiveData(std::shared_ptr<IStorage> storage)
         std::array<char16_t, SWKBD_OUTPUT_INTERACTIVE_BUFFER_SIZE / 2 - 2> string;
         std::memcpy(string.data(), data.data() + 4, string.size() * 2);
         frontend.SendTextCheckDialog(
-            Common::UTF16StringFromFixedZeroTerminatedBuffer(string.data(), string.size()));
+            Common::UTF16StringFromFixedZeroTerminatedBuffer(string.data(), string.size()), state);
     }
 }
 

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -63,7 +63,8 @@ void SoftwareKeyboard::Initialize(std::queue<std::shared_ptr<IStorage>> storage_
         return;
 
     std::vector<char16_t> string(config.initial_string_size);
-    std::memcpy(string.data(), work_buffer.data() + 4, string.size() * 2);
+    std::memcpy(string.data(), work_buffer.data() + config.initial_string_offset,
+                string.size() * 2);
     initial_text = Common::UTF16StringFromFixedZeroTerminatedBuffer(string.data(), string.size());
 }
 

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -74,7 +74,7 @@ bool SoftwareKeyboard::TransactionComplete() const {
 }
 
 ResultCode SoftwareKeyboard::GetStatus() const {
-    return status;
+    return RESULT_SUCCESS;
 }
 
 void SoftwareKeyboard::ExecuteInteractive() {
@@ -118,7 +118,6 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
 
     if (text.has_value()) {
         std::vector<u8> output_sub(SWKBD_OUTPUT_BUFFER_SIZE);
-        status = RESULT_SUCCESS;
 
         if (config.utf_8) {
             const u64 size = text->size() + 8;
@@ -154,7 +153,6 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
 
         broker->SignalStateChanged();
     } else {
-        status = ResultCode(-1);
         output_main[0] = 1;
         complete = true;
         broker->PushNormalDataFromApplet(IStorage{output_main});

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -127,7 +127,7 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
             std::memcpy(output_sub.data() + 8, new_text.data(),
                         std::min(new_text.size(), SWKBD_OUTPUT_BUFFER_SIZE - 8));
 
-            output_main[0] = config.text_check;
+            output_main[0] = INTERACTIVE_STATUS_OK;
             std::memcpy(output_main.data() + 4, new_text.data(),
                         std::min(new_text.size(), SWKBD_OUTPUT_BUFFER_SIZE - 4));
         } else {
@@ -136,7 +136,7 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
             std::memcpy(output_sub.data() + 8, text->data(),
                         std::min(text->size() * 2, SWKBD_OUTPUT_BUFFER_SIZE - 8));
 
-            output_main[0] = config.text_check;
+            output_main[0] = INTERACTIVE_STATUS_OK;
             std::memcpy(output_main.data() + 4, text->data(),
                         std::min(text->size() * 2, SWKBD_OUTPUT_BUFFER_SIZE - 4));
         }
@@ -147,7 +147,6 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
         if (complete) {
             broker->PushNormalDataFromApplet(IStorage{output_main});
         } else {
-            broker->PushNormalDataFromApplet(IStorage{output_main});
             broker->PushInteractiveDataFromApplet(IStorage{output_sub});
         }
 

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -42,7 +42,7 @@ SoftwareKeyboard::SoftwareKeyboard() = default;
 
 SoftwareKeyboard::~SoftwareKeyboard() = default;
 
-void SoftwareKeyboard::Initialize(std::vector<std::shared_ptr<IStorage>> storage_) {
+void SoftwareKeyboard::Initialize(std::queue<std::shared_ptr<IStorage>> storage_) {
     complete = false;
     initial_text.clear();
     final_data.clear();
@@ -50,11 +50,14 @@ void SoftwareKeyboard::Initialize(std::vector<std::shared_ptr<IStorage>> storage
     Applet::Initialize(std::move(storage_));
 
     ASSERT(storage_stack.size() >= 2);
-    const auto& keyboard_config = storage_stack[1]->GetData();
+    const auto& keyboard_config = storage_stack.front()->GetData();
+    storage_stack.pop();
+
     ASSERT(keyboard_config.size() >= sizeof(KeyboardConfig));
     std::memcpy(&config, keyboard_config.data(), sizeof(KeyboardConfig));
 
-    const auto& work_buffer = storage_stack[2]->GetData();
+    const auto& work_buffer = storage_stack.front()->GetData();
+    storage_stack.pop();
 
     if (config.initial_string_size == 0)
         return;

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -1,0 +1,71 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "common/string_util.h"
+#include "core/frontend/applets/software_keyboard.h"
+#include "core/hle/service/am/am.h"
+#include "core/hle/service/am/applets/software_keyboard.h"
+
+namespace Service::AM::Applets {
+
+constexpr std::size_t SWKBD_OUTPUT_BUFFER_SIZE = 0x7D8;
+constexpr std::size_t DEFAULT_MAX_LENGTH = 500;
+
+static Frontend::SoftwareKeyboardApplet::Parameters ConvertToFrontendParameters(
+    KeyboardConfig config, std::u16string initial_text) {
+    Frontend::SoftwareKeyboardApplet::Parameters params{};
+
+    params.submit_text = Common::UTF16StringFromFixedZeroTerminatedBuffer(
+        config.submit_text.data(), config.submit_text.size());
+    params.header_text = Common::UTF16StringFromFixedZeroTerminatedBuffer(
+        config.header_text.data(), config.header_text.size());
+    params.sub_text = Common::UTF16StringFromFixedZeroTerminatedBuffer(config.sub_text.data(),
+                                                                       config.sub_text.size());
+    params.guide_text = Common::UTF16StringFromFixedZeroTerminatedBuffer(config.guide_text.data(),
+                                                                         config.guide_text.size());
+    params.initial_text = initial_text;
+    params.max_length = config.length_limit == 0 ? DEFAULT_MAX_LENGTH : config.length_limit;
+    params.password = static_cast<bool>(config.is_password);
+    params.cursor_at_beginning = static_cast<bool>(config.initial_cursor_position);
+    params.value = static_cast<u8>(config.keyset_disable_bitmask);
+
+    return params;
+}
+
+void SoftwareKeyboard::Initialize(std::vector<std::shared_ptr<IStorage>> storage_) {
+    Applet::Initialize(std::move(storage_));
+
+    ASSERT(storage_stack.size() >= 2);
+    const auto& keyboard_config = storage_stack[1]->GetData();
+    ASSERT(keyboard_config.size() >= sizeof(KeyboardConfig));
+    std::memcpy(&config, keyboard_config.data(), sizeof(KeyboardConfig));
+
+    ASSERT_MSG(config.text_check == 0, "Text check software keyboard mode is not implemented!");
+
+    const auto& work_buffer = storage_stack[2]->GetData();
+    std::memcpy(initial_text.data(), work_buffer.data() + config.initial_string_offset,
+                config.initial_string_size);
+}
+
+IStorage SoftwareKeyboard::Execute() {
+    const auto frontend{GetSoftwareKeyboard()};
+    ASSERT(frontend != nullptr);
+
+    const auto parameters = ConvertToFrontendParameters(config, initial_text);
+
+    std::u16string text;
+    const auto success = frontend->GetText(parameters, text);
+
+    std::vector<u8> output(SWKBD_OUTPUT_BUFFER_SIZE);
+
+    if (success) {
+        output[0] = 1;
+        std::memcpy(output.data() + 4, text.data(),
+                    std::min<std::size_t>(text.size() * 2, SWKBD_OUTPUT_BUFFER_SIZE - 4));
+    }
+
+    return IStorage{output};
+}
+} // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -33,7 +33,8 @@ struct KeyboardConfig {
     u32_le length_limit;
     INSERT_PADDING_BYTES(4);
     u32_le is_password;
-    INSERT_PADDING_BYTES(6);
+    INSERT_PADDING_BYTES(5);
+    bool utf_8;
     bool draw_background;
     u32_le initial_string_offset;
     u32_le initial_string_size;

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -1,0 +1,57 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_funcs.h"
+#include "core/hle/service/am/applets/applets.h"
+
+namespace Service::AM::Applets {
+
+enum class KeysetDisable : u32 {
+    Space = 0x02,
+    Address = 0x04,
+    Percent = 0x08,
+    Slashes = 0x10,
+    Numbers = 0x40,
+    DownloadCode = 0x80,
+};
+
+struct KeyboardConfig {
+    INSERT_PADDING_BYTES(4);
+    std::array<char16_t, 9> submit_text;
+    u16_le left_symbol_key;
+    u16_le right_symbol_key;
+    INSERT_PADDING_BYTES(1);
+    KeysetDisable keyset_disable_bitmask;
+    u32_le initial_cursor_position;
+    std::array<char16_t, 65> header_text;
+    std::array<char16_t, 129> sub_text;
+    std::array<char16_t, 257> guide_text;
+    u32_le length_limit;
+    INSERT_PADDING_BYTES(4);
+    u32_le is_password;
+    INSERT_PADDING_BYTES(6);
+    bool draw_background;
+    u32_le initial_string_offset;
+    u32_le initial_string_size;
+    u32_le user_dictionary_offset;
+    u32_le user_dictionary_size;
+    bool text_check;
+    u64_le text_check_callback;
+};
+static_assert(sizeof(KeyboardConfig) == 0x3E0, "KeyboardConfig has incorrect size.");
+
+class SoftwareKeyboard final : public Applet {
+public:
+    void Initialize(std::vector<std::shared_ptr<IStorage>> storage) override;
+
+    IStorage Execute() override;
+
+private:
+    KeyboardConfig config;
+    std::u16string initial_text;
+};
+
+} // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -55,7 +55,8 @@ public:
     ResultCode GetStatus() const override;
     void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) override;
     void Execute(AppletStorageProxyFunction out_data,
-                 AppletStorageProxyFunction out_interactive_data) override;
+                 AppletStorageProxyFunction out_interactive_data,
+                 AppletStateProxyFunction state) override;
 
     void WriteText(std::optional<std::u16string> text);
 
@@ -64,9 +65,11 @@ private:
     std::u16string initial_text;
     bool complete = false;
     std::vector<u8> final_data;
+    ResultCode status = ResultCode(-1);
 
     AppletStorageProxyFunction out_data;
     AppletStorageProxyFunction out_interactive_data;
+    AppletStateProxyFunction state;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -57,11 +57,16 @@ public:
     void Execute(AppletStorageProxyFunction out_data,
                  AppletStorageProxyFunction out_interactive_data) override;
 
+    void WriteText(std::optional<std::u16string> text);
+
 private:
     KeyboardConfig config;
     std::u16string initial_text;
     bool complete = false;
     std::vector<u8> final_data;
+
+    AppletStorageProxyFunction out_data;
+    AppletStorageProxyFunction out_interactive_data;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -64,7 +64,6 @@ private:
     std::u16string initial_text;
     bool complete = false;
     std::vector<u8> final_data;
-    ResultCode status = ResultCode(-1);
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -50,14 +50,12 @@ public:
     SoftwareKeyboard();
     ~SoftwareKeyboard() override;
 
-    void Initialize(std::queue<std::shared_ptr<IStorage>> storage) override;
+    void Initialize(std::shared_ptr<AppletDataBroker> broker) override;
 
     bool TransactionComplete() const override;
     ResultCode GetStatus() const override;
-    void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) override;
-    void Execute(AppletStorageProxyFunction out_data,
-                 AppletStorageProxyFunction out_interactive_data,
-                 AppletStateProxyFunction state) override;
+    void ExecuteInteractive() override;
+    void Execute() override;
 
     void WriteText(std::optional<std::u16string> text);
 
@@ -67,10 +65,6 @@ private:
     bool complete = false;
     std::vector<u8> final_data;
     ResultCode status = ResultCode(-1);
-
-    AppletStorageProxyFunction out_data;
-    AppletStorageProxyFunction out_interactive_data;
-    AppletStateProxyFunction state;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -49,7 +49,7 @@ public:
     SoftwareKeyboard();
     ~SoftwareKeyboard() override;
 
-    void Initialize(std::vector<std::shared_ptr<IStorage>> storage) override;
+    void Initialize(std::queue<std::shared_ptr<IStorage>> storage) override;
 
     bool TransactionComplete() const override;
     ResultCode GetStatus() const override;

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/common_funcs.h"
+#include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applets.h"
 
 namespace Service::AM::Applets {
@@ -45,13 +46,21 @@ static_assert(sizeof(KeyboardConfig) == 0x3E0, "KeyboardConfig has incorrect siz
 
 class SoftwareKeyboard final : public Applet {
 public:
+    SoftwareKeyboard();
+    ~SoftwareKeyboard() override;
+
     void Initialize(std::vector<std::shared_ptr<IStorage>> storage) override;
 
+    bool TransactionComplete() const override;
+    ResultCode GetStatus() const override;
+    void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) override;
     IStorage Execute() override;
 
 private:
     KeyboardConfig config;
     std::u16string initial_text;
+    bool complete = false;
+    std::vector<u8> final_data;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -54,7 +54,8 @@ public:
     bool TransactionComplete() const override;
     ResultCode GetStatus() const override;
     void ReceiveInteractiveData(std::shared_ptr<IStorage> storage) override;
-    IStorage Execute() override;
+    void Execute(AppletStorageProxyFunction out_data,
+                 AppletStorageProxyFunction out_interactive_data) override;
 
 private:
     KeyboardConfig config;

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(yuzu
     Info.plist
     about_dialog.cpp
     about_dialog.h
+    applets/software_keyboard.cpp
+    applets/software_keyboard.h
     bootmanager.cpp
     bootmanager.h
     compatibility_list.cpp

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -97,11 +97,11 @@ void QtSoftwareKeyboardDialog::Reject() {
     accept();
 }
 
-std::u16string QtSoftwareKeyboardDialog::GetText() {
+std::u16string QtSoftwareKeyboardDialog::GetText() const {
     return text;
 }
 
-bool QtSoftwareKeyboardDialog::GetStatus() {
+bool QtSoftwareKeyboardDialog::GetStatus() const {
     return ok;
 }
 
@@ -109,13 +109,12 @@ QtSoftwareKeyboard::QtSoftwareKeyboard(GMainWindow& parent) : main_window(parent
 
 QtSoftwareKeyboard::~QtSoftwareKeyboard() = default;
 
-bool QtSoftwareKeyboard::GetText(Core::Frontend::SoftwareKeyboardParameters parameters,
-                                 std::u16string& text) const {
-    bool success;
+std::optional<std::u16string> QtSoftwareKeyboard::GetText(
+    Core::Frontend::SoftwareKeyboardParameters parameters) const {
+    std::optional<std::u16string> success;
     QMetaObject::invokeMethod(&main_window, "SoftwareKeyboardGetText", Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(bool, success),
-                              Q_ARG(Core::Frontend::SoftwareKeyboardParameters, parameters),
-                              Q_ARG(std::u16string&, text));
+                              Q_RETURN_ARG(std::optional<std::u16string>, success),
+                              Q_ARG(Core::Frontend::SoftwareKeyboardParameters, parameters));
     return success;
 }
 

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -1,0 +1,107 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <locale>
+#include <QDialogButtonBox>
+#include <QFont>
+#include <QLabel>
+#include <QLineEdit>
+#include <QVBoxLayout>
+#include "common/logging/backend.h"
+#include "yuzu/applets/software_keyboard.h"
+
+QtSoftwareKeyboardValidator::QtSoftwareKeyboardValidator(
+    Frontend::SoftwareKeyboardApplet::Parameters parameters)
+    : parameters(std::move(parameters)) {}
+
+QValidator::State QtSoftwareKeyboardValidator::validate(QString& input, int&) const {
+    if (input.size() > parameters.max_length)
+        return Invalid;
+    if (parameters.disable_space && input.contains(' '))
+        return Invalid;
+    if (parameters.disable_address && input.contains('@'))
+        return Invalid;
+    if (parameters.disable_percent && input.contains('%'))
+        return Invalid;
+    if (parameters.disable_slash && (input.contains('/') || input.contains('\\')))
+        return Invalid;
+    if (parameters.disable_number &&
+        std::any_of(input.begin(), input.end(), [](QChar c) { return c.isDigit(); }))
+        return Invalid;
+
+    if (parameters.disable_download_code &&
+        std::any_of(input.begin(), input.end(), [](QChar c) { return c == 'O' || c == 'I'; }))
+        return Invalid;
+
+    return Acceptable;
+}
+
+QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
+    QWidget* parent, Frontend::SoftwareKeyboardApplet::Parameters parameters_)
+    : QDialog(parent), parameters(std::move(parameters_)) {
+    layout = new QVBoxLayout;
+
+    header_label = new QLabel(QString::fromStdU16String(parameters.header_text));
+    header_label->setFont({header_label->font().family(), 12, QFont::Bold});
+    if (header_label->text().isEmpty())
+        header_label->setText(tr("Enter text:"));
+
+    sub_label = new QLabel(QString::fromStdU16String(parameters.sub_text));
+    sub_label->setFont({sub_label->font().family(), sub_label->font().pointSize(),
+                        sub_label->font().weight(), true});
+    sub_label->setHidden(parameters.sub_text.empty());
+
+    guide_label = new QLabel(QString::fromStdU16String(parameters.guide_text));
+    guide_label->setHidden(parameters.guide_text.empty());
+
+    line_edit = new QLineEdit;
+    line_edit->setValidator(new QtSoftwareKeyboardValidator(parameters));
+    line_edit->setMaxLength(static_cast<int>(parameters.max_length));
+    line_edit->setText(QString::fromStdU16String(parameters.initial_text));
+    line_edit->setCursorPosition(
+        parameters.cursor_at_beginning ? 0 : static_cast<int>(parameters.initial_text.size()));
+    line_edit->setEchoMode(parameters.password ? QLineEdit::Password : QLineEdit::Normal);
+
+    buttons = new QDialogButtonBox;
+    buttons->addButton(tr("Cancel"), QDialogButtonBox::RejectRole);
+    buttons->addButton(parameters.submit_text.empty()
+                           ? tr("OK")
+                           : QString::fromStdU16String(parameters.submit_text),
+                       QDialogButtonBox::AcceptRole);
+
+    connect(buttons, &QDialogButtonBox::accepted, this, &QtSoftwareKeyboardDialog::Submit);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QtSoftwareKeyboardDialog::Reject);
+    layout->addWidget(header_label);
+    layout->addWidget(sub_label);
+    layout->addWidget(guide_label);
+    layout->addWidget(line_edit);
+    layout->addWidget(buttons);
+    setLayout(layout);
+    setWindowTitle("Software Keyboard");
+}
+
+void QtSoftwareKeyboardDialog::Submit() {
+    ok = true;
+    text = line_edit->text().toStdU16String();
+    accept();
+}
+
+void QtSoftwareKeyboardDialog::Reject() {
+    ok = false;
+    text = Common::UTF8ToUTF16("");
+    accept();
+}
+
+QtSoftwareKeyboard::QtSoftwareKeyboard(QWidget& parent) : parent(parent) {}
+
+bool QtSoftwareKeyboard::GetText(Parameters parameters, std::u16string& text) {
+    QtSoftwareKeyboardDialog dialog(&parent, parameters);
+    dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
+                          Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.exec();
+
+    text = dialog.text;
+    return dialog.ok;
+}

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -47,7 +47,7 @@ QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
     layout = new QVBoxLayout;
 
     header_label = new QLabel(QString::fromStdU16String(parameters.header_text));
-    header_label->setFont({header_label->font().family(), 12, QFont::Bold});
+    header_label->setFont({header_label->font().family(), 11, QFont::Bold});
     if (header_label->text().isEmpty())
         header_label->setText(tr("Enter text:"));
 
@@ -59,6 +59,10 @@ QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
     guide_label = new QLabel(QString::fromStdU16String(parameters.guide_text));
     guide_label->setHidden(parameters.guide_text.empty());
 
+    length_label = new QLabel(QStringLiteral("0/%1").arg(parameters.max_length));
+    length_label->setAlignment(Qt::AlignRight);
+    length_label->setFont({length_label->font().family(), 8});
+
     line_edit = new QLineEdit;
     line_edit->setValidator(new QtSoftwareKeyboardValidator(parameters));
     line_edit->setMaxLength(static_cast<int>(parameters.max_length));
@@ -66,6 +70,10 @@ QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
     line_edit->setCursorPosition(
         parameters.cursor_at_beginning ? 0 : static_cast<int>(parameters.initial_text.size()));
     line_edit->setEchoMode(parameters.password ? QLineEdit::Password : QLineEdit::Normal);
+
+    connect(line_edit, &QLineEdit::textChanged, this, [this](const QString& text) {
+        length_label->setText(QStringLiteral("%1/%2").arg(text.size()).arg(parameters.max_length));
+    });
 
     buttons = new QDialogButtonBox;
     buttons->addButton(tr("Cancel"), QDialogButtonBox::RejectRole);
@@ -79,6 +87,7 @@ QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
     layout->addWidget(header_label);
     layout->addWidget(sub_label);
     layout->addWidget(guide_label);
+    layout->addWidget(length_label);
     layout->addWidget(line_edit);
     layout->addWidget(buttons);
     setLayout(layout);

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -9,6 +9,7 @@
 #include <QLineEdit>
 #include <QVBoxLayout>
 #include "common/logging/backend.h"
+#include "common/string_util.h"
 #include "yuzu/applets/software_keyboard.h"
 
 QtSoftwareKeyboardValidator::QtSoftwareKeyboardValidator(

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -62,7 +62,8 @@ public:
 
     void RequestText(std::function<void(std::optional<std::u16string>)> out,
                      Core::Frontend::SoftwareKeyboardParameters parameters) const override;
-    void SendTextCheckDialog(std::u16string error_message) const override;
+    void SendTextCheckDialog(std::u16string error_message,
+                             std::function<void()> finished_check) const override;
 
 signals:
     void MainWindowGetText(Core::Frontend::SoftwareKeyboardParameters parameters) const;
@@ -70,7 +71,9 @@ signals:
 
 public slots:
     void MainWindowFinishedText(std::optional<std::u16string> text);
+    void MainWindowFinishedCheckDialog();
 
 private:
     mutable std::function<void(std::optional<std::u16string>)> text_output;
+    mutable std::function<void()> finished_check;
 };

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -1,0 +1,62 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+#include <QDialog>
+#include <QValidator>
+#include "common/assert.h"
+#include "core/frontend/applets/software_keyboard.h"
+
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QVBoxLayout;
+class QtSoftwareKeyboard;
+
+class QtSoftwareKeyboardValidator final : public QValidator {
+public:
+    explicit QtSoftwareKeyboardValidator(Frontend::SoftwareKeyboardApplet::Parameters parameters);
+    State validate(QString&, int&) const override;
+
+private:
+    Frontend::SoftwareKeyboardApplet::Parameters parameters;
+};
+
+class QtSoftwareKeyboardDialog final : public QDialog {
+    Q_OBJECT
+
+public:
+    QtSoftwareKeyboardDialog(QWidget* parent,
+                             Frontend::SoftwareKeyboardApplet::Parameters parameters);
+    void Submit();
+    void Reject();
+
+private:
+    bool ok = false;
+    std::u16string text;
+
+    QDialogButtonBox* buttons;
+    QLabel* header_label;
+    QLabel* sub_label;
+    QLabel* guide_label;
+    QLineEdit* line_edit;
+    QVBoxLayout* layout;
+
+    Frontend::SoftwareKeyboardApplet::Parameters parameters;
+
+    friend class QtSoftwareKeyboard;
+};
+
+class QtSoftwareKeyboard final : public QObject, public Frontend::SoftwareKeyboardApplet {
+public:
+    explicit QtSoftwareKeyboard(QWidget& parent);
+    bool GetText(Parameters parameters, std::u16string& text) override;
+
+    ~QtSoftwareKeyboard() {
+        UNREACHABLE();
+    }
+
+private:
+    QWidget& parent;
+};

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -36,8 +36,8 @@ public:
     void Submit();
     void Reject();
 
-    std::u16string GetText();
-    bool GetStatus();
+    std::u16string GetText() const;
+    bool GetStatus() const;
 
 private:
     bool ok = false;
@@ -58,8 +58,8 @@ public:
     explicit QtSoftwareKeyboard(GMainWindow& parent);
     ~QtSoftwareKeyboard() override;
 
-    bool GetText(Core::Frontend::SoftwareKeyboardParameters parameters,
-                 std::u16string& text) const override;
+    std::optional<std::u16string> GetText(
+        Core::Frontend::SoftwareKeyboardParameters parameters) const override;
     void SendTextCheckDialog(std::u16string error_message) const override;
 
 private:

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -47,6 +47,7 @@ private:
     QLabel* header_label;
     QLabel* sub_label;
     QLabel* guide_label;
+    QLabel* length_label;
     QLineEdit* line_edit;
     QVBoxLayout* layout;
 

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -3,11 +3,13 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include <QDialog>
 #include <QValidator>
 #include "common/assert.h"
 #include "core/frontend/applets/software_keyboard.h"
 
+class GMainWindow;
 class QDialogButtonBox;
 class QLabel;
 class QLineEdit;
@@ -16,11 +18,11 @@ class QtSoftwareKeyboard;
 
 class QtSoftwareKeyboardValidator final : public QValidator {
 public:
-    explicit QtSoftwareKeyboardValidator(Frontend::SoftwareKeyboardApplet::Parameters parameters);
-    State validate(QString&, int&) const override;
+    explicit QtSoftwareKeyboardValidator(Core::Frontend::SoftwareKeyboardParameters parameters);
+    State validate(QString& input, int& pos) const override;
 
 private:
-    Frontend::SoftwareKeyboardApplet::Parameters parameters;
+    Core::Frontend::SoftwareKeyboardParameters parameters;
 };
 
 class QtSoftwareKeyboardDialog final : public QDialog {
@@ -28,9 +30,14 @@ class QtSoftwareKeyboardDialog final : public QDialog {
 
 public:
     QtSoftwareKeyboardDialog(QWidget* parent,
-                             Frontend::SoftwareKeyboardApplet::Parameters parameters);
+                             Core::Frontend::SoftwareKeyboardParameters parameters);
+    ~QtSoftwareKeyboardDialog() override;
+
     void Submit();
     void Reject();
+
+    std::u16string GetText();
+    bool GetStatus();
 
 private:
     bool ok = false;
@@ -43,20 +50,18 @@ private:
     QLineEdit* line_edit;
     QVBoxLayout* layout;
 
-    Frontend::SoftwareKeyboardApplet::Parameters parameters;
-
-    friend class QtSoftwareKeyboard;
+    Core::Frontend::SoftwareKeyboardParameters parameters;
 };
 
-class QtSoftwareKeyboard final : public QObject, public Frontend::SoftwareKeyboardApplet {
+class QtSoftwareKeyboard final : public QObject, public Core::Frontend::SoftwareKeyboardApplet {
 public:
-    explicit QtSoftwareKeyboard(QWidget& parent);
-    bool GetText(Parameters parameters, std::u16string& text) override;
+    explicit QtSoftwareKeyboard(GMainWindow& parent);
+    ~QtSoftwareKeyboard() override;
 
-    ~QtSoftwareKeyboard() {
-        UNREACHABLE();
-    }
+    bool GetText(Core::Frontend::SoftwareKeyboardParameters parameters,
+                 std::u16string& text) const override;
+    void SendTextCheckDialog(std::u16string error_message) const override;
 
 private:
-    QWidget& parent;
+    GMainWindow& main_window;
 };

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -54,14 +54,23 @@ private:
 };
 
 class QtSoftwareKeyboard final : public QObject, public Core::Frontend::SoftwareKeyboardApplet {
+    Q_OBJECT
+
 public:
     explicit QtSoftwareKeyboard(GMainWindow& parent);
     ~QtSoftwareKeyboard() override;
 
-    std::optional<std::u16string> GetText(
-        Core::Frontend::SoftwareKeyboardParameters parameters) const override;
+    void RequestText(std::function<void(std::optional<std::u16string>)> out,
+                     Core::Frontend::SoftwareKeyboardParameters parameters) const override;
     void SendTextCheckDialog(std::u16string error_message) const override;
 
+signals:
+    void MainWindowGetText(Core::Frontend::SoftwareKeyboardParameters parameters) const;
+    void MainWindowTextCheckDialog(std::u16string error_message) const;
+
+public slots:
+    void MainWindowFinishedText(std::optional<std::u16string> text);
+
 private:
-    GMainWindow& main_window;
+    mutable std::function<void(std::optional<std::u16string>)> text_output;
 };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -61,6 +61,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/savedata_factory.h"
 #include "core/file_sys/submission_package.h"
+#include "core/frontend/applets/software_keyboard.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/filesystem/fsp_ldr.h"
@@ -204,6 +205,22 @@ GMainWindow::~GMainWindow() {
     // will get automatically deleted otherwise
     if (render_window->parent() == nullptr)
         delete render_window;
+}
+
+bool GMainWindow::SoftwareKeyboardGetText(
+    const Core::Frontend::SoftwareKeyboardParameters& parameters, std::u16string& text) {
+    QtSoftwareKeyboardDialog dialog(this, parameters);
+    dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
+                          Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.exec();
+
+    text = dialog.GetText();
+    return dialog.GetStatus();
+}
+
+void GMainWindow::SoftwareKeyboardInvokeCheckDialog(std::u16string error_message) {
+    QMessageBox::warning(this, tr("Text Check Failed"), QString::fromStdU16String(error_message));
 }
 
 void GMainWindow::InitializeWidgets() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -215,14 +215,17 @@ void GMainWindow::SoftwareKeyboardGetText(
     dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
 
-    if (!dialog.GetStatus())
+    if (!dialog.GetStatus()) {
         emit SoftwareKeyboardFinishedText(std::nullopt);
+        return;
+    }
 
     emit SoftwareKeyboardFinishedText(dialog.GetText());
 }
 
 void GMainWindow::SoftwareKeyboardInvokeCheckDialog(std::u16string error_message) {
     QMessageBox::warning(this, tr("Text Check Failed"), QString::fromStdU16String(error_message));
+    emit SoftwareKeyboardFinishedCheckDialog();
 }
 
 void GMainWindow::InitializeWidgets() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -8,9 +8,11 @@
 #include <thread>
 
 // VFS includes must be before glad as they will conflict with Windows file api, which uses defines.
+#include "applets/software_keyboard.h"
 #include "core/file_sys/vfs.h"
 #include "core/file_sys/vfs_real.h"
 #include "core/hle/service/acc/profile_manager.h"
+#include "core/hle/service/am/applets/applets.h"
 
 // These are wrappers to avoid the calls to CreateDirectory and CreateFile because of the Windows
 // defines.
@@ -558,6 +560,8 @@ bool GMainWindow::LoadROM(const QString& filename) {
     system.SetFilesystem(vfs);
 
     system.SetGPUDebugContext(debug_context);
+
+    Service::AM::Applets::RegisterSoftwareKeyboard(std::make_shared<QtSoftwareKeyboard>(*this));
 
     const Core::System::ResultStatus result{system.Load(*render_window, filename.toStdString())};
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -207,16 +207,18 @@ GMainWindow::~GMainWindow() {
         delete render_window;
 }
 
-bool GMainWindow::SoftwareKeyboardGetText(
-    const Core::Frontend::SoftwareKeyboardParameters& parameters, std::u16string& text) {
+std::optional<std::u16string> GMainWindow::SoftwareKeyboardGetText(
+    const Core::Frontend::SoftwareKeyboardParameters& parameters) {
     QtSoftwareKeyboardDialog dialog(this, parameters);
     dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                           Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
     dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
 
-    text = dialog.GetText();
-    return dialog.GetStatus();
+    if (!dialog.GetStatus())
+        return std::nullopt;
+
+    return dialog.GetText();
 }
 
 void GMainWindow::SoftwareKeyboardInvokeCheckDialog(std::u16string error_message) {
@@ -1251,10 +1253,10 @@ void GMainWindow::OnStartGame() {
     emu_thread->SetRunning(true);
 
     qRegisterMetaType<Core::Frontend::SoftwareKeyboardParameters>(
-        "core::Frontend::SoftwareKeyboardParameters");
+        "Core::Frontend::SoftwareKeyboardParameters");
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
-    qRegisterMetaType<std::u16string>("std::u16string");
+    qRegisterMetaType<std::optional<std::u16string>>("std::optional<std::u16string>");
 
     connect(emu_thread.get(), &EmuThread::ErrorThrown, this, &GMainWindow::OnCoreError);
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -207,7 +207,7 @@ GMainWindow::~GMainWindow() {
         delete render_window;
 }
 
-std::optional<std::u16string> GMainWindow::SoftwareKeyboardGetText(
+void GMainWindow::SoftwareKeyboardGetText(
     const Core::Frontend::SoftwareKeyboardParameters& parameters) {
     QtSoftwareKeyboardDialog dialog(this, parameters);
     dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
@@ -216,9 +216,9 @@ std::optional<std::u16string> GMainWindow::SoftwareKeyboardGetText(
     dialog.exec();
 
     if (!dialog.GetStatus())
-        return std::nullopt;
+        emit SoftwareKeyboardFinishedText(std::nullopt);
 
-    return dialog.GetText();
+    emit SoftwareKeyboardFinishedText(dialog.GetText());
 }
 
 void GMainWindow::SoftwareKeyboardInvokeCheckDialog(std::u16string error_message) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -561,7 +561,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     system.SetGPUDebugContext(debug_context);
 
-    Service::AM::Applets::RegisterSoftwareKeyboard(std::make_shared<QtSoftwareKeyboard>(*this));
+    system.SetSoftwareKeyboard(std::make_unique<QtSoftwareKeyboard>(*this));
 
     const Core::System::ResultStatus result{system.Load(*render_window, filename.toStdString())};
 
@@ -1232,8 +1232,13 @@ void GMainWindow::OnMenuRecentFile() {
 
 void GMainWindow::OnStartGame() {
     emu_thread->SetRunning(true);
+
+    qRegisterMetaType<Core::Frontend::SoftwareKeyboardParameters>(
+        "core::Frontend::SoftwareKeyboardParameters");
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
+    qRegisterMetaType<std::u16string>("std::u16string");
+
     connect(emu_thread.get(), &EmuThread::ErrorThrown, this, &GMainWindow::OnCoreError);
 
     ui.action_Start->setEnabled(false);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -99,9 +99,10 @@ signals:
     // Signal that tells widgets to update icons to use the current theme
     void UpdateThemedIcons();
 
+    void SoftwareKeyboardFinishedText(std::optional<std::u16string> text);
+
 public slots:
-    std::optional<std::u16string> SoftwareKeyboardGetText(
-        const Core::Frontend::SoftwareKeyboardParameters& parameters);
+    void SoftwareKeyboardGetText(const Core::Frontend::SoftwareKeyboardParameters& parameters);
     void SoftwareKeyboardInvokeCheckDialog(std::u16string error_message);
 
 private:

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -100,8 +100,8 @@ signals:
     void UpdateThemedIcons();
 
 public slots:
-    bool SoftwareKeyboardGetText(const Core::Frontend::SoftwareKeyboardParameters& parameters,
-                                 std::u16string& text);
+    std::optional<std::u16string> SoftwareKeyboardGetText(
+        const Core::Frontend::SoftwareKeyboardParameters& parameters);
     void SoftwareKeyboardInvokeCheckDialog(std::u16string error_message);
 
 private:

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -100,6 +100,7 @@ signals:
     void UpdateThemedIcons();
 
     void SoftwareKeyboardFinishedText(std::optional<std::u16string> text);
+    void SoftwareKeyboardFinishedCheckDialog();
 
 public slots:
     void SoftwareKeyboardGetText(const Core::Frontend::SoftwareKeyboardParameters& parameters);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -29,6 +29,10 @@ class ProfilerWidget;
 class WaitTreeWidget;
 enum class GameListOpenTarget;
 
+namespace Core::Frontend {
+struct SoftwareKeyboardParameters;
+} // namespace Core::Frontend
+
 namespace FileSys {
 class RegisteredCacheUnion;
 class VfsFilesystem;
@@ -94,6 +98,11 @@ signals:
 
     // Signal that tells widgets to update icons to use the current theme
     void UpdateThemedIcons();
+
+public slots:
+    bool SoftwareKeyboardGetText(const Core::Frontend::SoftwareKeyboardParameters& parameters,
+                                 std::u16string& text);
+    void SoftwareKeyboardInvokeCheckDialog(std::u16string error_message);
 
 private:
     void InitializeWidgets();


### PR DESCRIPTION
Used by Minecraft, Pokken Tournament, Stardew Valley, and some other indie games.
Prompts a dialog when the game requests the swkbd, uses the same validation as the real game.

Big thanks to @misson20000 for his help with understanding applets and hwtest (https://github.com/misson20000/swkbd-demo)

Also adds TransferMemory, as this is used by the swkbd for some of the data transfer.