### PR TITLE
gl_shader_decompiler: Remove UNREACHABLE when setting RZ 

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -761,8 +761,7 @@ private:
                      u64 dest_num_components, u64 value_num_components, u64 dest_elem,
                      bool precise) {
         if (reg == Register::ZeroIndex) {
-            LOG_CRITICAL(HW_GPU, "Cannot set Register::ZeroIndex");
-            UNREACHABLE();
+            // Setting RZ is a nop in hardware.
             return;
         }
 


### PR DESCRIPTION
The following example sets 1 to $r20:

mov32i 0x0 0xdeadbeef 0xf
mov32i $r20 0x00000001 0xf
iadd $r20 $r20 0x0

That implies that writing to RZ (0x0 in envyas syntax) is a nop (reading from it always returns zero). I didn't test what happens to condition codes in those cases, but that's beyond the scope of SetRegister.