### PR TITLE
Use default values for unknown framebuffer pixel format 

### DIFF
--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -17,6 +17,8 @@ u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
     switch (format) {
     case PixelFormat::ABGR8:
         return 4;
+    default:
+        return 4;
     }
 
     UNREACHABLE();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -304,6 +304,12 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
         gl_framebuffer_data.resize(texture.width * texture.height * 4);
         break;
     default:
+        internal_format = GL_RGBA;
+        texture.gl_format = GL_RGBA;
+        texture.gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;
+        gl_framebuffer_data.resize(texture.width * texture.height * 4);
+        LOG_CRITICAL(Render_OpenGL, "Unknown framebuffer pixel format: {}",
+                     static_cast<u32>(framebuffer.pixel_format));
         UNREACHABLE();
     }
 


### PR DESCRIPTION
This fixes Bayonetta 2 and Okami HD crashes.