### PR TITLE
Added predicate comparison LessEqualWithNan 

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -153,6 +153,7 @@ enum class PredCondition : u64 {
     NotEqual = 5,
     GreaterEqual = 6,
     LessThanWithNan = 9,
+    LessEqualWithNan = 11,
     GreaterThanWithNan = 12,
     NotEqualWithNan = 13,
     GreaterEqualWithNan = 14,

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1075,7 +1075,8 @@ private:
             {PredCondition::LessEqual, "<="},         {PredCondition::GreaterThan, ">"},
             {PredCondition::NotEqual, "!="},          {PredCondition::GreaterEqual, ">="},
             {PredCondition::LessThanWithNan, "<"},    {PredCondition::NotEqualWithNan, "!="},
-            {PredCondition::GreaterThanWithNan, ">"}, {PredCondition::GreaterEqualWithNan, ">="}};
+            {PredCondition::LessEqualWithNan, ">"},   {PredCondition::GreaterThanWithNan, ">"},
+            {PredCondition::GreaterEqualWithNan, ">="}};
 
         const auto& comparison{PredicateComparisonStrings.find(condition)};
         ASSERT_MSG(comparison != PredicateComparisonStrings.end(),
@@ -1084,6 +1085,7 @@ private:
         std::string predicate{'(' + op_a + ") " + comparison->second + " (" + op_b + ')'};
         if (condition == PredCondition::LessThanWithNan ||
             condition == PredCondition::NotEqualWithNan ||
+            condition == PredCondition::LessEqualWithNan ||
             condition == PredCondition::GreaterThanWithNan ||
             condition == PredCondition::GreaterEqualWithNan) {
             predicate += " || isnan(" + op_a + ") || isnan(" + op_b + ')';

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1071,11 +1071,16 @@ private:
                                        const std::string& op_a, const std::string& op_b) const {
         using Tegra::Shader::PredCondition;
         static const std::unordered_map<PredCondition, const char*> PredicateComparisonStrings = {
-            {PredCondition::LessThan, "<"},           {PredCondition::Equal, "=="},
-            {PredCondition::LessEqual, "<="},         {PredCondition::GreaterThan, ">"},
-            {PredCondition::NotEqual, "!="},          {PredCondition::GreaterEqual, ">="},
-            {PredCondition::LessThanWithNan, "<"},    {PredCondition::NotEqualWithNan, "!="},
-            {PredCondition::LessEqualWithNan, "<="},   {PredCondition::GreaterThanWithNan, ">"},
+            {PredCondition::LessThan, "<"},
+            {PredCondition::Equal, "=="},
+            {PredCondition::LessEqual, "<="},
+            {PredCondition::GreaterThan, ">"},
+            {PredCondition::NotEqual, "!="},
+            {PredCondition::GreaterEqual, ">="},
+            {PredCondition::LessThanWithNan, "<"},
+            {PredCondition::NotEqualWithNan, "!="},
+            {PredCondition::LessEqualWithNan, "<="},
+            {PredCondition::GreaterThanWithNan, ">"},
             {PredCondition::GreaterEqualWithNan, ">="}};
 
         const auto& comparison{PredicateComparisonStrings.find(condition)};

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1075,7 +1075,7 @@ private:
             {PredCondition::LessEqual, "<="},         {PredCondition::GreaterThan, ">"},
             {PredCondition::NotEqual, "!="},          {PredCondition::GreaterEqual, ">="},
             {PredCondition::LessThanWithNan, "<"},    {PredCondition::NotEqualWithNan, "!="},
-            {PredCondition::LessEqualWithNan, ">"},   {PredCondition::GreaterThanWithNan, ">"},
+            {PredCondition::LessEqualWithNan, "<="},   {PredCondition::GreaterThanWithNan, ">"},
             {PredCondition::GreaterEqualWithNan, ">="}};
 
         const auto& comparison{PredicateComparisonStrings.find(condition)};


### PR DESCRIPTION
Implements predicate comparison 11 (0xB), also known as LessEqualWithNan.

Fixes a crash while trying to go ingame in L.A. Noire.
Fixes trainer battle crashes in Pokemon Let's Go.