### PR TITLE
gl_rasterizer: Fixup for #1723.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -668,7 +668,7 @@ void RasterizerOpenGL::DrawArrays() {
     bool invalidate = buffer_cache.Map(buffer_size);
     if (invalidate) {
         // As all cached buffers are invalidated, we need to recheck their state.
-        gpu.dirty_flags.vertex_attrib_format = 0xFFFFFFFF;
+        gpu.dirty_flags.vertex_array = 0xFFFFFFFF;
     }
 
     SetupVertexFormat();


### PR DESCRIPTION
On invalidating the streaming buffer, we need to reupload all vertex buffers.
But we don't need to reconfigure the vertex format.
This was a (silly) misstake in #1723.

Thanks at Rodrigo for discovering the issue.

Fun fact, as configuring the vertex format also invalidate the vertex buffer,
this misstake had no affect on the behavior.