### PR TITLE
Fix debug build

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1044,7 +1044,7 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
     LOG_TRACE(Kernel_SVC,
               "called entrypoint=0x{:08X} ({}), arg=0x{:08X}, stacktop=0x{:08X}, "
               "threadpriority=0x{:08X}, processorid=0x{:08X} : created handle=0x{:08X}",
-              entry_point, name, arg, stack_top, priority, processor_id, *out_handle);
+              entry_point, arg, stack_top, priority, processor_id, *out_handle);
 
     if (priority > THREADPRIO_LOWEST) {
         LOG_ERROR(Kernel_SVC, "An invalid priority was specified, expected {} but got {}",

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -128,10 +128,8 @@ enum class BufferMethods {
 };
 
 void GPU::CallMethod(const MethodCall& method_call) {
-    LOG_TRACE(HW_GPU,
-              "Processing method {:08X} on subchannel {} value "
-              "{:08X} remaining params {}",
-              MethCall.method, MethCall.subchannel, value, remaining_params);
+    LOG_TRACE(HW_GPU, "Processing method {:08X} on subchannel {}", method_call.method,
+              method_call.subchannel);
 
     ASSERT(method_call.subchannel < bound_engines.size());
 


### PR DESCRIPTION
A non-existent parameter was left in some formatting calls (the logging
macro for which only does anything meaningful on debug builds)