### PR TITLE
kernel/svc: Correct behavior of svcResetSignal() 

### DIFF
--- a/src/core/hle/kernel/object.cpp
+++ b/src/core/hle/kernel/object.cpp
@@ -15,6 +15,7 @@ bool Object::IsWaitable() const {
     switch (GetHandleType()) {
     case HandleType::ReadableEvent:
     case HandleType::Thread:
+    case HandleType::Process:
     case HandleType::Timer:
     case HandleType::ServerPort:
     case HandleType::ServerSession:
@@ -23,7 +24,6 @@ bool Object::IsWaitable() const {
     case HandleType::Unknown:
     case HandleType::WritableEvent:
     case HandleType::SharedMemory:
-    case HandleType::Process:
     case HandleType::AddressArbiter:
     case HandleType::ResourceLimit:
     case HandleType::ClientPort:

--- a/src/core/hle/kernel/readable_event.cpp
+++ b/src/core/hle/kernel/readable_event.cpp
@@ -4,10 +4,10 @@
 
 #include <algorithm>
 #include "common/assert.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/readable_event.h"
 #include "core/hle/kernel/thread.h"
-#include "core/hle/kernel/writable_event.h"
 
 namespace Kernel {
 
@@ -32,6 +32,16 @@ void ReadableEvent::Signal() {
 
 void ReadableEvent::Clear() {
     signaled = false;
+}
+
+ResultCode ReadableEvent::Reset() {
+    if (!signaled) {
+        return ERR_INVALID_STATE;
+    }
+
+    Clear();
+
+    return RESULT_SUCCESS;
 }
 
 void ReadableEvent::WakeupAllWaitingThreads() {

--- a/src/core/hle/kernel/readable_event.h
+++ b/src/core/hle/kernel/readable_event.h
@@ -7,6 +7,8 @@
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/wait_object.h"
 
+union ResultCode;
+
 namespace Kernel {
 
 class KernelCore;
@@ -39,7 +41,16 @@ public:
 
     void WakeupAllWaitingThreads() override;
 
+    /// Unconditionally clears the readable event's state.
     void Clear();
+
+    /// Clears the readable event's state if and only if it
+    /// has already been signaled.
+    ///
+    /// @pre The event must be in a signaled state. If this event
+    ///      is in an unsignaled state and this function is called,
+    ///      then ERR_INVALID_STATE will be returned.
+    ResultCode Reset();
 
 private:
     explicit ReadableEvent(KernelCore& kernel);


### PR DESCRIPTION
While partially correct, this service call allows the retrieved event to be null, as it also uses the same handle to check if it was referring to a Process instance.
This also corrects Process' inheritance, given it's actually a synchronizable object that can be waited upon for state changes.