### PR TITLE
Perf: Avoid (expensive) audio interpolation when sample rates already match 

### DIFF
--- a/src/audio_core/algorithm/interpolate.cpp
+++ b/src/audio_core/algorithm/interpolate.cpp
@@ -54,8 +54,9 @@ std::vector<s16> Interpolate(InterpolationState& state, std::vector<s16> input, 
             double l = 0.0;
             double r = 0.0;
             for (std::size_t j = 0; j < h.size(); j++) {
-                l += Lanczos(taps, pos + j - taps + 1) * h[j][0];
-                r += Lanczos(taps, pos + j - taps + 1) * h[j][1];
+                const double lanczos_calc = Lanczos(taps, pos + j - taps + 1);
+                l += lanczos_calc * h[j][0];
+                r += lanczos_calc * h[j][1];
             }
             output.emplace_back(static_cast<s16>(std::clamp(l, -32768.0, 32767.0)));
             output.emplace_back(static_cast<s16>(std::clamp(r, -32768.0, 32767.0)));

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -285,8 +285,11 @@ void AudioRenderer::VoiceState::RefreshBuffer() {
         break;
     }
 
-    samples =
-        Interpolate(interp_state, std::move(samples), GetInfo().sample_rate, STREAM_SAMPLE_RATE);
+    // Only interpolate when necessary, expensive.
+    if (GetInfo().sample_rate != STREAM_SAMPLE_RATE) {
+        samples = Interpolate(interp_state, std::move(samples), GetInfo().sample_rate,
+                              STREAM_SAMPLE_RATE);
+    }
 
     is_refresh_pending = false;
 }


### PR DESCRIPTION
Also removes redundant lanczos calculation, which was being calculated twice (surprised the compiler didn't eliminate that).

In BOTW, the vast majority of samples don't need the interpolation, (Interpolation goes from ~4% of CPU time to basically nothing), but if that's an outlier then we should move to a faster sine approximation when interpolation is needed. That's most of the remaining cost.

By code inspection skipping interpolation when sample rates match appears (and sounds) correct, but not very familiar with this logic. At the least a fast-path should be possible for 1.0 ratios