### PR TITLE
gl_shader_decompiler: IPA FrontFacing: the right value when is the fr…

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -928,7 +928,7 @@ private:
         case Attribute::Index::FrontFacing:
             // TODO(Subv): Find out what the values are for the other elements.
             ASSERT(stage == Maxwell3D::Regs::ShaderStage::Fragment);
-            return "vec4(0, 0, 0, uintBitsToFloat(gl_FrontFacing ? 1 : 0))";
+            return "vec4(0, 0, 0, intBitsToFloat(gl_FrontFacing ? -1 : 0))";
         default:
             const u32 index{static_cast<u32>(attribute) -
                             static_cast<u32>(Attribute::Index::Attribute_0)};


### PR DESCRIPTION
gl_shader_decompiler: IPA FrontFacing: the right value when is the front face is 0xFFFFFFFF.
That Should fix moustache and red flag colour and other issues related.

Especially thanks to Rodrigo for help in the HW test.