### PR TITLE
process: Store the extra resource memory size

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -63,6 +63,10 @@ u32 ProgramMetadata::GetMainThreadStackSize() const {
     return npdm_header.main_stack_size;
 }
 
+u32 ProgramMetadata::GetExtraResourceSize() const {
+    return npdm_header.extra_resource_size;
+}
+
 u64 ProgramMetadata::GetTitleID() const {
     return aci_header.title_id;
 }

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -48,6 +48,7 @@ public:
     u8 GetMainThreadPriority() const;
     u8 GetMainThreadCore() const;
     u32 GetMainThreadStackSize() const;
+    u32 GetExtraResourceSize() const;
     u64 GetTitleID() const;
     u64 GetFilesystemPermissions() const;
 
@@ -68,7 +69,8 @@ private:
         u8 reserved_3;
         u8 main_thread_priority;
         u8 main_thread_cpu;
-        std::array<u8, 8> reserved_4;
+        std::array<u8, 4> reserved_4;
+        u32_le extra_resource_size;
         u32_le process_category;
         u32_le main_stack_size;
         std::array<u8, 0x10> application_name;

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -68,6 +68,7 @@ void Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
     program_id = metadata.GetTitleID();
     ideal_processor = metadata.GetMainThreadCore();
     is_64bit_process = metadata.Is64BitProgram();
+    extra_resource_size = metadata.GetExtraResourceSize();
     vm_manager.Reset(metadata.GetAddressSpaceType());
 }
 

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -189,8 +189,9 @@ public:
         return allowed_thread_priority_mask;
     }
 
-    u32 IsVirtualMemoryEnabled() const {
-        return is_virtual_address_memory_enabled;
+    /// Gets the size of the extra resource memory in bytes.
+    u64 GetExtraResourceSize() const {
+        return extra_resource_size;
     }
 
     /// Whether this process is an AArch64 or AArch32 process.
@@ -313,7 +314,9 @@ private:
     /// this value from the process header.
     u32 allowed_processor_mask = THREADPROCESSORID_DEFAULT_MASK;
     u32 allowed_thread_priority_mask = 0xFFFFFFFF;
-    u32 is_virtual_address_memory_enabled = 0;
+
+    /// Size of the extra resource memory in bytes.
+    u64 extra_resource_size = 0;
 
     /// The Thread Local Storage area is allocated as processes create threads,
     /// each TLS area is 0x200 bytes, so one page (0x1000) is split up in 8 parts, and each part

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -672,8 +672,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         NewMapRegionBaseAddr = 14,
         NewMapRegionSize = 15,
         // 3.0.0+
-        IsVirtualAddressMemoryEnabled = 16,
-        PersonalMmHeapUsage = 17,
+        ExtraResourceSize = 16,
+        ExtraResourceUsage = 17,
         TitleId = 18,
         // 4.0.0+
         PrivilegedProcessId = 19,
@@ -697,8 +697,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     case GetInfoType::NewMapRegionSize:
     case GetInfoType::TotalMemoryUsage:
     case GetInfoType::TotalHeapUsage:
-    case GetInfoType::IsVirtualAddressMemoryEnabled:
-    case GetInfoType::PersonalMmHeapUsage:
+    case GetInfoType::ExtraResourceSize:
+    case GetInfoType::ExtraResourceUsage:
     case GetInfoType::TitleId:
     case GetInfoType::UserExceptionContextAddr: {
         if (info_sub_id != 0) {
@@ -760,8 +760,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
             *result = process->VMManager().GetTotalHeapUsage();
             return RESULT_SUCCESS;
 
-        case GetInfoType::IsVirtualAddressMemoryEnabled:
-            *result = process->IsVirtualMemoryEnabled();
+        case GetInfoType::ExtraResourceSize:
+            *result = process->GetExtraResourceSize();
             return RESULT_SUCCESS;
 
         case GetInfoType::TitleId:


### PR DESCRIPTION
An NPDM stores an amount of extra memory that can be used by a process
which is then able to be utilized with svcMapPhysicalMemory and
svcUnmapPhysical memory.

This is currently not used, but will be made use of in the following
changes.