### PR TITLE
patch_manager: Prevent use of a dangling pointer within PatchRomFS

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -286,13 +286,12 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
 VirtualFile PatchManager::PatchRomFS(VirtualFile romfs, u64 ivfc_offset, ContentRecordType type,
                                      VirtualFile update_raw) const {
     const auto log_string = fmt::format("Patching RomFS for title_id={:016X}, type={:02X}",
-                                        title_id, static_cast<u8>(type))
-                                .c_str();
+                                        title_id, static_cast<u8>(type));
 
     if (type == ContentRecordType::Program || type == ContentRecordType::Data)
-        LOG_INFO(Loader, log_string);
+        LOG_INFO(Loader, "{}", log_string);
     else
-        LOG_DEBUG(Loader, log_string);
+        LOG_DEBUG(Loader, "{}", log_string);
 
     if (romfs == nullptr)
         return romfs;


### PR DESCRIPTION
fmt::format() returns a std::string instance by value, so calling
.c_str() on it here is equivalent to doing:

auto* ptr = std::string{}.c_str();

The data being pointed to isn't guaranteed to actually be valid anymore
after that expression ends. Instead, we can just take the string as is,
and provide the necessary formatting parameters.