### PR TITLE
 Merge pull request yuzu-emu#1877 from heapo/audio_interp 

### DIFF
--- a/src/audio_core/algorithm/interpolate.cpp
+++ b/src/audio_core/algorithm/interpolate.cpp
@@ -54,8 +54,9 @@ std::vector<s16> Interpolate(InterpolationState& state, std::vector<s16> input, 
             double l = 0.0;
             double r = 0.0;
             for (std::size_t j = 0; j < h.size(); j++) {
-                l += Lanczos(taps, pos + j - taps + 1) * h[j][0];
-                r += Lanczos(taps, pos + j - taps + 1) * h[j][1];
+                const double lanczos_calc = Lanczos(taps, pos + j - taps + 1);
+                l += lanczos_calc * h[j][0];
+                r += lanczos_calc * h[j][1];
             }
             output.emplace_back(static_cast<s16>(std::clamp(l, -32768.0, 32767.0)));
             output.emplace_back(static_cast<s16>(std::clamp(r, -32768.0, 32767.0)));

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -285,8 +285,11 @@ void AudioRenderer::VoiceState::RefreshBuffer() {
         break;
     }
 
-    samples =
-        Interpolate(interp_state, std::move(samples), GetInfo().sample_rate, STREAM_SAMPLE_RATE);
+    // Only interpolate when necessary, expensive.
+    if (GetInfo().sample_rate != STREAM_SAMPLE_RATE) {
+        samples = Interpolate(interp_state, std::move(samples), GetInfo().sample_rate,
+                              STREAM_SAMPLE_RATE);
+    }
 
     is_refresh_pending = false;
 }

--- a/src/core/file_sys/directory.h
+++ b/src/core/file_sys/directory.h
@@ -29,8 +29,8 @@ struct Entry {
         filename[copy_size] = '\0';
     }
 
-    char filename[0x300];
-    INSERT_PADDING_BYTES(4);
+    char filename[0x301];
+    INSERT_PADDING_BYTES(3);
     EntryType type;
     INSERT_PADDING_BYTES(3);
     u64 file_size;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -928,7 +928,7 @@ private:
         case Attribute::Index::FrontFacing:
             // TODO(Subv): Find out what the values are for the other elements.
             ASSERT(stage == Maxwell3D::Regs::ShaderStage::Fragment);
-            return "vec4(0, 0, 0, uintBitsToFloat(gl_FrontFacing ? 1 : 0))";
+            return "vec4(0, 0, 0, intBitsToFloat(gl_FrontFacing ? -1 : 0))";
         default:
             const u32 index{static_cast<u32>(attribute) -
                             static_cast<u32>(Attribute::Index::Attribute_0)};


### PR DESCRIPTION
Perf: Avoid (expensive) audio interpolation when sample rates already match