### PR TITLE
Limit setting hold types to either vertical and horizontal

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -512,11 +512,21 @@ std::size_t Controller_NPad::GetSupportedNPadIdTypesSize() const {
 
 void Controller_NPad::SetHoldType(NpadHoldType joy_hold_type) {
     styleset_changed_event.writable->Signal();
-    hold_type = joy_hold_type;
+    if (joy_hold_type < NpadHoldType::HoldType_Max) {
+        hold_type = joy_hold_type;
+    } else {
+        LOG_WARNING(Service_HID, "got bad hold type={}", static_cast<u64>(joy_hold_type));
+    }
 }
 
 Controller_NPad::NpadHoldType Controller_NPad::GetHoldType() const {
-    return hold_type;
+    if (hold_type < NpadHoldType::HoldType_Max) {
+        return hold_type;
+    } else {
+        LOG_WARNING(Service_HID, "has bad stored hold_type={}, defaulting to vertical",
+                    static_cast<u64>(hold_type));
+        return NpadHoldType::Vertical;
+    }
 }
 
 void Controller_NPad::SetNpadMode(u32 npad_id, NPadAssignments assignment_mode) {

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -61,6 +61,7 @@ public:
     enum class NpadHoldType : u64 {
         Vertical = 0,
         Horizontal = 1,
+        HoldType_Max = 2,
     };
 
     enum class NPadAssignments : u32_le {


### PR DESCRIPTION
Apparently some games throw bad values for this, does not look like any error codes are in place from what I can see, will need to investigate further to see why games try this.