### PR TITLE
kernel/process: Remove most allocation functions from Process' interface

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -198,22 +198,6 @@ void Process::LoadModule(CodeSet module_, VAddr base_addr) {
     Core::System::GetInstance().ArmInterface(3).ClearInstructionCache();
 }
 
-ResultVal<VAddr> Process::HeapAllocate(VAddr target, u64 size, VMAPermission perms) {
-    return vm_manager.HeapAllocate(target, size, perms);
-}
-
-ResultCode Process::HeapFree(VAddr target, u32 size) {
-    return vm_manager.HeapFree(target, size);
-}
-
-ResultCode Process::MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size, MemoryState state) {
-    return vm_manager.MirrorMemory(dst_addr, src_addr, size, state);
-}
-
-ResultCode Process::UnmapMemory(VAddr dst_addr, VAddr /*src_addr*/, u64 size) {
-    return vm_manager.UnmapRange(dst_addr, size);
-}
-
 Kernel::Process::Process(KernelCore& kernel) : WaitObject{kernel} {}
 Kernel::Process::~Process() {}
 

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -242,20 +242,13 @@ public:
     void LoadModule(CodeSet module_, VAddr base_addr);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    // Memory Management
+    // Thread-local storage management
 
     // Marks the next available region as used and returns the address of the slot.
     VAddr MarkNextAvailableTLSSlotAsUsed(Thread& thread);
 
     // Frees a used TLS slot identified by the given address
     void FreeTLSSlot(VAddr tls_address);
-
-    ResultVal<VAddr> HeapAllocate(VAddr target, u64 size, VMAPermission perms);
-    ResultCode HeapFree(VAddr target, u32 size);
-
-    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size, MemoryState state);
-
-    ResultCode UnmapMemory(VAddr dst_addr, VAddr src_addr, u64 size);
 
 private:
     explicit Process(KernelCore& kernel);

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -318,14 +318,18 @@ public:
             return;
         }
 
-        ASSERT(process->MirrorMemory(*map_address, nro_addr, nro_size,
-                                     Kernel::MemoryState::ModuleCodeStatic) == RESULT_SUCCESS);
-        ASSERT(process->UnmapMemory(nro_addr, 0, nro_size) == RESULT_SUCCESS);
+        ASSERT(vm_manager
+                   .MirrorMemory(*map_address, nro_addr, nro_size,
+                                 Kernel::MemoryState::ModuleCodeStatic)
+                   .IsSuccess());
+        ASSERT(vm_manager.UnmapRange(nro_addr, nro_size).IsSuccess());
 
         if (bss_size > 0) {
-            ASSERT(process->MirrorMemory(*map_address + nro_size, bss_addr, bss_size,
-                                         Kernel::MemoryState::ModuleCodeStatic) == RESULT_SUCCESS);
-            ASSERT(process->UnmapMemory(bss_addr, 0, bss_size) == RESULT_SUCCESS);
+            ASSERT(vm_manager
+                       .MirrorMemory(*map_address + nro_size, bss_addr, bss_size,
+                                     Kernel::MemoryState::ModuleCodeStatic)
+                       .IsSuccess());
+            ASSERT(vm_manager.UnmapRange(bss_addr, bss_size).IsSuccess());
         }
 
         vm_manager.ReprotectRange(*map_address, header.text_size,
@@ -380,13 +384,14 @@ public:
             return;
         }
 
-        auto* process = Core::CurrentProcess();
-        auto& vm_manager = process->VMManager();
+        auto& vm_manager = Core::CurrentProcess()->VMManager();
         const auto& nro_size = iter->second.size;
 
-        ASSERT(process->MirrorMemory(heap_addr, mapped_addr, nro_size,
-                                     Kernel::MemoryState::ModuleCodeStatic) == RESULT_SUCCESS);
-        ASSERT(process->UnmapMemory(mapped_addr, 0, nro_size) == RESULT_SUCCESS);
+        ASSERT(vm_manager
+                   .MirrorMemory(heap_addr, mapped_addr, nro_size,
+                                 Kernel::MemoryState::ModuleCodeStatic)
+                   .IsSuccess());
+        ASSERT(vm_manager.UnmapRange(mapped_addr, nro_size).IsSuccess());
 
         Core::System::GetInstance().InvalidateCpuInstructionCaches();
 


### PR DESCRIPTION
In all cases that these functions are needed, the VMManager can just be
retrieved and used instead of providing the same functions in Process'
interface.

This also makes it a little nicer dependency-wise, since it gets rid of
cases where the VMManager interface was being used, and then switched
over to using the interface for a Process instance. Instead, it makes
all accesses uniform and uses the VMManager instance for all necessary
tasks.

All the basic memory mapping functions did was forward to the Process'
VMManager instance anyways.