### PR TITLE
audio_core: Convert LOG_CRITICAL + UNREACHABLE over to UNIMPLEMENTED/…

### DIFF
--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -22,8 +22,7 @@ static Stream::Format ChannelsToStreamFormat(u32 num_channels) {
         return Stream::Format::Multi51Channel16;
     }
 
-    LOG_CRITICAL(Audio, "Unimplemented num_channels={}", num_channels);
-    UNREACHABLE();
+    UNIMPLEMENTED_MSG("Unimplemented num_channels={}", num_channels);
     return {};
 }
 

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -260,8 +260,7 @@ void AudioRenderer::VoiceState::RefreshBuffer() {
         break;
     }
     default:
-        LOG_CRITICAL(Audio, "Unimplemented sample_format={}", info.sample_format);
-        UNREACHABLE();
+        UNIMPLEMENTED_MSG("Unimplemented sample_format={}", info.sample_format);
         break;
     }
 
@@ -280,8 +279,7 @@ void AudioRenderer::VoiceState::RefreshBuffer() {
         break;
     }
     default:
-        LOG_CRITICAL(Audio, "Unimplemented channel_count={}", info.channel_count);
-        UNREACHABLE();
+        UNIMPLEMENTED_MSG("Unimplemented channel_count={}", info.channel_count);
         break;
     }
 

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -28,8 +28,7 @@ u32 Stream::GetNumChannels() const {
     case Format::Multi51Channel16:
         return 6;
     }
-    LOG_CRITICAL(Audio, "Unimplemented format={}", static_cast<u32>(format));
-    UNREACHABLE();
+    UNIMPLEMENTED_MSG("Unimplemented format={}", static_cast<u32>(format));
     return {};
 }
 
@@ -49,7 +48,7 @@ void Stream::Play() {
 
 void Stream::Stop() {
     state = State::Stopped;
-    ASSERT_MSG(false, "Unimplemented");
+    UNIMPLEMENTED();
 }
 
 Stream::State Stream::GetState() const {
@@ -120,7 +119,7 @@ bool Stream::QueueBuffer(BufferPtr&& buffer) {
 }
 
 bool Stream::ContainsBuffer(Buffer::Tag tag) const {
-    ASSERT_MSG(false, "Unimplemented");
+    UNIMPLEMENTED();
     return {};
 }
 


### PR DESCRIPTION
…UNIMPLEMENTED_MSG

These two macros being used in tandem were used prior to the
introduction of UNIMPLEMENTED and UNIMPLEMENTED_MSG. This provides
equivalent behavior, just with less typing/reading involved.