### PR TITLE
qt: Add setting to prompt for user on game boot

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -470,6 +470,8 @@ void Config::ReadValues() {
         qt_config->value("enable_discord_presence", true).toBool();
     UISettings::values.screenshot_resolution_factor =
         static_cast<u16>(qt_config->value("screenshot_resolution_factor", 0).toUInt());
+    UISettings::values.select_user_on_boot =
+        qt_config->value("select_user_on_boot", false).toBool();
 
     qt_config->beginGroup("UIGameList");
     UISettings::values.show_unknown = qt_config->value("show_unknown", true).toBool();
@@ -693,6 +695,7 @@ void Config::SaveValues() {
     qt_config->setValue("enable_discord_presence", UISettings::values.enable_discord_presence);
     qt_config->setValue("screenshot_resolution_factor",
                         UISettings::values.screenshot_resolution_factor);
+    qt_config->setValue("select_user_on_boot", UISettings::values.select_user_on_boot);
 
     qt_config->beginGroup("UIGameList");
     qt_config->setValue("show_unknown", UISettings::values.show_unknown);

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -30,6 +30,7 @@ ConfigureGeneral::~ConfigureGeneral() = default;
 void ConfigureGeneral::setConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
+    ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot);
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
     ui->enable_nfc->setChecked(Settings::values.enable_nfc);
@@ -42,6 +43,7 @@ void ConfigureGeneral::PopulateHotkeyList(const HotkeyRegistry& registry) {
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toggle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
+    UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
 

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -38,6 +38,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="toggle_user_on_boot">
+            <property name="text">
+             <string>Prompt for user on game boot</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
        </layout>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -687,9 +687,25 @@ bool GMainWindow::LoadROM(const QString& filename) {
     return true;
 }
 
+void GMainWindow::SelectAndSetCurrentUser() {
+    QtProfileSelectionDialog dialog(this);
+    dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
+                          Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
+    dialog.setWindowModality(Qt::WindowModal);
+    dialog.exec();
+
+    if (dialog.GetStatus()) {
+        Settings::values.current_user = static_cast<s32>(dialog.GetIndex());
+    }
+}
+
 void GMainWindow::BootGame(const QString& filename) {
     LOG_INFO(Frontend, "yuzu starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
+
+    if (UISettings::values.select_user_on_boot) {
+        SelectAndSetCurrentUser();
+    }
 
     if (!LoadROM(filename))
         return;

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -128,6 +128,8 @@ private:
     void ShowTelemetryCallout();
     void SetDiscordEnabled(bool state);
 
+    void SelectAndSetCurrentUser();
+
     /**
      * Stores the filename in the recently loaded files list.
      * The new filename is stored at the beginning of the recently loaded files list.

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -40,6 +40,8 @@ struct Values {
     bool confirm_before_closing;
     bool first_start;
 
+    bool select_user_on_boot;
+
     // Discord RPC
     bool enable_discord_presence;
 


### PR DESCRIPTION
Using the QtProfileSelectorDialog, this implementation is trivial. This mimics the real switch behavior of asking which user on every game boot, but it is default disabled as that might get inconvenient.