### PR TITLE
Fixed botw deadlock(and possibly 30 fps games rendering too fast? needs further testing on better hardware) 

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -166,7 +166,7 @@ Layer::~Layer() = default;
 
 Display::Display(u64 id, std::string name) : id(id), name(std::move(name)) {
     auto& kernel = Core::System::GetInstance().Kernel();
-    vsync_event = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Pulse,
+    vsync_event = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Sticky,
                                                          fmt::format("Display VSync Event {}", id));
 }
 


### PR DESCRIPTION
Upon investigating the issue with #1878, I found that games are the ones who handle the vsync event resetting and not us.