### PR TITLE
gl_rasterizer_cache: Use dirty flags for framebuffers 

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -135,6 +135,15 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
 
     if (regs.reg_array[method_call.method] != method_call.argument) {
         regs.reg_array[method_call.method] = method_call.argument;
+        // Color buffers
+        constexpr u32 first_rt_reg = MAXWELL3D_REG_INDEX(rt);
+        constexpr u32 registers_per_rt = sizeof(regs.rt[0]) / sizeof(u32);
+        if (method_call.method >= first_rt_reg &&
+            method_call.method < first_rt_reg + registers_per_rt * Regs::NumRenderTargets) {
+            const std::size_t rt_index = (method_call.method - first_rt_reg) / registers_per_rt;
+            dirty_flags.color_buffer |= 1u << static_cast<u32>(rt_index);
+        }
+
         // Shader
         constexpr u32 shader_registers_count =
             sizeof(regs.shader_config[0]) * Regs::MaxShaderProgram / sizeof(u32);

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -144,6 +144,16 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
             dirty_flags.color_buffer |= 1u << static_cast<u32>(rt_index);
         }
 
+        // Zeta buffer
+        constexpr u32 registers_in_zeta = sizeof(regs.zeta) / sizeof(u32);
+        if (method_call.method == MAXWELL3D_REG_INDEX(zeta_enable) ||
+            method_call.method == MAXWELL3D_REG_INDEX(zeta_width) ||
+            method_call.method == MAXWELL3D_REG_INDEX(zeta_height) ||
+            (method_call.method >= MAXWELL3D_REG_INDEX(zeta) &&
+             method_call.method < MAXWELL3D_REG_INDEX(zeta) + registers_in_zeta)) {
+            dirty_flags.zeta_buffer = true;
+        }
+
         // Shader
         constexpr u32 shader_registers_count =
             sizeof(regs.shader_config[0]) * Regs::MaxShaderProgram / sizeof(u32);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1089,12 +1089,15 @@ public:
     MemoryManager& memory_manager;
 
     struct DirtyFlags {
+        u8 color_buffer = 0xFF;
+
         bool shaders = true;
 
         bool vertex_attrib_format = true;
         u32 vertex_array = 0xFFFFFFFF;
 
         void OnMemoryWrite() {
+            color_buffer = 0xFF;
             shaders = true;
             vertex_array = 0xFFFFFFFF;
         }

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1090,6 +1090,7 @@ public:
 
     struct DirtyFlags {
         u8 color_buffer = 0xFF;
+        bool zeta_buffer = true;
 
         bool shaders = true;
 
@@ -1098,6 +1099,7 @@ public:
 
         void OnMemoryWrite() {
             color_buffer = 0xFF;
+            zeta_buffer = true;
             shaders = true;
             vertex_array = 0xFFFFFFFF;
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -488,7 +488,19 @@ void RasterizerOpenGL::ConfigureFramebuffers(OpenGLState& current_state, bool us
                                              bool using_depth_fb, bool preserve_contents,
                                              std::optional<std::size_t> single_color_target) {
     MICROPROFILE_SCOPE(OpenGL_Framebuffer);
-    const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
+    const auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
+    const auto& regs = gpu.regs;
+
+    const FramebufferConfigState fb_config_state{using_color_fb, using_depth_fb, preserve_contents,
+                                                 single_color_target};
+    if (fb_config_state == current_framebuffer_config_state && gpu.dirty_flags.color_buffer == 0 &&
+        !gpu.dirty_flags.zeta_buffer) {
+        // Only skip if the previous ConfigureFramebuffers call was from the same kind (multiple or
+        // single color targets). This is done because the guest registers may not change but the
+        // host framebuffer may contain different attachments
+        return;
+    }
+    current_framebuffer_config_state = fb_config_state;
 
     Surface depth_surface;
     if (using_depth_fb) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -94,6 +94,23 @@ private:
         float max_anisotropic = 1.0f;
     };
 
+    struct FramebufferConfigState {
+        bool using_color_fb{};
+        bool using_depth_fb{};
+        bool preserve_contents{};
+        std::optional<std::size_t> single_color_target;
+
+        bool operator==(const FramebufferConfigState& rhs) const {
+            return std::tie(using_color_fb, using_depth_fb, preserve_contents,
+                            single_color_target) == std::tie(rhs.using_color_fb, rhs.using_depth_fb,
+                                                             rhs.preserve_contents,
+                                                             rhs.single_color_target);
+        }
+        bool operator!=(const FramebufferConfigState& rhs) const {
+            return !operator==(rhs);
+        }
+    };
+
     /**
      * Configures the color and depth framebuffer states.
      * @param use_color_fb If true, configure color framebuffers.
@@ -197,6 +214,7 @@ private:
         vertex_array_cache;
 
     std::map<FramebufferCacheKey, OGLFramebuffer> framebuffer_cache;
+    FramebufferConfigState current_framebuffer_config_state;
 
     std::array<SamplerInfo, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> texture_samplers;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -396,6 +396,8 @@ private:
     /// Use a Pixel Buffer Object to download the previous texture and then upload it to the new one
     /// using the new format.
     OGLBuffer copy_pbo;
+
+    std::array<Surface, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> last_color_buffers;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -398,6 +398,7 @@ private:
     OGLBuffer copy_pbo;
 
     std::array<Surface, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> last_color_buffers;
+    Surface last_depth_buffer;
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
This skips the search of color buffers and the depth buffer if the configuration has not changed (the first two commits). It also skips the framebuffer configuration step if the requested configuration has not changed from the previous call and color and depth buffers are not dirty.