### PR TITLE
gl_global_cache: Add dummy global cache manager 

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(video_core STATIC
     renderer_base.h
     renderer_opengl/gl_buffer_cache.cpp
     renderer_opengl/gl_buffer_cache.h
+    renderer_opengl/gl_global_cache.cpp
+    renderer_opengl/gl_global_cache.h
     renderer_opengl/gl_primitive_assembler.cpp
     renderer_opengl/gl_primitive_assembler.h
     renderer_opengl/gl_rasterizer.cpp

--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <glad/glad.h>
+
+#include "video_core/renderer_opengl/gl_global_cache.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
+#include "video_core/renderer_opengl/utils.h"
+
+namespace OpenGL {
+
+CachedGlobalRegion::CachedGlobalRegion(VAddr addr, u32 size) : addr{addr}, size{size} {
+    buffer.Create();
+    // Bind and unbind the buffer so it gets allocated by the driver
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, buffer.handle);
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+    LabelGLObject(GL_BUFFER, buffer.handle, addr, "GlobalMemory");
+}
+
+GlobalRegionCacheOpenGL::GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer)
+    : RasterizerCache{rasterizer} {}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -1,0 +1,60 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <glad/glad.h>
+
+#include "common/common_types.h"
+#include "video_core/rasterizer_cache.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+
+namespace OpenGL {
+
+namespace GLShader {
+class GlobalMemoryEntry;
+} // namespace GLShader
+
+class RasterizerOpenGL;
+class CachedGlobalRegion;
+using GlobalRegion = std::shared_ptr<CachedGlobalRegion>;
+
+class CachedGlobalRegion final : public RasterizerCacheObject {
+public:
+    explicit CachedGlobalRegion(VAddr addr, u32 size);
+
+    /// Gets the address of the shader in guest memory, required for cache management
+    VAddr GetAddr() const {
+        return addr;
+    }
+
+    /// Gets the size of the shader in guest memory, required for cache management
+    std::size_t GetSizeInBytes() const {
+        return size;
+    }
+
+    /// Gets the GL program handle for the buffer
+    GLuint GetBufferHandle() const {
+        return buffer.handle;
+    }
+
+    // TODO(Rodrigo): When global memory is written (STG), implement flushing
+    void Flush() override {
+        UNIMPLEMENTED();
+    }
+
+private:
+    VAddr addr{};
+    u32 size{};
+
+    OGLBuffer buffer;
+};
+
+class GlobalRegionCacheOpenGL final : public RasterizerCache<GlobalRegion> {
+public:
+    explicit GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer);
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -101,7 +101,7 @@ struct FramebufferCacheKey {
 
 RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo& info)
     : res_cache{*this}, shader_cache{*this}, emu_window{window}, screen_info{info},
-      buffer_cache(*this, STREAM_BUFFER_SIZE) {
+      buffer_cache(*this, STREAM_BUFFER_SIZE), global_cache{*this} {
     // Create sampler objects
     for (std::size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();
@@ -763,6 +763,7 @@ void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.InvalidateRegion(addr, size);
     shader_cache.InvalidateRegion(addr, size);
+    global_cache.InvalidateRegion(addr, size);
     buffer_cache.InvalidateRegion(addr, size);
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -23,6 +23,7 @@
 #include "video_core/rasterizer_cache.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_global_cache.h"
 #include "video_core/renderer_opengl/gl_primitive_assembler.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
@@ -66,6 +67,10 @@ public:
     static_assert(MaxConstbufferSize % sizeof(GLvec4) == 0,
                   "The maximum size of a constbuffer must be a multiple of the size of GLvec4");
 
+    static constexpr std::size_t MaxGlobalMemorySize = 0x10000;
+    static_assert(MaxGlobalMemorySize % sizeof(float) == 0,
+                  "The maximum size of a global memory must be a multiple of the size of float");
+
 private:
     class SamplerInfo {
     public:
@@ -105,7 +110,7 @@ private:
                                bool using_depth_fb = true, bool preserve_contents = true,
                                std::optional<std::size_t> single_color_target = {});
 
-    /*
+    /**
      * Configures the current constbuffers to use for the draw command.
      * @param stage The shader stage to configure buffers for.
      * @param shader The shader object that contains the specified stage.
@@ -115,7 +120,7 @@ private:
     u32 SetupConstBuffers(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, Shader& shader,
                           GLenum primitive_mode, u32 current_bindpoint);
 
-    /*
+    /**
      * Configures the current textures to use for the draw command.
      * @param stage The shader stage to configure textures for.
      * @param shader The shader object that contains the specified stage.
@@ -185,6 +190,7 @@ private:
 
     RasterizerCacheOpenGL res_cache;
     ShaderCacheOpenGL shader_cache;
+    GlobalRegionCacheOpenGL global_cache;
 
     Core::Frontend::EmuWindow& emu_window;
 


### PR DESCRIPTION
Declares the interface for global memory management so other PRs can be canary compatible.