### PR TITLE
loader: Add getters for application banner and logo

### DIFF
--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -359,6 +359,8 @@ bool NCA::ReadPFS0Section(const NCASectionHeader& section, const NCASectionTable
             dirs.push_back(std::move(npfs));
             if (IsDirectoryExeFS(dirs.back()))
                 exefs = dirs.back();
+            else if (IsDirectoryLogoPartition(dirs.back()))
+                logo = dirs.back();
         } else {
             if (has_rights_id)
                 status = Loader::ResultStatus::ErrorIncorrectTitlekeyOrTitlekek;
@@ -544,6 +546,10 @@ VirtualFile NCA::GetBaseFile() const {
 
 u64 NCA::GetBaseIVFCOffset() const {
     return ivfc_offset;
+}
+
+VirtualDir NCA::GetLogoPartition() const {
+    return logo;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -74,6 +74,13 @@ inline bool IsDirectoryExeFS(const std::shared_ptr<VfsDirectory>& pfs) {
     return pfs->GetFile("main") != nullptr && pfs->GetFile("main.npdm") != nullptr;
 }
 
+inline bool IsDirectoryLogoPartition(const VirtualDir& pfs) {
+    // NintendoLogo is the static image in the top left corner while StartupMovie is the animation
+    // in the bottom right corner.
+    return pfs->GetFile("NintendoLogo.png") != nullptr &&
+           pfs->GetFile("StartupMovie.gif") != nullptr;
+}
+
 // An implementation of VfsDirectory that represents a Nintendo Content Archive (NCA) conatiner.
 // After construction, use GetStatus to determine if the file is valid and ready to be used.
 class NCA : public ReadOnlyVfsDirectory {
@@ -102,6 +109,8 @@ public:
     // Returns the base ivfc offset used in BKTR patching.
     u64 GetBaseIVFCOffset() const;
 
+    VirtualDir GetLogoPartition() const;
+
 private:
     bool CheckSupportedNCA(const NCAHeader& header);
     bool HandlePotentialHeaderDecryption();
@@ -122,6 +131,7 @@ private:
 
     VirtualFile romfs = nullptr;
     VirtualDir exefs = nullptr;
+    VirtualDir logo = nullptr;
     VirtualFile file;
     VirtualFile bktr_base_romfs;
     u64 ivfc_offset = 0;

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -178,6 +178,8 @@ public:
 
     /**
      * Get the banner (typically banner section) of the application
+     * In the context of NX, this is the animation that displays in the bottom right of the screen
+     * when a game boots. Stored in GIF format.
      * @param buffer Reference to buffer to store data
      * @return ResultStatus result of function
      */
@@ -187,6 +189,8 @@ public:
 
     /**
      * Get the logo (typically logo section) of the application
+     * In the context of NX, this is the static image that displays in the top left of the screen
+     * when a game boots. Stored in JPEG format.
      * @param buffer Reference to buffer to store data
      * @return ResultStatus result of function
      */

--- a/src/core/loader/nax.cpp
+++ b/src/core/loader/nax.cpp
@@ -79,4 +79,13 @@ u64 AppLoader_NAX::ReadRomFSIVFCOffset() const {
 ResultStatus AppLoader_NAX::ReadProgramId(u64& out_program_id) {
     return nca_loader->ReadProgramId(out_program_id);
 }
+
+ResultStatus AppLoader_NAX::ReadBanner(std::vector<u8>& buffer) {
+    return nca_loader->ReadBanner(buffer);
+}
+
+ResultStatus AppLoader_NAX::ReadLogo(std::vector<u8>& buffer) {
+    return nca_loader->ReadLogo(buffer);
+}
+
 } // namespace Loader

--- a/src/core/loader/nax.h
+++ b/src/core/loader/nax.h
@@ -39,6 +39,9 @@ public:
     u64 ReadRomFSIVFCOffset() const override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
+    ResultStatus ReadBanner(std::vector<u8>& buffer) override;
+    ResultStatus ReadLogo(std::vector<u8>& buffer) override;
+
 private:
     std::unique_ptr<FileSys::NAX> nax;
     std::unique_ptr<AppLoader_NCA> nca_loader;

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -84,4 +84,23 @@ ResultStatus AppLoader_NCA::ReadProgramId(u64& out_program_id) {
     return ResultStatus::Success;
 }
 
+ResultStatus AppLoader_NCA::ReadBanner(std::vector<u8>& buffer) {
+    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
+        return ResultStatus::ErrorNotInitialized;
+    const auto logo = nca->GetLogoPartition();
+    if (logo == nullptr)
+        return ResultStatus::ErrorNoIcon;
+    buffer = logo->GetFile("StartupMovie.gif")->ReadAllBytes();
+    return ResultStatus::Success;
+}
+
+ResultStatus AppLoader_NCA::ReadLogo(std::vector<u8>& buffer) {
+    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
+        return ResultStatus::ErrorNotInitialized;
+    const auto logo = nca->GetLogoPartition();
+    if (logo == nullptr)
+        return ResultStatus::ErrorNoIcon;
+    buffer = logo->GetFile("NintendoLogo.png")->ReadAllBytes();
+    return ResultStatus::Success;
+}
 } // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -39,6 +39,9 @@ public:
     u64 ReadRomFSIVFCOffset() const override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
+    ResultStatus ReadBanner(std::vector<u8>& buffer) override;
+    ResultStatus ReadLogo(std::vector<u8>& buffer) override;
+
 private:
     std::unique_ptr<FileSys::NCA> nca;
     std::unique_ptr<AppLoader_DeconstructedRomDirectory> directory_loader;

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -166,4 +166,13 @@ ResultStatus AppLoader_NSP::ReadManualRomFS(FileSys::VirtualFile& file) {
     file = nca->GetRomFS();
     return file == nullptr ? ResultStatus::ErrorNoRomFS : ResultStatus::Success;
 }
+
+ResultStatus AppLoader_NSP::ReadBanner(std::vector<u8>& buffer) {
+    return secondary_loader->ReadBanner(buffer);
+}
+
+ResultStatus AppLoader_NSP::ReadLogo(std::vector<u8>& buffer) {
+    return secondary_loader->ReadLogo(buffer);
+}
+
 } // namespace Loader

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -46,6 +46,9 @@ public:
     ResultStatus ReadControlData(FileSys::NACP& nacp) override;
     ResultStatus ReadManualRomFS(FileSys::VirtualFile& file) override;
 
+    ResultStatus ReadBanner(std::vector<u8>& buffer) override;
+    ResultStatus ReadLogo(std::vector<u8>& buffer) override;
+
 private:
     std::unique_ptr<FileSys::NSP> nsp;
     std::unique_ptr<AppLoader> secondary_loader;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -137,4 +137,12 @@ ResultStatus AppLoader_XCI::ReadManualRomFS(FileSys::VirtualFile& file) {
     return file == nullptr ? ResultStatus::ErrorNoRomFS : ResultStatus::Success;
 }
 
+ResultStatus AppLoader_XCI::ReadBanner(std::vector<u8>& buffer) {
+    return nca_loader->ReadBanner(buffer);
+}
+
+ResultStatus AppLoader_XCI::ReadLogo(std::vector<u8>& buffer) {
+    return nca_loader->ReadLogo(buffer);
+}
+
 } // namespace Loader

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -46,6 +46,9 @@ public:
     ResultStatus ReadControlData(FileSys::NACP& control) override;
     ResultStatus ReadManualRomFS(FileSys::VirtualFile& file) override;
 
+    ResultStatus ReadBanner(std::vector<u8>& buffer) override;
+    ResultStatus ReadLogo(std::vector<u8>& buffer) override;
+
 private:
     std::unique_ptr<FileSys::XCI> xci;
     std::unique_ptr<AppLoader_NCA> nca_loader;


### PR DESCRIPTION
These are the two assets used in the pre-game loading screen on hardware. They are packaged at the NCA level, so all games except extracted directories and homebrew should have it. I'd show the assets here, but I think there's some legal reason I cannot.