### PR TITLE
Frontend: Migrate to QOpenGLWindow and support shared contexts

### DIFF
--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -13,6 +13,23 @@
 namespace Core::Frontend {
 
 /**
+ * Represents a graphics context that can be used for background computation or drawing. If the
+ * graphics backend doesn't require the context, then the implementation of these methods can be
+ * stubs
+ */
+class GraphicsContext {
+public:
+    /// Makes the graphics context current for the caller thread
+    virtual void MakeCurrent() = 0;
+
+    /// Releases (dunno if this is the "right" word) the context from the caller thread
+    virtual void DoneCurrent() = 0;
+
+    /// Swap buffers to display the next frame
+    virtual void SwapBuffers() = 0;
+};
+
+/**
  * Abstraction class used to provide an interface between emulation code and the frontend
  * (e.g. SDL, QGLWidget, GLFW, etc...).
  *
@@ -30,7 +47,7 @@ namespace Core::Frontend {
  * - DO NOT TREAT THIS CLASS AS A GUI TOOLKIT ABSTRACTION LAYER. That's not what it is. Please
  *   re-read the upper points again and think about it if you don't see this.
  */
-class EmuWindow {
+class EmuWindow : public GraphicsContext {
 public:
     /// Data structure to store emuwindow configuration
     struct WindowConfig {
@@ -40,17 +57,21 @@ public:
         std::pair<unsigned, unsigned> min_client_area_size;
     };
 
-    /// Swap buffers to display the next frame
-    virtual void SwapBuffers() = 0;
-
     /// Polls window events
     virtual void PollEvents() = 0;
 
-    /// Makes the graphics context current for the caller thread
-    virtual void MakeCurrent() = 0;
-
-    /// Releases (dunno if this is the "right" word) the GLFW context from the caller thread
-    virtual void DoneCurrent() = 0;
+    /**
+     * Returns a GraphicsContext that the frontend provides that is shared with the emu window. This
+     * context can be used from other threads for background graphics computation. If the frontend
+     * is using a graphics backend that doesn't need anything specific to run on a different thread,
+     * then it can use a stubbed implemenation for GraphicsContext.
+     *
+     * If the return value is null, then the core should assume that the frontend cannot provide a
+     * Shared Context
+     */
+    virtual std::unique_ptr<GraphicsContext> CreateSharedContext() const {
+        return nullptr;
+    }
 
     /**
      * Signal that a touch pressed event has occurred (e.g. mouse click pressed)

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -393,6 +393,8 @@ void GRenderWindow::InitRenderTarget() {
     BackupGeometry();
     // show causes the window to actually be created and the gl context as well
     show();
+    // but we don't want the widget to be shown yet, so immediately hide it
+    hide();
 }
 
 void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -7,9 +7,9 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <QGLWidget>
 #include <QImage>
 #include <QThread>
+#include <QWidget>
 #include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
@@ -21,6 +21,8 @@ class QTouchEvent;
 class GGLWidgetInternal;
 class GMainWindow;
 class GRenderWindow;
+class QSurface;
+class QOpenGLContext;
 
 class EmuThread : public QThread {
     Q_OBJECT
@@ -115,6 +117,7 @@ public:
     void MakeCurrent() override;
     void DoneCurrent() override;
     void PollEvents() override;
+    std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 
     void BackupGeometry();
     void RestoreGeometry();
@@ -168,6 +171,11 @@ private:
     QByteArray geometry;
 
     EmuThread* emu_thread;
+    // Context that backs the GGLWidgetInternal (and will be used by core to render)
+    std::unique_ptr<QOpenGLContext> context;
+    // Context that will be shared between all newly created contexts. This should never be made
+    // current
+    std::unique_ptr<QOpenGLContext> shared_context;
 
     /// Temporary storage of the screenshot taken
     QImage screenshot_image;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2032,7 +2032,8 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("yuzu team");
     QCoreApplication::setApplicationName("yuzu");
 
-    QApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
+    // Enables the core to make the qt created contexts current on std::threads
+    QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
     QApplication app(argc, argv);
 
     // Qt changes the locale and causes issues in float conversion using std::to_string() when

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -27,6 +27,8 @@ public:
     /// Releases the GL context from the caller thread
     void DoneCurrent() override;
 
+    std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
+
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;
 


### PR DESCRIPTION
Since QT5, QGLWidget has been deprecated and superseded with QOpenGLWidget and other classes. I replace usages of QGLWidget with the comparable QOpenGLWindow, which gives us the bonus ability to easily create shared contexts.

To support shared contexts, frontends can now implement the GraphicsContext class and the core can attempt to get a shared context from the frontend by calling GetSharedContext. If the rendering backend doesn't need shared contexts, then it just doesn't request a shared context from the frontend. If the backend does request a shared context, it should be ready to handle the case where the frontend returns nullptr (ie: because its not supported on this platform or frontend)

In this PR, I added shared context support to the QT and SDL frontends, but I haven't had a chance to extensively test shared contexts yet. We've had several suggested features that could benefit from shared context support, so I wanted to put it out there that the code is ready, but I also understand if others think we should wait until we have code that actually uses shared contexts.

Looking for feedback about the changes I made to EmuWindow to add a new function to get a shared context. I couldn't think of a better way to enable the video core to get a shared context where needed while still letting the frontend actually create that context.