### PR TITLE
maxwell_3d: Set rt_separate_frag_data to 1 by default

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -37,6 +37,7 @@ void Maxwell3D::InitializeRegisterDefaults() {
         regs.viewports[viewport].depth_range_near = 0.0f;
         regs.viewports[viewport].depth_range_far = 1.0f;
     }
+
     // Doom and Bomberman seems to use the uninitialized registers and just enable blend
     // so initialize blend registers with sane values
     regs.blend.equation_rgb = Regs::Blend::Equation::Add;
@@ -66,6 +67,7 @@ void Maxwell3D::InitializeRegisterDefaults() {
     regs.stencil_back_func_func = Regs::ComparisonOp::Always;
     regs.stencil_back_func_mask = 0xFFFFFFFF;
     regs.stencil_back_mask = 0xFFFFFFFF;
+
     // TODO(Rodrigo): Most games do not set a point size. I think this is a case of a
     // register carrying a default value. Assume it's OpenGL's default (1).
     regs.point_size = 1.0f;
@@ -78,6 +80,9 @@ void Maxwell3D::InitializeRegisterDefaults() {
         regs.color_mask[color_mask].B.Assign(1);
         regs.color_mask[color_mask].A.Assign(1);
     }
+
+    // Commercial games seem to assume this value is enabled and nouveau sets this value manually.
+    regs.rt_separate_frag_data = 1;
 }
 
 void Maxwell3D::CallMacroMethod(u32 method, std::vector<u32> parameters) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -509,10 +509,7 @@ void RasterizerOpenGL::ConfigureFramebuffers(OpenGLState& current_state, bool us
         depth_surface = res_cache.GetDepthBufferSurface(preserve_contents);
     }
 
-    // TODO(bunnei): Figure out how the below register works. According to envytools, this should be
-    // used to enable multiple render targets. However, it is left unset on all games that I have
-    // tested.
-    UNIMPLEMENTED_IF(regs.rt_separate_frag_data != 0);
+    UNIMPLEMENTED_IF(regs.rt_separate_frag_data == 0);
 
     // Bind the framebuffer surfaces
     current_state.framebuffer_srgb.enabled = regs.framebuffer_srgb != 0;


### PR DESCRIPTION
Commercial games assume that this value is 1 but they never set it. On
the other hand nouveau manually sets this register. On
ConfigureFramebuffers we were asserting for what we are actually
implementing (according to envytools).