### PR TITLE
service/pm: Implement SetMaintenanceBoot 

### DIFF
--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -24,8 +24,10 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(static_cast<u32>(SystemBootMode::Normal)); // Normal boot mode
+        rb.PushEnum(boot_mode);
     }
+
+    SystemBootMode boot_mode = SystemBootMode::Normal;
 };
 
 class DebugMonitor final : public ServiceFramework<DebugMonitor> {

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -13,7 +13,7 @@ public:
     explicit BootMode() : ServiceFramework{"pm:bm"} {
         static const FunctionInfo functions[] = {
             {0, &BootMode::GetBootMode, "GetBootMode"},
-            {1, nullptr, "SetMaintenanceBoot"},
+            {1, &BootMode::SetMaintenanceBoot, "SetMaintenanceBoot"},
         };
         RegisterHandlers(functions);
     }
@@ -25,6 +25,15 @@ private:
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.PushEnum(boot_mode);
+    }
+
+    void SetMaintenanceBoot(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service_PM, "called");
+
+        boot_mode = SystemBootMode::Maintenance;
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
     }
 
     SystemBootMode boot_mode = SystemBootMode::Normal;

--- a/src/core/hle/service/pm/pm.h
+++ b/src/core/hle/service/pm/pm.h
@@ -9,7 +9,12 @@ class ServiceManager;
 }
 
 namespace Service::PM {
-enum class SystemBootMode : u32 { Normal = 0, Maintenance = 1 };
+
+enum class SystemBootMode {
+    Normal,
+    Maintenance,
+};
+
 /// Registers all PM services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 


### PR DESCRIPTION
This is an extremely simple interface function to implement. The service literally just sets the boot mode to maintenance mode like it says it does. No other other checking or anything else is performed, that's all it does.

This completes the pm:bm interface for the time being (until it's added to in subsequent system versions).