### PR TITLE
shader_ir: Unify constant buffer offset values

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1248,11 +1248,19 @@ union Instruction {
     union {
         BitField<20, 14, u64> offset;
         BitField<34, 5, u64> index;
+
+        u64 GetOffset() const {
+            return offset * 4;
+        }
     } cbuf34;
 
     union {
         BitField<20, 16, s64> offset;
         BitField<36, 5, u64> index;
+
+        s64 GetOffset() const {
+            return offset;
+        }
     } cbuf36;
 
     // Unsure about the size of this one.

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -957,7 +957,7 @@ void RasterizerOpenGL::SetupConstBuffers(Tegra::Engines::Maxwell3D::Regs::Shader
             }
         } else {
             // Buffer is accessed directly, upload just what we use
-            size = used_buffer.GetSize() * sizeof(float);
+            size = used_buffer.GetSize();
         }
 
         // Align the actual size so it ends up being a multiple of vec4 to meet the OpenGL std140

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -543,8 +543,9 @@ private:
             if (const auto immediate = std::get_if<ImmediateNode>(offset)) {
                 // Direct access
                 const u32 offset_imm = immediate->GetValue();
-                return fmt::format("{}[{}][{}]", GetConstBuffer(cbuf->GetIndex()), offset_imm / 4,
-                                   offset_imm % 4);
+                ASSERT_MSG(offset_imm % 4 == 0, "Unaligned cbuf direct access");
+                return fmt::format("{}[{}][{}]", GetConstBuffer(cbuf->GetIndex()),
+                                   offset_imm / (4 * 4), (offset_imm / 4) % 4);
 
             } else if (std::holds_alternative<OperationNode>(*offset)) {
                 // Indirect access

--- a/src/video_core/shader/decode/arithmetic.cpp
+++ b/src/video_core/shader/decode/arithmetic.cpp
@@ -25,7 +25,7 @@ u32 ShaderIR::DecodeArithmetic(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
 

--- a/src/video_core/shader/decode/arithmetic_half.cpp
+++ b/src/video_core/shader/decode/arithmetic_half.cpp
@@ -35,7 +35,7 @@ u32 ShaderIR::DecodeArithmeticHalf(BasicBlock& bb, const BasicBlock& code, u32 p
         switch (opcode->get().GetId()) {
         case OpCode::Id::HADD2_C:
         case OpCode::Id::HMUL2_C:
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         case OpCode::Id::HADD2_R:
         case OpCode::Id::HMUL2_R:
             return GetRegister(instr.gpr20);

--- a/src/video_core/shader/decode/arithmetic_integer.cpp
+++ b/src/video_core/shader/decode/arithmetic_integer.cpp
@@ -26,7 +26,7 @@ u32 ShaderIR::DecodeArithmeticInteger(BasicBlock& bb, const BasicBlock& code, u3
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
 

--- a/src/video_core/shader/decode/conversion.cpp
+++ b/src/video_core/shader/decode/conversion.cpp
@@ -48,7 +48,7 @@ u32 ShaderIR::DecodeConversion(BasicBlock& bb, const BasicBlock& code, u32 pc) {
             if (instr.is_b_gpr) {
                 return GetRegister(instr.gpr20);
             } else {
-                return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+                return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
             }
         }();
         const bool input_signed = instr.conversion.is_input_signed;
@@ -72,7 +72,7 @@ u32 ShaderIR::DecodeConversion(BasicBlock& bb, const BasicBlock& code, u32 pc) {
             if (instr.is_b_gpr) {
                 return GetRegister(instr.gpr20);
             } else {
-                return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+                return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
             }
         }();
 
@@ -110,7 +110,7 @@ u32 ShaderIR::DecodeConversion(BasicBlock& bb, const BasicBlock& code, u32 pc) {
             if (instr.is_b_gpr) {
                 return GetRegister(instr.gpr20);
             } else {
-                return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+                return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
             }
         }();
 

--- a/src/video_core/shader/decode/ffma.cpp
+++ b/src/video_core/shader/decode/ffma.cpp
@@ -27,14 +27,14 @@ u32 ShaderIR::DecodeFfma(BasicBlock& bb, const BasicBlock& code, u32 pc) {
     auto [op_b, op_c] = [&]() -> std::tuple<Node, Node> {
         switch (opcode->get().GetId()) {
         case OpCode::Id::FFMA_CR: {
-            return {GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset),
+            return {GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset()),
                     GetRegister(instr.gpr39)};
         }
         case OpCode::Id::FFMA_RR:
             return {GetRegister(instr.gpr20), GetRegister(instr.gpr39)};
         case OpCode::Id::FFMA_RC: {
             return {GetRegister(instr.gpr39),
-                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset)};
+                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset())};
         }
         case OpCode::Id::FFMA_IMM:
             return {GetImmediate19(instr), GetRegister(instr.gpr39)};

--- a/src/video_core/shader/decode/float_set.cpp
+++ b/src/video_core/shader/decode/float_set.cpp
@@ -25,7 +25,7 @@ u32 ShaderIR::DecodeFloatSet(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
 

--- a/src/video_core/shader/decode/float_set_predicate.cpp
+++ b/src/video_core/shader/decode/float_set_predicate.cpp
@@ -25,7 +25,7 @@ u32 ShaderIR::DecodeFloatSetPredicate(BasicBlock& bb, const BasicBlock& code, u3
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
     op_b = GetOperandAbsNegFloat(op_b, instr.fsetp.abs_b, false);

--- a/src/video_core/shader/decode/hfma2.cpp
+++ b/src/video_core/shader/decode/hfma2.cpp
@@ -39,13 +39,14 @@ u32 ShaderIR::DecodeHfma2(BasicBlock& bb, const BasicBlock& code, u32 pc) {
             neg_b = instr.hfma2.negate_b;
             neg_c = instr.hfma2.negate_c;
             return {instr.hfma2.saturate, instr.hfma2.type_b,
-                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset), instr.hfma2.type_reg39,
-                    GetRegister(instr.gpr39)};
+                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset()),
+                    instr.hfma2.type_reg39, GetRegister(instr.gpr39)};
         case OpCode::Id::HFMA2_RC:
             neg_b = instr.hfma2.negate_b;
             neg_c = instr.hfma2.negate_c;
             return {instr.hfma2.saturate, instr.hfma2.type_reg39, GetRegister(instr.gpr39),
-                    instr.hfma2.type_b, GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset)};
+                    instr.hfma2.type_b,
+                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset())};
         case OpCode::Id::HFMA2_RR:
             neg_b = instr.hfma2.rr.negate_b;
             neg_c = instr.hfma2.rr.negate_c;

--- a/src/video_core/shader/decode/integer_set.cpp
+++ b/src/video_core/shader/decode/integer_set.cpp
@@ -23,7 +23,7 @@ u32 ShaderIR::DecodeIntegerSet(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
 

--- a/src/video_core/shader/decode/integer_set_predicate.cpp
+++ b/src/video_core/shader/decode/integer_set_predicate.cpp
@@ -25,7 +25,7 @@ u32 ShaderIR::DecodeIntegerSetPredicate(BasicBlock& bb, const BasicBlock& code, 
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
 

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -80,7 +80,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         Node index = GetRegister(instr.gpr8);
 
         const Node op_a =
-            GetConstBufferIndirect(instr.cbuf36.index, instr.cbuf36.offset + 0, index);
+            GetConstBufferIndirect(instr.cbuf36.index, instr.cbuf36.GetOffset() + 0, index);
 
         switch (instr.ld_c.type.Value()) {
         case Tegra::Shader::UniformType::Single:
@@ -89,7 +89,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
 
         case Tegra::Shader::UniformType::Double: {
             const Node op_b =
-                GetConstBufferIndirect(instr.cbuf36.index, instr.cbuf36.offset + 4, index);
+                GetConstBufferIndirect(instr.cbuf36.index, instr.cbuf36.GetOffset() + 4, index);
 
             SetTemporal(bb, 0, op_a);
             SetTemporal(bb, 1, op_b);
@@ -142,7 +142,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         ASSERT(cbuf != nullptr);
         const auto cbuf_offset_imm = std::get_if<ImmediateNode>(cbuf->GetOffset());
         ASSERT(cbuf_offset_imm != nullptr);
-        const auto cbuf_offset = cbuf_offset_imm->GetValue() * 4;
+        const auto cbuf_offset = cbuf_offset_imm->GetValue();
 
         bb.push_back(Comment(
             fmt::format("Base address is c[0x{:x}][0x{:x}]", cbuf->GetIndex(), cbuf_offset)));

--- a/src/video_core/shader/decode/shift.cpp
+++ b/src/video_core/shader/decode/shift.cpp
@@ -23,7 +23,7 @@ u32 ShaderIR::DecodeShift(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         } else if (instr.is_b_gpr) {
             return GetRegister(instr.gpr20);
         } else {
-            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset);
+            return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
 

--- a/src/video_core/shader/decode/xmad.cpp
+++ b/src/video_core/shader/decode/xmad.cpp
@@ -32,13 +32,14 @@ u32 ShaderIR::DecodeXmad(BasicBlock& bb, const BasicBlock& code, u32 pc) {
     auto [is_merge, op_b, op_c] = [&]() -> std::tuple<bool, Node, Node> {
         switch (opcode->get().GetId()) {
         case OpCode::Id::XMAD_CR:
-            return {instr.xmad.merge_56, GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset),
+            return {instr.xmad.merge_56,
+                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset()),
                     GetRegister(instr.gpr39)};
         case OpCode::Id::XMAD_RR:
             return {instr.xmad.merge_37, GetRegister(instr.gpr20), GetRegister(instr.gpr39)};
         case OpCode::Id::XMAD_RC:
             return {false, GetRegister(instr.gpr39),
-                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset)};
+                    GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset())};
         case OpCode::Id::XMAD_IMM:
             return {instr.xmad.merge_37, Immediate(static_cast<u32>(instr.xmad.imm20_16)),
                     GetRegister(instr.gpr39)};

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -249,7 +249,7 @@ public:
     }
 
     u32 GetSize() const {
-        return max_offset + 1;
+        return max_offset + sizeof(float);
     }
 
 private:


### PR DESCRIPTION
Constant buffer values on the shader IR were using different offsets if the access direct or indirect. cbuf34 has a non-multiplied offset while cbuf36 does. On shader decoding this commit multiplies it by four on cbuf34 queries.