### PR TITLE
service/nvflinger: Minor renaming changes

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -61,7 +61,7 @@ u64 NVFlinger::OpenDisplay(std::string_view name) {
 }
 
 u64 NVFlinger::CreateLayer(u64 display_id) {
-    auto& display = GetDisplay(display_id);
+    auto& display = FindDisplay(display_id);
 
     ASSERT_MSG(display.layers.empty(), "Only one layer is supported per display at the moment");
 
@@ -73,16 +73,16 @@ u64 NVFlinger::CreateLayer(u64 display_id) {
     return layer_id;
 }
 
-u32 NVFlinger::GetBufferQueueId(u64 display_id, u64 layer_id) {
-    const auto& layer = GetLayer(display_id, layer_id);
+u32 NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) {
+    const auto& layer = FindLayer(display_id, layer_id);
     return layer.buffer_queue->GetId();
 }
 
 Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::GetVsyncEvent(u64 display_id) {
-    return GetDisplay(display_id).vsync_event.readable;
+    return FindDisplay(display_id).vsync_event.readable;
 }
 
-std::shared_ptr<BufferQueue> NVFlinger::GetBufferQueue(u32 id) const {
+std::shared_ptr<BufferQueue> NVFlinger::FindBufferQueue(u32 id) const {
     const auto itr = std::find_if(buffer_queues.begin(), buffer_queues.end(),
                                   [&](const auto& queue) { return queue->GetId() == id; });
 
@@ -90,7 +90,7 @@ std::shared_ptr<BufferQueue> NVFlinger::GetBufferQueue(u32 id) const {
     return *itr;
 }
 
-Display& NVFlinger::GetDisplay(u64 display_id) {
+Display& NVFlinger::FindDisplay(u64 display_id) {
     const auto itr = std::find_if(displays.begin(), displays.end(),
                                   [&](const Display& display) { return display.id == display_id; });
 
@@ -98,8 +98,8 @@ Display& NVFlinger::GetDisplay(u64 display_id) {
     return *itr;
 }
 
-Layer& NVFlinger::GetLayer(u64 display_id, u64 layer_id) {
-    auto& display = GetDisplay(display_id);
+Layer& NVFlinger::FindLayer(u64 display_id, u64 layer_id) {
+    auto& display = FindDisplay(display_id);
 
     const auto itr = std::find_if(display.layers.begin(), display.layers.end(),
                                   [&](const Layer& layer) { return layer.id == layer_id; });

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -73,7 +73,7 @@ u64 NVFlinger::CreateLayer(u64 display_id) {
     return layer_id;
 }
 
-u32 NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) {
+u32 NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) const {
     const auto& layer = FindLayer(display_id, layer_id);
     return layer.buffer_queue->GetId();
 }
@@ -98,8 +98,26 @@ Display& NVFlinger::FindDisplay(u64 display_id) {
     return *itr;
 }
 
+const Display& NVFlinger::FindDisplay(u64 display_id) const {
+    const auto itr = std::find_if(displays.begin(), displays.end(),
+                                  [&](const Display& display) { return display.id == display_id; });
+
+    ASSERT(itr != displays.end());
+    return *itr;
+}
+
 Layer& NVFlinger::FindLayer(u64 display_id, u64 layer_id) {
     auto& display = FindDisplay(display_id);
+
+    const auto itr = std::find_if(display.layers.begin(), display.layers.end(),
+                                  [&](const Layer& layer) { return layer.id == layer_id; });
+
+    ASSERT(itr != display.layers.end());
+    return *itr;
+}
+
+const Layer& NVFlinger::FindLayer(u64 display_id, u64 layer_id) const {
+    const auto& display = FindDisplay(display_id);
 
     const auto itr = std::find_if(display.layers.begin(), display.layers.end(),
                                   [&](const Layer& layer) { return layer.id == layer_id; });

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -64,7 +64,7 @@ public:
     u64 CreateLayer(u64 display_id);
 
     /// Finds the buffer queue ID of the specified layer in the specified display.
-    u32 FindBufferQueueId(u64 display_id, u64 layer_id);
+    u32 FindBufferQueueId(u64 display_id, u64 layer_id) const;
 
     /// Gets the vsync event for the specified display.
     Kernel::SharedPtr<Kernel::ReadableEvent> GetVsyncEvent(u64 display_id);
@@ -80,8 +80,14 @@ private:
     /// Finds the display identified by the specified ID.
     Display& FindDisplay(u64 display_id);
 
+    /// Finds the display identified by the specified ID.
+    const Display& FindDisplay(u64 display_id) const;
+
     /// Finds the layer identified by the specified ID in the desired display.
     Layer& FindLayer(u64 display_id, u64 layer_id);
+
+    /// Finds the layer identified by the specified ID in the desired display.
+    const Layer& FindLayer(u64 display_id, u64 layer_id) const;
 
     std::shared_ptr<Nvidia::Module> nvdrv;
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -57,31 +57,31 @@ public:
     /// Sets the NVDrv module instance to use to send buffers to the GPU.
     void SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance);
 
-    /// Opens the specified display and returns the id.
+    /// Opens the specified display and returns the ID.
     u64 OpenDisplay(std::string_view name);
 
-    /// Creates a layer on the specified display and returns the layer id.
+    /// Creates a layer on the specified display and returns the layer ID.
     u64 CreateLayer(u64 display_id);
 
-    /// Gets the buffer queue id of the specified layer in the specified display.
-    u32 GetBufferQueueId(u64 display_id, u64 layer_id);
+    /// Finds the buffer queue ID of the specified layer in the specified display.
+    u32 FindBufferQueueId(u64 display_id, u64 layer_id);
 
     /// Gets the vsync event for the specified display.
     Kernel::SharedPtr<Kernel::ReadableEvent> GetVsyncEvent(u64 display_id);
 
-    /// Obtains a buffer queue identified by the id.
-    std::shared_ptr<BufferQueue> GetBufferQueue(u32 id) const;
+    /// Obtains a buffer queue identified by the ID.
+    std::shared_ptr<BufferQueue> FindBufferQueue(u32 id) const;
 
     /// Performs a composition request to the emulated nvidia GPU and triggers the vsync events when
     /// finished.
     void Compose();
 
 private:
-    /// Returns the display identified by the specified id.
-    Display& GetDisplay(u64 display_id);
+    /// Finds the display identified by the specified ID.
+    Display& FindDisplay(u64 display_id);
 
-    /// Returns the layer identified by the specified id in the desired display.
-    Layer& GetLayer(u64 display_id, u64 layer_id);
+    /// Finds the layer identified by the specified ID in the desired display.
+    Layer& FindLayer(u64 display_id, u64 layer_id);
 
     std::shared_ptr<Nvidia::Module> nvdrv;
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -524,7 +524,7 @@ private:
         LOG_DEBUG(Service_VI, "called. id=0x{:08X} transaction={:X}, flags=0x{:08X}", id,
                   static_cast<u32>(transaction), flags);
 
-        auto buffer_queue = nv_flinger->GetBufferQueue(id);
+        auto buffer_queue = nv_flinger->FindBufferQueue(id);
 
         if (transaction == TransactionId::Connect) {
             IGBPConnectRequestParcel request{ctx.ReadBuffer()};
@@ -558,7 +558,7 @@ private:
                     [=](Kernel::SharedPtr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
                         Kernel::ThreadWakeupReason reason) {
                         // Repeat TransactParcel DequeueBuffer when a buffer is available
-                        auto buffer_queue = nv_flinger->GetBufferQueue(id);
+                        auto buffer_queue = nv_flinger->FindBufferQueue(id);
                         std::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);
                         ASSERT_MSG(slot != std::nullopt, "Could not dequeue buffer.");
 
@@ -628,7 +628,7 @@ private:
 
         LOG_WARNING(Service_VI, "(STUBBED) called id={}, unknown={:08X}", id, unknown);
 
-        const auto buffer_queue = nv_flinger->GetBufferQueue(id);
+        const auto buffer_queue = nv_flinger->FindBufferQueue(id);
 
         // TODO(Subv): Find out what this actually is.
         IPC::ResponseBuilder rb{ctx, 2, 1};
@@ -1044,7 +1044,7 @@ private:
         LOG_DEBUG(Service_VI, "called. layer_id=0x{:016X}, aruid=0x{:016X}", layer_id, aruid);
 
         const u64 display_id = nv_flinger->OpenDisplay(display_name);
-        const u32 buffer_queue_id = nv_flinger->GetBufferQueueId(display_id, layer_id);
+        const u32 buffer_queue_id = nv_flinger->FindBufferQueueId(display_id, layer_id);
 
         NativeWindow native_window{buffer_queue_id};
         IPC::ResponseBuilder rb{ctx, 4};
@@ -1063,7 +1063,7 @@ private:
         // TODO(Subv): What's the difference between a Stray and a Managed layer?
 
         const u64 layer_id = nv_flinger->CreateLayer(display_id);
-        const u32 buffer_queue_id = nv_flinger->GetBufferQueueId(display_id, layer_id);
+        const u32 buffer_queue_id = nv_flinger->FindBufferQueueId(display_id, layer_id);
 
         NativeWindow native_window{buffer_queue_id};
         IPC::ResponseBuilder rb{ctx, 6};


### PR DESCRIPTION
Converts  Get  functions that don't simply "get" something into Find. This also makes FindBufferQueueId() a const qualified member function, since it doesn't modify instance state. This is just a preliminary cleanup before more changes related to the vi service are made following this.


