### PR TITLE
kernel/wait_object: Devirtualize functions related to manipulating the thread list directly 

### DIFF
--- a/src/core/hle/kernel/readable_event.cpp
+++ b/src/core/hle/kernel/readable_event.cpp
@@ -44,8 +44,4 @@ ResultCode ReadableEvent::Reset() {
     return RESULT_SUCCESS;
 }
 
-void ReadableEvent::WakeupAllWaitingThreads() {
-    WaitObject::WakeupAllWaitingThreads();
-}
-
 } // namespace Kernel

--- a/src/core/hle/kernel/readable_event.h
+++ b/src/core/hle/kernel/readable_event.h
@@ -39,8 +39,6 @@ public:
     bool ShouldWait(Thread* thread) const override;
     void Acquire(Thread* thread) override;
 
-    void WakeupAllWaitingThreads() override;
-
     /// Unconditionally clears the readable event's state.
     void Clear();
 

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -66,10 +66,6 @@ void Timer::Clear() {
     signaled = false;
 }
 
-void Timer::WakeupAllWaitingThreads() {
-    WaitObject::WakeupAllWaitingThreads();
-}
-
 void Timer::Signal(int cycles_late) {
     LOG_TRACE(Kernel, "Timer {} fired", GetObjectId());
 

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -51,8 +51,6 @@ public:
     bool ShouldWait(Thread* thread) const override;
     void Acquire(Thread* thread) override;
 
-    void WakeupAllWaitingThreads() override;
-
     /**
      * Starts the timer, with the specified initial delay and interval.
      * @param initial Delay until the timer is first fired

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -33,19 +33,19 @@ public:
      * Add a thread to wait on this object
      * @param thread Pointer to thread to add
      */
-    virtual void AddWaitingThread(SharedPtr<Thread> thread);
+    void AddWaitingThread(SharedPtr<Thread> thread);
 
     /**
      * Removes a thread from waiting on this object (e.g. if it was resumed already)
      * @param thread Pointer to thread to remove
      */
-    virtual void RemoveWaitingThread(Thread* thread);
+    void RemoveWaitingThread(Thread* thread);
 
     /**
      * Wake up all threads waiting on this object that can be awoken, in priority order,
      * and set the synchronization result and output of the thread.
      */
-    virtual void WakeupAllWaitingThreads();
+    void WakeupAllWaitingThreads();
 
     /**
      * Wakes up a single thread waiting on this object.


### PR DESCRIPTION
None of the current inheritors of the WaitObject class override these functions in any meaningful way. It's also kind of sketchy to allow overriding these, given the kernel itself doesn't really provide for it either.

Given the lack of usage, these can be devirtualized, simplifying the interface that needs to be cared about when inheriting from WaitObject.