### PR TITLE
Merge pull request #2085 from ReinUsesLisp/cube-minus-one

### DIFF
--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -182,7 +182,7 @@ struct TICEntry {
     };
     union {
         BitField<0, 16, u32> height_minus_1;
-        BitField<16, 15, u32> depth_minus_1;
+        BitField<16, 14, u32> depth_minus_1;
     };
     union {
         BitField<6, 13, u32> mip_lod_bias;


### PR DESCRIPTION
video_core/texture: Fix BitField size for depth_minus_one