### PR TITLE
nvdisp_disp0: change drawing message log level from Warning to Trace 

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -25,9 +25,9 @@ void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u3
                         u32 stride, NVFlinger::BufferQueue::BufferTransformFlags transform,
                         const MathUtil::Rectangle<int>& crop_rect) {
     VAddr addr = nvmap_dev->GetObjectAddress(buffer_handle);
-    LOG_WARNING(Service,
-                "Drawing from address {:X} offset {:08X} Width {} Height {} Stride {} Format {}",
-                addr, offset, width, height, stride, format);
+    LOG_TRACE(Service,
+              "Drawing from address {:X} offset {:08X} Width {} Height {} Stride {} Format {}",
+              addr, offset, width, height, stride, format);
 
     using PixelFormat = Tegra::FramebufferConfig::PixelFormat;
     const Tegra::FramebufferConfig framebuffer{


### PR DESCRIPTION
This is a leftover from the early yuzu days.
We shouldn't log every time when we are drawing by default, so let's change the log level to Trace.

As suggested by Hexagon12 on Discord.