### PR TITLE
Fixes Unicode Key File Directories

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -400,7 +400,7 @@ static bool ValidCryptoRevisionString(std::string_view base, size_t begin, size_
 void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
 #ifdef _WIN32
     std::string copy(filename);
-    if (copy.size() != 0 && copy.back() == ':')
+    if (!copy.empty() && copy.back() == ':')
         copy += DIR_SEP_CHR;
     std::wstring utf16 = Common::UTF8ToUTF16W(copy);
     std::ifstream file(utf16);

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -398,15 +398,8 @@ static bool ValidCryptoRevisionString(std::string_view base, size_t begin, size_
 }
 
 void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
-#ifdef _WIN32
-    std::string copy(filename);
-    if (!copy.empty() && copy.back() == ':')
-        copy += DIR_SEP_CHR;
-    std::wstring utf16 = Common::UTF8ToUTF16W(copy);
-    std::ifstream file(utf16);
-#else
-    std::ifstream file(filename);
-#endif
+    std::ifstream file;
+    OpenFStream<std::ifstream>(file, filename, std::ios_base::in);
     if (!file.is_open())
         return;
 

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -398,7 +398,15 @@ static bool ValidCryptoRevisionString(std::string_view base, size_t begin, size_
 }
 
 void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
+#ifdef _WIN32
+    std::string copy(filename);
+    if (copy.size() != 0 && copy.back() == ':')
+        copy += DIR_SEP_CHR;
+    std::wstring utf16 = Common::UTF8ToUTF16W(copy).c_str();
+    std::ifstream file(utf16);
+#else
     std::ifstream file(filename);
+#endif
     if (!file.is_open())
         return;
 

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -402,7 +402,7 @@ void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
     std::string copy(filename);
     if (copy.size() != 0 && copy.back() == ':')
         copy += DIR_SEP_CHR;
-    std::wstring utf16 = Common::UTF8ToUTF16W(copy).c_str();
+    std::wstring utf16 = Common::UTF8ToUTF16W(copy);
     std::ifstream file(utf16);
 #else
     std::ifstream file(filename);


### PR DESCRIPTION
Can load directories when on a Unicode file directory.

Code added to convert filepath from UTF8 to UTF16 on Windows, borrowed from FileUtil::Exists where it works appropriately.