### PR TITLE
vk_resource_manager: Implement fence and command buffer allocator 

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -105,7 +105,9 @@ if (ENABLE_VULKAN)
     target_sources(video_core PRIVATE
         renderer_vulkan/declarations.h
         renderer_vulkan/vk_device.cpp
-        renderer_vulkan/vk_device.h)
+        renderer_vulkan/vk_device.h
+        renderer_vulkan/vk_resource_manager.cpp
+        renderer_vulkan/vk_resource_manager.h)
 
     target_include_directories(video_core PRIVATE ../../externals/Vulkan-Headers/include)
     target_compile_definitions(video_core PRIVATE HAS_VULKAN)

--- a/src/video_core/renderer_vulkan/vk_resource_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.cpp
@@ -1,0 +1,14 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "video_core/renderer_vulkan/declarations.h"
+#include "video_core/renderer_vulkan/vk_resource_manager.h"
+
+namespace Vulkan {
+
+VKResource::VKResource() = default;
+
+VKResource::~VKResource() = default;
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_resource_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include "video_core/renderer_vulkan/declarations.h"
+#include "video_core/renderer_vulkan/vk_device.h"
 #include "video_core/renderer_vulkan/vk_resource_manager.h"
 
 namespace Vulkan {
@@ -10,5 +12,71 @@ namespace Vulkan {
 VKResource::VKResource() = default;
 
 VKResource::~VKResource() = default;
+
+VKFence::VKFence(const VKDevice& device, UniqueFence handle)
+    : device{device}, handle{std::move(handle)} {}
+
+VKFence::~VKFence() = default;
+
+void VKFence::Wait() {
+    const auto dev = device.GetLogical();
+    const auto& dld = device.GetDispatchLoader();
+    dev.waitForFences({*handle}, true, std::numeric_limits<u64>::max(), dld);
+}
+
+void VKFence::Release() {
+    is_owned = false;
+}
+
+void VKFence::Commit() {
+    is_owned = true;
+    is_used = true;
+}
+
+bool VKFence::Tick(bool gpu_wait, bool owner_wait) {
+    if (!is_used) {
+        // If a fence is not used it's always free.
+        return true;
+    }
+    if (is_owned && !owner_wait) {
+        // The fence is still being owned (Release has not been called) and ownership wait has
+        // not been asked.
+        return false;
+    }
+
+    const auto dev = device.GetLogical();
+    const auto& dld = device.GetDispatchLoader();
+    if (gpu_wait) {
+        // Wait for the fence if it has been requested.
+        dev.waitForFences({*handle}, true, std::numeric_limits<u64>::max(), dld);
+    } else {
+        if (dev.getFenceStatus(*handle, dld) != vk::Result::eSuccess) {
+            // Vulkan fence is not ready, not much it can do here
+            return false;
+        }
+    }
+
+    // Broadcast resources their free state.
+    for (auto* resource : protected_resources) {
+        resource->OnFenceRemoval(this);
+    }
+    protected_resources.clear();
+
+    // Prepare fence for reusage.
+    dev.resetFences({*handle}, dld);
+    is_used = false;
+    return true;
+}
+
+void VKFence::Protect(VKResource* resource) {
+    protected_resources.push_back(resource);
+}
+
+void VKFence::Unprotect(const VKResource* resource) {
+    const auto it = std::find(protected_resources.begin(), protected_resources.end(), resource);
+    if (it != protected_resources.end()) {
+        protected_resources.erase(it);
+    }
+}
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_resource_manager.h
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <vector>
 #include "video_core/renderer_vulkan/declarations.h"
 
@@ -114,6 +116,27 @@ public:
 
 private:
     VKFence* fence{}; ///< Fence watching this resource. nullptr when the watch is free.
+};
+
+/**
+ * The resource manager handles all resources that can be protected with a fence avoiding
+ * driver-side or GPU-side concurrent usage. Usage is documented in VKFence.
+ */
+class VKResourceManager final {
+public:
+    explicit VKResourceManager(const VKDevice& device);
+    ~VKResourceManager();
+
+    /// Commits a fence. It has to be sent to a queue and released.
+    VKFence& CommitFence();
+
+private:
+    /// Allocates new fences.
+    void GrowFences(std::size_t new_fences_count);
+
+    const VKDevice& device;          ///< Device handler.
+    std::size_t fences_iterator = 0; ///< Index where a free fence is likely to be found.
+    std::vector<std::unique_ptr<VKFence>> fences; ///< Pool of fences.
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_resource_manager.h
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.h
@@ -15,6 +15,8 @@ class VKDevice;
 class VKFence;
 class VKResourceManager;
 
+class CommandBufferPool;
+
 /// Interface for a Vulkan resource
 class VKResource {
 public:
@@ -162,13 +164,17 @@ public:
     /// Commits a fence. It has to be sent to a queue and released.
     VKFence& CommitFence();
 
+    /// Commits an unused command buffer and protects it with a fence.
+    vk::CommandBuffer CommitCommandBuffer(VKFence& fence);
+
 private:
     /// Allocates new fences.
     void GrowFences(std::size_t new_fences_count);
 
     const VKDevice& device;          ///< Device handler.
     std::size_t fences_iterator = 0; ///< Index where a free fence is likely to be found.
-    std::vector<std::unique_ptr<VKFence>> fences; ///< Pool of fences.
+    std::vector<std::unique_ptr<VKFence>> fences;           ///< Pool of fences.
+    std::unique_ptr<CommandBufferPool> command_buffer_pool; ///< Pool of command buffers.
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_resource_manager.h
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.h
@@ -4,11 +4,14 @@
 
 #pragma once
 
+#include <vector>
 #include "video_core/renderer_vulkan/declarations.h"
 
 namespace Vulkan {
 
+class VKDevice;
 class VKFence;
+class VKResourceManager;
 
 /// Interface for a Vulkan resource
 class VKResource {
@@ -21,6 +24,66 @@ public:
      * @param signaling_fence Fence that signals its usage end.
      */
     virtual void OnFenceRemoval(VKFence* signaling_fence) = 0;
+};
+
+/**
+ * Fences take ownership of objects, protecting them from GPU-side or driver-side concurrent access.
+ * They must be commited from the resource manager. Their usage flow is: commit the fence from the
+ * resource manager, protect resources with it and use them, send the fence to an execution queue
+ * and Wait for it if needed and then call Release. Used resources will automatically be signaled
+ * when they are free to be reused.
+ * @brief Protects resources for concurrent usage and signals its release.
+ */
+class VKFence {
+    friend class VKResourceManager;
+
+public:
+    explicit VKFence(const VKDevice& device, UniqueFence handle);
+    ~VKFence();
+
+    /**
+     * Waits for the fence to be signaled.
+     * @warning You must have ownership of the fence and it has to be previously sent to a queue to
+     * call this function.
+     */
+    void Wait();
+
+    /**
+     * Releases ownership of the fence. Pass after it has been sent to an execution queue.
+     * Unmanaged usage of the fence after the call will result in undefined behavior because it may
+     * be being used for something else.
+     */
+    void Release();
+
+    /// Protects a resource with this fence.
+    void Protect(VKResource* resource);
+
+    /// Removes protection for a resource.
+    void Unprotect(const VKResource* resource);
+
+    /// Retreives the fence.
+    operator vk::Fence() const {
+        return *handle;
+    }
+
+private:
+    /// Take ownership of the fence.
+    void Commit();
+
+    /**
+     * Updates the fence status.
+     * @warning Waiting for the owner might soft lock the execution.
+     * @param gpu_wait Wait for the fence to be signaled by the driver.
+     * @param owner_wait Wait for the owner to signal its freedom.
+     * @returns True if the fence is free. Waiting for gpu and owner will always return true.
+     */
+    bool Tick(bool gpu_wait, bool owner_wait);
+
+    const VKDevice& device;                       ///< Device handler
+    UniqueFence handle;                           ///< Vulkan fence
+    std::vector<VKResource*> protected_resources; ///< List of resources protected by this fence
+    bool is_owned = false; ///< The fence has been commited but not released yet.
+    bool is_used = false;  ///< The fence has been commited but it has not been checked to be free.
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_resource_manager.h
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.h
@@ -1,0 +1,26 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "video_core/renderer_vulkan/declarations.h"
+
+namespace Vulkan {
+
+class VKFence;
+
+/// Interface for a Vulkan resource
+class VKResource {
+public:
+    explicit VKResource();
+    virtual ~VKResource();
+
+    /**
+     * Signals the object that an owning fence has been signaled.
+     * @param signaling_fence Fence that signals its usage end.
+     */
+    virtual void OnFenceRemoval(VKFence* signaling_fence) = 0;
+};
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_resource_manager.h
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.h
@@ -86,4 +86,34 @@ private:
     bool is_used = false;  ///< The fence has been commited but it has not been checked to be free.
 };
 
+/**
+ * A fence watch is used to keep track of the usage of a fence and protect a resource or set of
+ * resources without having to inherit VKResource from their handlers.
+ */
+class VKFenceWatch final : public VKResource {
+public:
+    explicit VKFenceWatch();
+    ~VKFenceWatch();
+
+    /// Waits for the fence to be released.
+    void Wait();
+
+    /**
+     * Waits for a previous fence and watches a new one.
+     * @param new_fence New fence to wait to.
+     */
+    void Watch(VKFence& new_fence);
+
+    /**
+     * Checks if it's currently being watched and starts watching it if it's available.
+     * @returns True if a watch has started, false if it's being watched.
+     */
+    bool TryWatch(VKFence& new_fence);
+
+    void OnFenceRemoval(VKFence* signaling_fence) override;
+
+private:
+    VKFence* fence{}; ///< Fence watching this resource. nullptr when the watch is free.
+};
+
 } // namespace Vulkan


### PR DESCRIPTION
`VKResourceManager`  is an abstraction layer used to commit fences and command buffers from a pool on Vulkan. This avoids constantly allocating (and deallocating) resources in the hot loop. Details in the individual commits.