### PR TITLE
address_arbiter: Use nested namespaces where applicable 

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -17,8 +17,7 @@
 #include "core/hle/result.h"
 #include "core/memory.h"
 
-namespace Kernel {
-namespace AddressArbiter {
+namespace Kernel::AddressArbiter {
 
 // Performs actual address waiting logic.
 static ResultCode WaitForAddress(VAddr address, s64 timeout) {
@@ -176,5 +175,4 @@ ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout) {
 
     return WaitForAddress(address, timeout);
 }
-} // namespace AddressArbiter
-} // namespace Kernel
+} // namespace Kernel::AddressArbiter

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -8,9 +8,8 @@
 
 union ResultCode;
 
-namespace Kernel {
+namespace Kernel::AddressArbiter {
 
-namespace AddressArbiter {
 enum class ArbitrationType {
     WaitIfLessThan = 0,
     DecrementAndWaitIfLessThan = 1,
@@ -29,6 +28,5 @@ ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 valu
 
 ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement);
 ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout);
-} // namespace AddressArbiter
 
-} // namespace Kernel
+} // namespace Kernel::AddressArbiter


### PR DESCRIPTION
A fairly trivial change. Other sections of the codebase use nested namespaces instead of separate namespaces when possible. This one must have just been overlooked.

No functional changes. This is just a simplification.