### PR TITLE
Port citra-emu/citra#4655: "Remove GCC version checks" 

### DIFF
--- a/src/common/swap.h
+++ b/src/common/swap.h
@@ -28,8 +28,8 @@
 #include <cstring>
 #include "common/common_types.h"
 
-// GCC 4.6+
-#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+// GCC
+#ifdef __GNUC__
 
 #if __BYTE_ORDER__ && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && !defined(COMMON_LITTLE_ENDIAN)
 #define COMMON_LITTLE_ENDIAN 1
@@ -38,7 +38,7 @@
 #endif
 
 // LLVM/clang
-#elif __clang__
+#elif defined(__clang__)
 
 #if __LITTLE_ENDIAN__ && !defined(COMMON_LITTLE_ENDIAN)
 #define COMMON_LITTLE_ENDIAN 1


### PR DESCRIPTION
See [citra-emu/citra#4655](https://github.com/citra-emu/citra/pull/4655) for more details.

**Original description**:
Citra can't be compiled using GCC <7 because of required C++17 support, so these version checks don't need to exist anymore.