### PR TITLE
renderer_opengl: Update pixel format tracking

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -257,6 +257,7 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
                                                  const Tegra::FramebufferConfig& framebuffer) {
     texture.width = framebuffer.width;
     texture.height = framebuffer.height;
+    texture.pixel_format = framebuffer.pixel_format;
 
     GLint internal_format;
     switch (framebuffer.pixel_format) {


### PR DESCRIPTION
Framebuffer refreshing is tested against pixel format, but this one was never updated on reconfiguration resulting in a resource deletion + recreation + allocation each frame.