### PR TITLE
gl_rasterizer: Unbind textures but don't apply the gl_state 

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -739,22 +739,10 @@ void RasterizerOpenGL::DrawArrays() {
     state.Apply();
 
     res_cache.SignalPreDrawCall();
-
-    // Execute draw call
     params.DispatchDraw();
-
     res_cache.SignalPostDrawCall();
 
-    // Disable scissor test
-    state.viewports[0].scissor.enabled = false;
-
     accelerate_draw = AccelDraw::Disabled;
-
-    // Unbind textures for potential future use as framebuffer attachments
-    for (auto& texture_unit : state.texture_units) {
-        texture_unit.Unbind();
-    }
-    state.Apply();
 }
 
 void RasterizerOpenGL::FlushAll() {}

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -461,7 +461,7 @@ void OpenGLState::ApplyTextures() const {
 
     if (has_delta) {
         glBindTextures(static_cast<GLuint>(first), static_cast<GLsizei>(last - first + 1),
-                       textures.data());
+                       textures.data() + first);
     }
 }
 
@@ -482,7 +482,7 @@ void OpenGLState::ApplySamplers() const {
     }
     if (has_delta) {
         glBindSamplers(static_cast<GLuint>(first), static_cast<GLsizei>(last - first + 1),
-                       samplers.data());
+                       samplers.data() + first);
     }
 }
 


### PR DESCRIPTION
Applying the state to update a framebuffer will also update the state for the textures. Knowing this we can unbind the textures at the end of the draw call without applying it. Also fix a `gl_state` bug were the first index offset was being ignored.