### PR TITLE
service/vi: Unstub GetDisplayService

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -362,6 +362,11 @@ inline u32 RequestParser::Pop() {
     return cmdbuf[index++];
 }
 
+template <>
+inline s32 RequestParser::Pop() {
+    return static_cast<s32>(Pop<u32>());
+}
+
 template <typename T>
 void RequestParser::PopRaw(T& value) {
     std::memcpy(&value, cmdbuf + index, sizeof(T));
@@ -390,6 +395,16 @@ inline u64 RequestParser::Pop() {
     const u64 lsw = Pop<u32>();
     const u64 msw = Pop<u32>();
     return msw << 32 | lsw;
+}
+
+template <>
+inline s8 RequestParser::Pop() {
+    return static_cast<s8>(Pop<u8>());
+}
+
+template <>
+inline s16 RequestParser::Pop() {
+    return static_cast<s16>(Pop<u16>());
 }
 
 template <>

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -24,6 +24,7 @@
 #include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/nvflinger/buffer_queue.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
+#include "core/hle/service/service.h"
 #include "core/hle/service/vi/vi.h"
 #include "core/hle/service/vi/vi_m.h"
 #include "core/hle/service/vi/vi_s.h"
@@ -1202,26 +1203,18 @@ IApplicationDisplayService::IApplicationDisplayService(
     RegisterHandlers(functions);
 }
 
-Module::Interface::Interface(std::shared_ptr<Module> module, const char* name,
-                             std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : ServiceFramework(name), module(std::move(module)), nv_flinger(std::move(nv_flinger)) {}
-
-Module::Interface::~Interface() = default;
-
-void Module::Interface::GetDisplayService(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_VI, "(STUBBED) called");
-
+void detail::GetDisplayServiceImpl(Kernel::HLERequestContext& ctx,
+                                   std::shared_ptr<NVFlinger::NVFlinger> nv_flinger) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IApplicationDisplayService>(nv_flinger);
+    rb.PushIpcInterface<IApplicationDisplayService>(std::move(nv_flinger));
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager,
                        std::shared_ptr<NVFlinger::NVFlinger> nv_flinger) {
-    auto module = std::make_shared<Module>();
-    std::make_shared<VI_M>(module, nv_flinger)->InstallAsService(service_manager);
-    std::make_shared<VI_S>(module, nv_flinger)->InstallAsService(service_manager);
-    std::make_shared<VI_U>(module, nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_M>(nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_S>(nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_U>(nv_flinger)->InstallAsService(service_manager);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -4,35 +4,32 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "common/common_types.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
 
 namespace Service::NVFlinger {
 class NVFlinger;
 }
 
+namespace Service::SM {
+class ServiceManager;
+}
+
 namespace Service::VI {
+namespace detail {
+void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx,
+                           std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+}
 
 enum class DisplayResolution : u32 {
     DockedWidth = 1920,
     DockedHeight = 1080,
     UndockedWidth = 1280,
     UndockedHeight = 720,
-};
-
-class Module final {
-public:
-    class Interface : public ServiceFramework<Interface> {
-    public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name,
-                           std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
-        ~Interface() override;
-
-        void GetDisplayService(Kernel::HLERequestContext& ctx);
-
-    protected:
-        std::shared_ptr<Module> module;
-        std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
-    };
 };
 
 /// Registers all VI services with the specified service manager.

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -20,10 +20,6 @@ class ServiceManager;
 }
 
 namespace Service::VI {
-namespace detail {
-void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx,
-                           std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
-}
 
 enum class DisplayResolution : u32 {
     DockedWidth = 1920,
@@ -31,6 +27,25 @@ enum class DisplayResolution : u32 {
     UndockedWidth = 1280,
     UndockedHeight = 720,
 };
+
+/// Permission level for a particular VI service instance
+enum class Permission {
+    User,
+    System,
+    Manager,
+};
+
+/// A policy type that may be requested via GetDisplayService and
+/// GetDisplayServiceWithProxyNameExchange
+enum class Policy {
+    User,
+    Compositor,
+};
+
+namespace detail {
+void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx,
+                           std::shared_ptr<NVFlinger::NVFlinger> nv_flinger, Permission permission);
+} // namespace detail
 
 /// Registers all VI services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& service_manager,

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -20,9 +20,9 @@ VI_M::VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
 VI_M::~VI_M() = default;
 
 void VI_M::GetDisplayService(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_VI, "(STUBBED) called");
+    LOG_DEBUG(Service_VI, "called");
 
-    detail::GetDisplayServiceImpl(ctx, nv_flinger);
+    detail::GetDisplayServiceImpl(ctx, nv_flinger, Permission::Manager);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/hle/service/vi/vi.h"
 #include "core/hle/service/vi/vi_m.h"
 
 namespace Service::VI {
 
-VI_M::VI_M(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : Module::Interface(std::move(module), "vi:m", std::move(nv_flinger)) {
+VI_M::VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
+    : ServiceFramework{"vi:m"}, nv_flinger{std::move(nv_flinger)} {
     static const FunctionInfo functions[] = {
         {2, &VI_M::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
@@ -16,5 +18,11 @@ VI_M::VI_M(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger>
 }
 
 VI_M::~VI_M() = default;
+
+void VI_M::GetDisplayService(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_VI, "(STUBBED) called");
+
+    detail::GetDisplayServiceImpl(ctx, nv_flinger);
+}
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_m.h
+++ b/src/core/hle/service/vi/vi_m.h
@@ -4,14 +4,27 @@
 
 #pragma once
 
-#include "core/hle/service/vi/vi.h"
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::NVFlinger {
+class NVFlinger;
+}
 
 namespace Service::VI {
 
-class VI_M final : public Module::Interface {
+class VI_M final : public ServiceFramework<VI_M> {
 public:
-    explicit VI_M(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
     ~VI_M() override;
+
+private:
+    void GetDisplayService(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/hle/service/vi/vi.h"
 #include "core/hle/service/vi/vi_s.h"
 
 namespace Service::VI {
 
-VI_S::VI_S(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : Module::Interface(std::move(module), "vi:s", std::move(nv_flinger)) {
+VI_S::VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
+    : ServiceFramework{"vi:s"}, nv_flinger{std::move(nv_flinger)} {
     static const FunctionInfo functions[] = {
         {1, &VI_S::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
@@ -16,5 +18,11 @@ VI_S::VI_S(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger>
 }
 
 VI_S::~VI_S() = default;
+
+void VI_S::GetDisplayService(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_VI, "(STUBBED) called");
+
+    detail::GetDisplayServiceImpl(ctx, nv_flinger);
+}
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -20,9 +20,9 @@ VI_S::VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
 VI_S::~VI_S() = default;
 
 void VI_S::GetDisplayService(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_VI, "(STUBBED) called");
+    LOG_DEBUG(Service_VI, "called");
 
-    detail::GetDisplayServiceImpl(ctx, nv_flinger);
+    detail::GetDisplayServiceImpl(ctx, nv_flinger, Permission::System);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.h
+++ b/src/core/hle/service/vi/vi_s.h
@@ -4,14 +4,27 @@
 
 #pragma once
 
-#include "core/hle/service/vi/vi.h"
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::NVFlinger {
+class NVFlinger;
+}
 
 namespace Service::VI {
 
-class VI_S final : public Module::Interface {
+class VI_S final : public ServiceFramework<VI_S> {
 public:
-    explicit VI_S(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
     ~VI_S() override;
+
+private:
+    void GetDisplayService(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/hle/service/vi/vi.h"
 #include "core/hle/service/vi/vi_u.h"
 
 namespace Service::VI {
 
-VI_U::VI_U(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : Module::Interface(std::move(module), "vi:u", std::move(nv_flinger)) {
+VI_U::VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
+    : ServiceFramework{"vi:u"}, nv_flinger{std::move(nv_flinger)} {
     static const FunctionInfo functions[] = {
         {0, &VI_U::GetDisplayService, "GetDisplayService"},
     };
@@ -15,5 +17,11 @@ VI_U::VI_U(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger>
 }
 
 VI_U::~VI_U() = default;
+
+void VI_U::GetDisplayService(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_VI, "(STUBBED) called");
+
+    detail::GetDisplayServiceImpl(ctx, nv_flinger);
+}
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -19,9 +19,9 @@ VI_U::VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
 VI_U::~VI_U() = default;
 
 void VI_U::GetDisplayService(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_VI, "(STUBBED) called");
+    LOG_DEBUG(Service_VI, "called");
 
-    detail::GetDisplayServiceImpl(ctx, nv_flinger);
+    detail::GetDisplayServiceImpl(ctx, nv_flinger, Permission::User);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.h
+++ b/src/core/hle/service/vi/vi_u.h
@@ -4,14 +4,27 @@
 
 #pragma once
 
-#include "core/hle/service/vi/vi.h"
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::NVFlinger {
+class NVFlinger;
+}
 
 namespace Service::VI {
 
-class VI_U final : public Module::Interface {
+class VI_U final : public ServiceFramework<VI_U> {
 public:
-    explicit VI_U(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
     ~VI_U() override;
+
+private:
+    void GetDisplayService(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
 };
 
 } // namespace Service::VI


### PR DESCRIPTION
This function is also supposed to check its given policy type with the permission of the service itself. This implements the necessary machinery to unstub these functions.

Policy::User seems to just be basic access (which is probably why vi:u is restricted to that policy), while the other policy seems to be for extended abilities regarding which displays can be managed and queried, so this is assumed to be for a background compositor (which I've named, appropriately, Policy::Compositor).