### PR TITLE
yuzu/debugger/wait_tree: Remove use of global CurrentProcess accessor

### DIFF
--- a/src/yuzu/debugger/wait_tree.h
+++ b/src/yuzu/debugger/wait_tree.h
@@ -17,6 +17,7 @@
 class EmuThread;
 
 namespace Kernel {
+class HandleTable;
 class ReadableEvent;
 class WaitObject;
 class Thread;
@@ -72,7 +73,7 @@ public:
 class WaitTreeMutexInfo : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    explicit WaitTreeMutexInfo(VAddr mutex_address);
+    explicit WaitTreeMutexInfo(VAddr mutex_address, const Kernel::HandleTable& handle_table);
     ~WaitTreeMutexInfo() override;
 
     QString GetText() const override;


### PR DESCRIPTION
We already have the thread instance that was created under the current
process, so we can just pass the handle table of it along to retrieve
the owner of the mutex.