### PR TITLE
video_core/gpu: Make GPU's destructor virtual

### DIFF
--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -123,7 +123,7 @@ class GPU {
 public:
     explicit GPU(Core::System& system, VideoCore::RendererBase& renderer);
 
-    ~GPU();
+    virtual ~GPU();
 
     struct MethodCall {
         u32 method{};

--- a/src/video_core/gpu_asynch.h
+++ b/src/video_core/gpu_asynch.h
@@ -21,7 +21,7 @@ class ThreadManager;
 class GPUAsynch : public Tegra::GPU {
 public:
     explicit GPUAsynch(Core::System& system, VideoCore::RendererBase& renderer);
-    ~GPUAsynch();
+    ~GPUAsynch() override;
 
     void PushGPUEntries(Tegra::CommandList&& entries) override;
     void SwapBuffers(

--- a/src/video_core/gpu_synch.h
+++ b/src/video_core/gpu_synch.h
@@ -16,7 +16,7 @@ namespace VideoCommon {
 class GPUSynch : public Tegra::GPU {
 public:
     explicit GPUSynch(Core::System& system, VideoCore::RendererBase& renderer);
-    ~GPUSynch();
+    ~GPUSynch() override;
 
     void PushGPUEntries(Tegra::CommandList&& entries) override;
     void SwapBuffers(


### PR DESCRIPTION
Because of the recent separation of GPU functionality into sync/async
variants, we need to mark the destructor virtual to provide proper
destruction behavior, given we use the base class within the System
class.

Prior to this, it was undefined behavior whether or not the destructor
in the derived classes would ever execute.