### PR TITLE
dma_pusher: Store command_list_header by copy

### DIFF
--- a/src/video_core/dma_pusher.cpp
+++ b/src/video_core/dma_pusher.cpp
@@ -39,7 +39,7 @@ bool DmaPusher::Step() {
     }
 
     const CommandList& command_list{dma_pushbuffer.front()};
-    const CommandListHeader& command_list_header{command_list[dma_pushbuffer_subindex++]};
+    const CommandListHeader command_list_header{command_list[dma_pushbuffer_subindex++]};
     GPUVAddr dma_get = command_list_header.addr;
     GPUVAddr dma_put = dma_get + command_list_header.size * sizeof(u32);
     bool non_main = command_list_header.is_non_main;


### PR DESCRIPTION
Instead of holding a reference that will get invalidated by dma_pushbuffer.pop(), hold it as a copy. This doesn't have any performance cost since CommandListHeader is 8 bytes long.