### PR TITLE
core/settings: Log more setting values 

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -93,7 +93,8 @@ void LogSettings() {
     LogSetting("Renderer_FrameLimit", Settings::values.frame_limit);
     LogSetting("Renderer_UseDiskShaderCache", Settings::values.use_disk_shader_cache);
     LogSetting("Renderer_UseAccurateGpuEmulation", Settings::values.use_accurate_gpu_emulation);
-    LogSetting("Renderer_UseAsynchronousGpuEmulation", Settings::values.use_asynchronous_gpu_emulation);
+    LogSetting("Renderer_UseAsynchronousGpuEmulation",
+               Settings::values.use_asynchronous_gpu_emulation);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);


### PR DESCRIPTION
This PR makes Yuzu log 2 new specific values (used or not):

 *   Asynchronous GPU emulation
 *   Disk Shader Cache
