### PR TITLE
audio_core/cubeb_sink: Convert _MSC_VER ifdefs to _WIN32 

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -12,7 +12,7 @@
 #include "common/ring_buffer.h"
 #include "core/settings.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <objbase.h>
 #endif
 
@@ -113,7 +113,7 @@ private:
 
 CubebSink::CubebSink(std::string_view target_device_name) {
     // Cubeb requires COM to be initialized on the thread calling cubeb_init on Windows
-#ifdef _MSC_VER
+#ifdef _WIN32
     com_init_result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 #endif
 
@@ -152,7 +152,7 @@ CubebSink::~CubebSink() {
 
     cubeb_destroy(ctx);
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     if (SUCCEEDED(com_init_result)) {
         CoUninitialize();
     }

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -26,7 +26,7 @@ private:
     cubeb_devid output_device{};
     std::vector<SinkStreamPtr> sink_streams;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     u32 com_init_result = 0;
 #endif
 };


### PR DESCRIPTION
This behavior also needs to be visible for MinGW builds as well.