### PR TITLE
set_sys: Implement GetFirmwareVersion(2) for libnx hosversion

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -68,6 +68,8 @@ add_library(core STATIC
     file_sys/system_archive/ng_word.h
     file_sys/system_archive/system_archive.cpp
     file_sys/system_archive/system_archive.h
+    file_sys/system_archive/system_version.cpp
+    file_sys/system_archive/system_version.h
     file_sys/vfs.cpp
     file_sys/vfs.h
     file_sys/vfs_concat.cpp

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -11,6 +11,9 @@ namespace FileSys {
 constexpr ResultCode ERROR_PATH_NOT_FOUND{ErrorModule::FS, 1};
 constexpr ResultCode ERROR_ENTITY_NOT_FOUND{ErrorModule::FS, 1002};
 constexpr ResultCode ERROR_SD_CARD_NOT_FOUND{ErrorModule::FS, 2001};
+constexpr ResultCode ERROR_OUT_OF_BOUNDS{ErrorModule::FS, 3005};
+constexpr ResultCode ERROR_FAILED_MOUNT_ARCHIVE{ErrorModule::FS, 3223};
+constexpr ResultCode ERROR_INVALID_ARGUMENT{ErrorModule::FS, 6001};
 constexpr ResultCode ERROR_INVALID_OFFSET{ErrorModule::FS, 6061};
 constexpr ResultCode ERROR_INVALID_SIZE{ErrorModule::FS, 6062};
 

--- a/src/core/file_sys/system_archive/system_archive.cpp
+++ b/src/core/file_sys/system_archive/system_archive.cpp
@@ -6,6 +6,7 @@
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/system_archive/ng_word.h"
 #include "core/file_sys/system_archive/system_archive.h"
+#include "core/file_sys/system_archive/system_version.h"
 
 namespace FileSys::SystemArchive {
 
@@ -30,7 +31,7 @@ constexpr std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHI
     {0x0100000000000806, "NgWord", &NgWord1},
     {0x0100000000000807, "SsidList", nullptr},
     {0x0100000000000808, "Dictionary", nullptr},
-    {0x0100000000000809, "SystemVersion", nullptr},
+    {0x0100000000000809, "SystemVersion", &SystemVersion},
     {0x010000000000080A, "AvatarImage", nullptr},
     {0x010000000000080B, "LocalNews", nullptr},
     {0x010000000000080C, "Eula", nullptr},

--- a/src/core/file_sys/system_archive/system_version.cpp
+++ b/src/core/file_sys/system_archive/system_version.cpp
@@ -16,15 +16,19 @@ constexpr u8 VERSION_MAJOR = 5;
 constexpr u8 VERSION_MINOR = 1;
 constexpr u8 VERSION_MICRO = 0;
 
-constexpr u8 REVISION_MAJOR = 0;
+constexpr u8 REVISION_MAJOR = 3;
 constexpr u8 REVISION_MINOR = 0;
 
-constexpr char PLATFORM_STRING[] = "YUZU";
-constexpr char VERSION_HASH[] = "";
+constexpr char PLATFORM_STRING[] = "NX";
+constexpr char VERSION_HASH[] = "23f9df53e25709d756e0c76effcb2473bd3447dd";
 constexpr char DISPLAY_VERSION[] = "5.1.0";
-constexpr char DISPLAY_TITLE[] = "YuzuEmulated Firmware for NX 5.1.0-0.0";
+constexpr char DISPLAY_TITLE[] = "NintendoSDK Firmware for NX 5.1.0-3.0";
 
 } // namespace SystemVersionData
+
+std::string GetLongDisplayVersion() {
+    return SystemVersionData::DISPLAY_TITLE;
+}
 
 VirtualDir SystemVersion() {
     VirtualFile file = std::make_shared<VectorVfsFile>(std::vector<u8>(0x100), "file");
@@ -34,13 +38,13 @@ VirtualDir SystemVersion() {
     file->WriteObject(SystemVersionData::REVISION_MAJOR, 4);
     file->WriteObject(SystemVersionData::REVISION_MINOR, 5);
     file->WriteArray(SystemVersionData::PLATFORM_STRING,
-                     std::min<u64>(sizeof(SystemVersionData::PLATFORM_STRING), 0x20ull), 0x8);
+                     std::min<u64>(sizeof(SystemVersionData::PLATFORM_STRING), 0x20ULL), 0x8);
     file->WriteArray(SystemVersionData::VERSION_HASH,
-                     std::min<u64>(sizeof(SystemVersionData::VERSION_HASH), 0x40ull), 0x28);
+                     std::min<u64>(sizeof(SystemVersionData::VERSION_HASH), 0x40ULL), 0x28);
     file->WriteArray(SystemVersionData::DISPLAY_VERSION,
-                     std::min<u64>(sizeof(SystemVersionData::DISPLAY_VERSION), 0x18ull), 0x68);
+                     std::min<u64>(sizeof(SystemVersionData::DISPLAY_VERSION), 0x18ULL), 0x68);
     file->WriteArray(SystemVersionData::DISPLAY_TITLE,
-                     std::min<u64>(sizeof(SystemVersionData::DISPLAY_TITLE), 0x80ull), 0x80);
+                     std::min<u64>(sizeof(SystemVersionData::DISPLAY_TITLE), 0x80ULL), 0x80);
     return std::make_shared<VectorVfsDirectory>(std::vector<VirtualFile>{file},
                                                 std::vector<VirtualDir>{}, "data");
 }

--- a/src/core/file_sys/system_archive/system_version.cpp
+++ b/src/core/file_sys/system_archive/system_version.cpp
@@ -34,13 +34,13 @@ VirtualDir SystemVersion() {
     file->WriteObject(SystemVersionData::REVISION_MAJOR, 4);
     file->WriteObject(SystemVersionData::REVISION_MINOR, 5);
     file->WriteArray(SystemVersionData::PLATFORM_STRING,
-                     std::min(sizeof(SystemVersionData::PLATFORM_STRING), 0x20ull), 0x8);
+                     std::min<u64>(sizeof(SystemVersionData::PLATFORM_STRING), 0x20ull), 0x8);
     file->WriteArray(SystemVersionData::VERSION_HASH,
-                     std::min(sizeof(SystemVersionData::VERSION_HASH), 0x40ull), 0x28);
+                     std::min<u64>(sizeof(SystemVersionData::VERSION_HASH), 0x40ull), 0x28);
     file->WriteArray(SystemVersionData::DISPLAY_VERSION,
-                     std::min(sizeof(SystemVersionData::DISPLAY_VERSION), 0x18ull), 0x68);
+                     std::min<u64>(sizeof(SystemVersionData::DISPLAY_VERSION), 0x18ull), 0x68);
     file->WriteArray(SystemVersionData::DISPLAY_TITLE,
-                     std::min(sizeof(SystemVersionData::DISPLAY_TITLE), 0x80ull), 0x80);
+                     std::min<u64>(sizeof(SystemVersionData::DISPLAY_TITLE), 0x80ull), 0x80);
     return std::make_shared<VectorVfsDirectory>(std::vector<VirtualFile>{file},
                                                 std::vector<VirtualDir>{}, "data");
 }

--- a/src/core/file_sys/system_archive/system_version.cpp
+++ b/src/core/file_sys/system_archive/system_version.cpp
@@ -1,0 +1,48 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/file_sys/system_archive/system_version.h"
+#include "core/file_sys/vfs_vector.h"
+
+namespace FileSys::SystemArchive {
+
+namespace SystemVersionData {
+
+// This section should reflect the best system version to describe yuzu's HLE api.
+// TODO(DarkLordZach): Update when HLE gets better.
+
+constexpr u8 VERSION_MAJOR = 5;
+constexpr u8 VERSION_MINOR = 1;
+constexpr u8 VERSION_MICRO = 0;
+
+constexpr u8 REVISION_MAJOR = 0;
+constexpr u8 REVISION_MINOR = 0;
+
+constexpr char PLATFORM_STRING[] = "YUZU";
+constexpr char VERSION_HASH[] = "";
+constexpr char DISPLAY_VERSION[] = "5.1.0";
+constexpr char DISPLAY_TITLE[] = "YuzuEmulated Firmware for NX 5.1.0-0.0";
+
+} // namespace SystemVersionData
+
+VirtualDir SystemVersion() {
+    VirtualFile file = std::make_shared<VectorVfsFile>(std::vector<u8>(0x100), "file");
+    file->WriteObject(SystemVersionData::VERSION_MAJOR, 0);
+    file->WriteObject(SystemVersionData::VERSION_MINOR, 1);
+    file->WriteObject(SystemVersionData::VERSION_MICRO, 2);
+    file->WriteObject(SystemVersionData::REVISION_MAJOR, 4);
+    file->WriteObject(SystemVersionData::REVISION_MINOR, 5);
+    file->WriteArray(SystemVersionData::PLATFORM_STRING,
+                     std::min(sizeof(SystemVersionData::PLATFORM_STRING), 0x20ull), 0x8);
+    file->WriteArray(SystemVersionData::VERSION_HASH,
+                     std::min(sizeof(SystemVersionData::VERSION_HASH), 0x40ull), 0x28);
+    file->WriteArray(SystemVersionData::DISPLAY_VERSION,
+                     std::min(sizeof(SystemVersionData::DISPLAY_VERSION), 0x18ull), 0x68);
+    file->WriteArray(SystemVersionData::DISPLAY_TITLE,
+                     std::min(sizeof(SystemVersionData::DISPLAY_TITLE), 0x80ull), 0x80);
+    return std::make_shared<VectorVfsDirectory>(std::vector<VirtualFile>{file},
+                                                std::vector<VirtualDir>{}, "data");
+}
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/system_version.h
+++ b/src/core/file_sys/system_archive/system_version.h
@@ -1,0 +1,13 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/file_sys/vfs_types.h"
+
+namespace FileSys::SystemArchive {
+
+VirtualDir SystemVersion();
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/system_version.h
+++ b/src/core/file_sys/system_archive/system_version.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <string>
 #include "core/file_sys/vfs_types.h"
 
 namespace FileSys::SystemArchive {
+
+std::string GetLongDisplayVersion();
 
 VirtualDir SystemVersion();
 

--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -13,6 +13,7 @@
 
 namespace Service::Set {
 
+namespace {
 constexpr u64 SYSTEM_VERSION_FILE_MINOR_REVISION_OFFSET = 0x05;
 
 enum class GetFirmwareVersionType {
@@ -20,7 +21,6 @@ enum class GetFirmwareVersionType {
     Version2,
 };
 
-namespace {
 void GetFirmwareVersionImpl(Kernel::HLERequestContext& ctx, GetFirmwareVersionType type) {
     LOG_WARNING(Service_SET, "called - Using hardcoded firmware version '{}'",
                 FileSys::SystemArchive::GetLongDisplayVersion());

--- a/src/core/hle/service/set/set_sys.h
+++ b/src/core/hle/service/set/set_sys.h
@@ -20,6 +20,8 @@ private:
         BasicBlack = 1,
     };
 
+    void GetFirmwareVersion(Kernel::HLERequestContext& ctx);
+    void GetFirmwareVersion2(Kernel::HLERequestContext& ctx);
     void GetColorSetId(Kernel::HLERequestContext& ctx);
     void SetColorSetId(Kernel::HLERequestContext& ctx);
 


### PR DESCRIPTION
Uses the synthesized system archive 9 (SystemVersion) and reports v5.1.0-0.0