### PR TITLE
service/service: Remove unncessary calls to c_str()

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -76,7 +76,8 @@ namespace Service {
  * Creates a function string for logging, complete with the name (or header code, depending
  * on what's passed in) the port name, and all the cmd_buff arguments.
  */
-[[maybe_unused]] static std::string MakeFunctionString(const char* name, const char* port_name,
+[[maybe_unused]] static std::string MakeFunctionString(std::string_view name,
+                                                       std::string_view port_name,
                                                        const u32* cmd_buff) {
     // Number of params == bits 0-5 + bits 6-11
     int num_params = (cmd_buff[0] & 0x3F) + ((cmd_buff[0] >> 6) & 0x3F);
@@ -158,9 +159,7 @@ void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {
         return ReportUnimplementedFunction(ctx, info);
     }
 
-    LOG_TRACE(
-        Service, "{}",
-        MakeFunctionString(info->name, GetServiceName().c_str(), ctx.CommandBuffer()).c_str());
+    LOG_TRACE(Service, "{}", MakeFunctionString(info->name, GetServiceName(), ctx.CommandBuffer()));
     handler_invoker(this, info->handler_callback, ctx);
 }
 


### PR DESCRIPTION
These can just be passed regularly, now that we use fmt instead of our
old logging system.

While we're at it, make the parameters to MakeFunctionString
std::string_views.