### PR TITLE
core/hle/result: Tidy up the base error code result header. 

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -19,8 +19,11 @@
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/server_session.h"
+#include "core/hle/result.h"
 
 namespace IPC {
+
+constexpr ResultCode ERR_REMOTE_PROCESS_DEAD{ErrorModule::HIPC, 301};
 
 class RequestHelperBase {
 protected:

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -128,11 +128,6 @@ union ResultCode {
     constexpr ResultCode(ErrorModule module_, u32 description_)
         : raw(module.FormatValue(module_) | description.FormatValue(description_)) {}
 
-    constexpr ResultCode& operator=(const ResultCode& o) {
-        raw = o.raw;
-        return *this;
-    }
-
     constexpr bool IsSuccess() const {
         return raw == 0;
     }

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -13,13 +13,6 @@
 // All the constants in this file come from http://switchbrew.org/index.php?title=Error_codes
 
 /**
- * Detailed description of the error. Code 0 always means success.
- */
-enum class ErrorDescription : u32 {
-    Success = 0,
-};
-
-/**
  * Identifies the module which caused the error. Error codes can be propagated through a call
  * chain, meaning that this doesn't always correspond to the module where the API call made is
  * contained.
@@ -131,9 +124,6 @@ union ResultCode {
     BitField<31, 1, u32> is_error;
 
     constexpr explicit ResultCode(u32 raw) : raw(raw) {}
-
-    constexpr ResultCode(ErrorModule module, ErrorDescription description)
-        : ResultCode(module, static_cast<u32>(description)) {}
 
     constexpr ResultCode(ErrorModule module_, u32 description_)
         : raw(module.FormatValue(module_) | description.FormatValue(description_)) {}

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -17,7 +17,6 @@
  */
 enum class ErrorDescription : u32 {
     Success = 0,
-    RemoteProcessDead = 301,
 };
 
 /**

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -112,7 +112,7 @@ enum class ErrorModule : u32 {
     ShopN = 811,
 };
 
-/// Encapsulates a CTR-OS error code, allowing it to be separated into its constituent fields.
+/// Encapsulates a Horizon OS error code, allowing it to be separated into its constituent fields.
 union ResultCode {
     u32 raw;
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -11,7 +11,6 @@
 #include "core/hle/ipc.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_port.h"
-#include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/server_port.h"
@@ -169,7 +168,7 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
     case IPC::CommandType::Close: {
         IPC::ResponseBuilder rb{context, 2};
         rb.Push(RESULT_SUCCESS);
-        return ResultCode(ErrorModule::HIPC, ErrorDescription::RemoteProcessDead);
+        return IPC::ERR_REMOTE_PROCESS_DEAD;
     }
     case IPC::CommandType::ControlWithContext:
     case IPC::CommandType::Control: {


### PR DESCRIPTION
With the recent changes done to BitField, we can remove an unnecessary copy assignment operator. By moving the lone IPC-related error to the IPC utilities, we can then remove an unnecessary constructor.