### PR TITLE
Revert "Devirtualize Register/Unregister and use a wrapper instead."

### DIFF
--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -132,7 +132,7 @@ protected:
     }
 
     /// Register an object into the cache
-    void Register(const T& object) {
+    virtual void Register(const T& object) {
         std::lock_guard<std::recursive_mutex> lock{mutex};
 
         object->SetIsRegistered(true);
@@ -142,7 +142,7 @@ protected:
     }
 
     /// Unregisters an object from the cache
-    void Unregister(const T& object) {
+    virtual void Unregister(const T& object) {
         std::lock_guard<std::recursive_mutex> lock{mutex};
 
         object->SetIsRegistered(false);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -941,7 +941,7 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
             // If surface parameters changed and we care about keeping the previous data, recreate
             // the surface from the old one
             Surface new_surface{RecreateSurface(surface, params)};
-            UnregisterSurface(surface);
+            Unregister(surface);
             Register(new_surface);
             if (new_surface->IsUploaded()) {
                 RegisterReinterpretSurface(new_surface);
@@ -949,7 +949,7 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
             return new_surface;
         } else {
             // Delete the old surface before creating a new one to prevent collisions.
-            UnregisterSurface(surface);
+            Unregister(surface);
         }
     }
 
@@ -1304,12 +1304,12 @@ static bool IsReinterpretInvalidSecond(const Surface render_surface,
 bool RasterizerCacheOpenGL::PartialReinterpretSurface(Surface triggering_surface,
                                                       Surface intersect) {
     if (IsReinterpretInvalid(triggering_surface, intersect)) {
-        UnregisterSurface(intersect);
+        Unregister(intersect);
         return false;
     }
     if (!LayerFitReinterpretSurface(*this, triggering_surface, intersect)) {
         if (IsReinterpretInvalidSecond(triggering_surface, intersect)) {
-            UnregisterSurface(intersect);
+            Unregister(intersect);
             return false;
         }
         FlushObject(intersect);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -533,13 +533,17 @@ private:
         return nullptr;
     }
 
+    void Register(const Surface& object) {
+        RasterizerCache<Surface>::Register(object);
+    }
+
     /// Unregisters an object from the cache
-    void UnregisterSurface(const Surface& object) {
+    void Unregister(const Surface& object) {
         if (object->IsReinterpreted()) {
             auto interval = GetReinterpretInterval(object);
             reinterpreted_surfaces.erase(interval);
         }
-        Unregister(object);
+        RasterizerCache<Surface>::Unregister(object);
     }
 };
 


### PR DESCRIPTION
- Fixes graphical issues from transitions in Super Mario Odyssey.