### PR TITLE
core/hle/kernel: Split transfer memory handling out into its own class

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -140,6 +140,8 @@ add_library(core STATIC
     hle/kernel/svc_wrap.h
     hle/kernel/thread.cpp
     hle/kernel/thread.h
+    hle/kernel/transfer_memory.cpp
+    hle/kernel/transfer_memory.h
     hle/kernel/vm_manager.cpp
     hle/kernel/vm_manager.h
     hle/kernel/wait_object.cpp

--- a/src/core/hle/kernel/object.cpp
+++ b/src/core/hle/kernel/object.cpp
@@ -23,6 +23,7 @@ bool Object::IsWaitable() const {
     case HandleType::Unknown:
     case HandleType::WritableEvent:
     case HandleType::SharedMemory:
+    case HandleType::TransferMemory:
     case HandleType::AddressArbiter:
     case HandleType::ResourceLimit:
     case HandleType::ClientPort:

--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -22,6 +22,7 @@ enum class HandleType : u32 {
     WritableEvent,
     ReadableEvent,
     SharedMemory,
+    TransferMemory,
     Thread,
     Process,
     AddressArbiter,

--- a/src/core/hle/kernel/transfer_memory.cpp
+++ b/src/core/hle/kernel/transfer_memory.cpp
@@ -1,0 +1,73 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/kernel/shared_memory.h"
+#include "core/hle/kernel/transfer_memory.h"
+#include "core/hle/result.h"
+
+namespace Kernel {
+
+TransferMemory::TransferMemory(KernelCore& kernel) : Object{kernel} {}
+TransferMemory::~TransferMemory() = default;
+
+SharedPtr<TransferMemory> TransferMemory::Create(KernelCore& kernel, VAddr base_address,
+                                                 size_t size, MemoryPermission permissions) {
+    SharedPtr<TransferMemory> transfer_memory{new TransferMemory(kernel)};
+
+    transfer_memory->base_address = base_address;
+    transfer_memory->memory_size = size;
+    transfer_memory->owner_permissions = permissions;
+    transfer_memory->owner_process = kernel.CurrentProcess();
+
+    return transfer_memory;
+}
+
+ResultCode TransferMemory::MapMemory(VAddr address, size_t size, MemoryPermission permissions) {
+    if (memory_size != size) {
+        return ERR_INVALID_SIZE;
+    }
+
+    if (owner_permissions != permissions) {
+        return ERR_INVALID_STATE;
+    }
+
+    if (is_mapped) {
+        return ERR_INVALID_STATE;
+    }
+
+    const auto map_state = owner_permissions == MemoryPermission::None
+                               ? MemoryState::TransferMemoryIsolated
+                               : MemoryState::TransferMemory;
+    auto& vm_manager = owner_process->VMManager();
+    const auto map_result = vm_manager.MapMemoryBlock(
+        address, std::make_shared<std::vector<u8>>(size), 0, size, map_state);
+
+    if (map_result.Failed()) {
+        return map_result.Code();
+    }
+
+    is_mapped = true;
+    return RESULT_SUCCESS;
+}
+
+ResultCode TransferMemory::UnmapMemory(VAddr address, size_t size) {
+    if (memory_size != size) {
+        return ERR_INVALID_SIZE;
+    }
+
+    auto& vm_manager = owner_process->VMManager();
+    const auto result = vm_manager.UnmapRange(address, size);
+
+    if (result.IsError()) {
+        return result;
+    }
+
+    is_mapped = false;
+    return RESULT_SUCCESS;
+}
+
+} // namespace Kernel


### PR DESCRIPTION
Within the kernel, shared memory and transfer memory facilities exist as completely different kernel objects. They also have different validity checking as well. Therefore, we shouldn't be treating the two as the same kind of memory.

They also differ in terms of their behavioral aspect as well. Shared memory is intended for sharing memory between processes, while transfer memory is intended to be for transferring memory to other processes.

This breaks out the handling for transfer memory into its own class and treats it as its own kernel object. This is also important when we consider resource limits as well. Particularly because transfer memory is limited by the resource limit value set for it. While we currently don't handle resource limit testing against objects yet (but we do allow setting them), this will make implementing that behavior much easier in the future, as we don't need to distinguish between shared memory and transfer memory allocations in the same place.

While we're at it, this also implements svcMapTransferMemory and svcUnmapTransferMemory, which completes the svc interface when it comes to transfer memory.