### PR TITLE
Allow picking a Compatibility Profile for OpenGL. 

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -90,6 +90,7 @@ void LogSettings() {
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);
     LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);
     LogSetting("Renderer_FrameLimit", Settings::values.frame_limit);
+    LogSetting("Renderer_UseCompatibilityProfile", Settings::values.use_compatibility_profile);
     LogSetting("Renderer_UseDiskShaderCache", Settings::values.use_disk_shader_cache);
     LogSetting("Renderer_UseAccurateGpuEmulation", Settings::values.use_accurate_gpu_emulation);
     LogSetting("Renderer_UseAsynchronousGpuEmulation",

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -390,6 +390,7 @@ struct Values {
     float resolution_factor;
     bool use_frame_limit;
     u16 frame_limit;
+    bool use_compatibility_profile;
     bool use_disk_shader_cache;
     bool use_accurate_gpu_emulation;
     bool use_asynchronous_gpu_emulation;

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -377,7 +377,11 @@ void GRenderWindow::InitRenderTarget() {
     // WA_DontShowOnScreen, WA_DeleteOnClose
     QSurfaceFormat fmt;
     fmt.setVersion(4, 3);
-    fmt.setProfile(QSurfaceFormat::CoreProfile);
+    if (Settings::values.use_compatibility_profile) {
+        fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
+    } else {
+        fmt.setProfile(QSurfaceFormat::CoreProfile);
+    }
     // TODO: expose a setting for buffer value (ie default/single/double/triple)
     fmt.setSwapBehavior(QSurfaceFormat::DefaultSwapBehavior);
     shared_context = std::make_unique<QOpenGLContext>();

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -389,6 +389,8 @@ void Config::ReadValues() {
     Settings::values.resolution_factor = ReadSetting("resolution_factor", 1.0).toFloat();
     Settings::values.use_frame_limit = ReadSetting("use_frame_limit", true).toBool();
     Settings::values.frame_limit = ReadSetting("frame_limit", 100).toInt();
+    Settings::values.use_compatibility_profile =
+        ReadSetting("use_compatibility_profile", true).toBool();
     Settings::values.use_disk_shader_cache = ReadSetting("use_disk_shader_cache", true).toBool();
     Settings::values.use_accurate_gpu_emulation =
         ReadSetting("use_accurate_gpu_emulation", false).toBool();
@@ -661,6 +663,7 @@ void Config::SaveValues() {
     WriteSetting("resolution_factor", (double)Settings::values.resolution_factor, 1.0);
     WriteSetting("use_frame_limit", Settings::values.use_frame_limit, true);
     WriteSetting("frame_limit", Settings::values.frame_limit, 100);
+    WriteSetting("use_compatibility_profile", Settings::values.use_compatibility_profile, true);
     WriteSetting("use_disk_shader_cache", Settings::values.use_disk_shader_cache, true);
     WriteSetting("use_accurate_gpu_emulation", Settings::values.use_accurate_gpu_emulation, false);
     WriteSetting("use_asynchronous_gpu_emulation", Settings::values.use_asynchronous_gpu_emulation,

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -73,6 +73,7 @@ void ConfigureGraphics::setConfiguration() {
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
     ui->frame_limit->setValue(Settings::values.frame_limit);
+    ui->use_compatibility_profile->setChecked(Settings::values.use_compatibility_profile);
     ui->use_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache);
     ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
     ui->use_asynchronous_gpu_emulation->setEnabled(!Core::System::GetInstance().IsPoweredOn());
@@ -88,6 +89,7 @@ void ConfigureGraphics::applyConfiguration() {
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.use_frame_limit = ui->toggle_frame_limit->isChecked();
     Settings::values.frame_limit = ui->frame_limit->value();
+    Settings::values.use_compatibility_profile = ui->use_compatibility_profile->isChecked();
     Settings::values.use_disk_shader_cache = ui->use_disk_shader_cache->isChecked();
     Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values.use_asynchronous_gpu_emulation =

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -50,6 +50,13 @@
          </layout>
         </item>
         <item>
+         <widget class="QCheckBox" name="use_compatibility_profile">
+          <property name="text">
+           <string>Use OpenGL compatibility profile</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="use_disk_shader_cache">
           <property name="text">
            <string>Use disk shader cache</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -349,6 +349,8 @@ void Config::ReadValues() {
     Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));
+    Settings::values.use_compatibility_profile =
+        sdl2_config->GetBoolean("Renderer", "use_compatibility_profile", true);
     Settings::values.use_disk_shader_cache =
         sdl2_config->GetBoolean("Renderer", "use_disk_shader_cache", false);
     Settings::values.use_accurate_gpu_emulation =


### PR DESCRIPTION
Allowing the compatibility profile to be selected will ease our work on debugging yuzu as currently some games are fixed under it. We are currently researching the reason behind it.