### PR TITLE
loader/nso: Remove left-in debug pragma

### DIFF
--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -21,8 +21,6 @@
 #include "core/memory.h"
 #include "core/settings.h"
 
-#pragma optimize("", off)
-
 namespace Loader {
 namespace {
 struct MODHeader {


### PR DESCRIPTION
Unintentionally introduced in 552d5071fa171165e4054392d8bb6bf2ecc924e2