### PR TITLE
gl_shader_disk_cache: Skip stored shader variants instead of asserting 

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -475,7 +475,10 @@ void ShaderDiskCacheOpenGL::SaveUsage(const ShaderDiskCacheUsage& usage) {
     ASSERT_MSG(it != transferable.end(), "Saving shader usage without storing raw previously");
 
     auto& usages{it->second};
-    ASSERT(usages.find(usage) == usages.end());
+    if (usages.find(usage) != usages.end()) {
+        // Skip this variant since the shader is already stored.
+        return;
+    }
     usages.insert(usage);
 
     FileUtil::IOFile file = AppendTransferableFile();


### PR DESCRIPTION
Instead of asserting on already stored shader variants, silently skip them.

This shouldn't be happening but when a shader is invalidated and it is not stored in the shader cache, this assert would hit and save that shader anyways when the asserts are disabled.

I want to know if this is related to games dumping more shaders than what they should.