### PR TITLE
common/zstd_compression: Remove #pragma once directive from source file

### DIFF
--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include <algorithm>
 #include <zstd.h>
 


### PR DESCRIPTION
Introduced in 72477731ed20c56a4d6f18a22f43224fab667cef. This is only
necessary within header files.