### PR TITLE
core/telemetry_session: Only create the backend when we really need it

### DIFF
--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -102,12 +102,6 @@ bool VerifyLogin(const std::string& username, const std::string& token) {
 }
 
 TelemetrySession::TelemetrySession() {
-#ifdef ENABLE_WEB_SERVICE
-    backend = std::make_unique<WebService::TelemetryJson>(
-        Settings::values.web_api_url, Settings::values.yuzu_username, Settings::values.yuzu_token);
-#else
-    backend = std::make_unique<Telemetry::NullVisitor>();
-#endif
     // Log one-time top-level information
     AddField(Telemetry::FieldType::None, "TelemetryId", GetTelemetryId());
 
@@ -175,9 +169,14 @@ TelemetrySession::~TelemetrySession() {
                                 .count()};
     AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
 
+#ifdef ENABLE_WEB_SERVICE
+    auto backend = std::make_unique<WebService::TelemetryJson>(
+        Settings::values.web_api_url, Settings::values.yuzu_username, Settings::values.yuzu_token);
+#else
+    auto backend = std::make_unique<Telemetry::NullVisitor>();
+#endif
+
     // Complete the session, submitting to web service if necessary
-    // This is just a placeholder to wrap up the session once the core completes and this is
-    // destroyed. This will be moved elsewhere once we are actually doing real I/O with the service.
     field_collection.Accept(*backend);
     if (Settings::values.enable_telemetry)
         backend->Complete();
@@ -186,6 +185,8 @@ TelemetrySession::~TelemetrySession() {
 
 bool TelemetrySession::SubmitTestcase() {
 #ifdef ENABLE_WEB_SERVICE
+    auto backend = std::make_unique<WebService::TelemetryJson>(
+        Settings::values.web_api_url, Settings::values.yuzu_username, Settings::values.yuzu_token);
     field_collection.Accept(*backend);
     return backend->SubmitTestcase();
 #else

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -39,7 +39,6 @@ public:
 
 private:
     Telemetry::FieldCollection field_collection; ///< Tracks all added fields for the session
-    std::unique_ptr<Telemetry::VisitorInterface> backend; ///< Backend interface that logs fields
 };
 
 /**


### PR DESCRIPTION
The backend is not used until we decide to submit the testcase/telemetry, and creating it early prevents users from updating the credentials properly while the games are running.