### PR TITLE
yuzu/hotkeys: Remove unnecessary constructor

### DIFF
--- a/src/yuzu/hotkeys.h
+++ b/src/yuzu/hotkeys.h
@@ -67,8 +67,6 @@ public:
 
 private:
     struct Hotkey {
-        Hotkey() : shortcut(nullptr), context(Qt::WindowShortcut) {}
-
         QKeySequence keyseq;
         QShortcut* shortcut = nullptr;
         Qt::ShortcutContext context = Qt::WindowShortcut;


### PR DESCRIPTION
The behavior of the Hotkey constructor is already accomplished via in-class member
initializers, so the constructor is superfluous here.