### PR TITLE
video_core/gpu_thread: Remove redundant copy constructor for CommandDataContainer 

### DIFF
--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -81,12 +81,6 @@ struct CommandDataContainer {
     CommandDataContainer(CommandData&& data, u64 next_fence)
         : data{std::move(data)}, fence{next_fence} {}
 
-    CommandDataContainer& operator=(const CommandDataContainer& t) {
-        data = std::move(t.data);
-        fence = t.fence;
-        return *this;
-    }
-
     CommandData data;
     u64 fence{};
 };


### PR DESCRIPTION
std::move within a copy constructor (on a data member that isn't mutable) will always result in a copy. Because of that, the behavior of this copy constructor is identical to the one that would be generated automatically by the compiler, so we can remove it.