### PR TITLE
video_core/engines/engine_upload: Minor tidying

### DIFF
--- a/src/video_core/engines/engine_upload.cpp
+++ b/src/video_core/engines/engine_upload.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "common/assert.h"
 #include "video_core/engines/engine_upload.h"
 #include "video_core/memory_manager.h"

--- a/src/video_core/engines/engine_upload.cpp
+++ b/src/video_core/engines/engine_upload.cpp
@@ -12,7 +12,7 @@
 namespace Tegra::Engines::Upload {
 
 State::State(MemoryManager& memory_manager, Registers& regs)
-    : memory_manager(memory_manager), regs(regs) {}
+    : regs{regs}, memory_manager{memory_manager} {}
 
 State::~State() = default;
 

--- a/src/video_core/engines/engine_upload.cpp
+++ b/src/video_core/engines/engine_upload.cpp
@@ -14,6 +14,8 @@ namespace Tegra::Engines::Upload {
 State::State(MemoryManager& memory_manager, Registers& regs)
     : memory_manager(memory_manager), regs(regs) {}
 
+State::~State() = default;
+
 void State::ProcessExec(const bool is_linear) {
     write_offset = 0;
     copy_size = regs.line_length_in * regs.line_count;

--- a/src/video_core/engines/engine_upload.h
+++ b/src/video_core/engines/engine_upload.h
@@ -55,7 +55,7 @@ struct Registers {
 class State {
 public:
     State(MemoryManager& memory_manager, Registers& regs);
-    ~State() = default;
+    ~State();
 
     void ProcessExec(bool is_linear);
     void ProcessData(u32 data, bool is_last_call);

--- a/src/video_core/engines/engine_upload.h
+++ b/src/video_core/engines/engine_upload.h
@@ -4,10 +4,8 @@
 
 #pragma once
 
-#include <cstddef>
 #include <vector>
 #include "common/bit_field.h"
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Tegra {

--- a/src/video_core/engines/engine_upload.h
+++ b/src/video_core/engines/engine_upload.h
@@ -57,8 +57,8 @@ public:
     State(MemoryManager& memory_manager, Registers& regs);
     ~State() = default;
 
-    void ProcessExec(const bool is_linear);
-    void ProcessData(const u32 data, const bool is_last_call);
+    void ProcessExec(bool is_linear);
+    void ProcessData(u32 data, bool is_last_call);
 
 private:
     u32 write_offset = 0;


### PR DESCRIPTION
Resolves a -Wreorder compilation warning and makes the class potentially not result in a compilation error with regards to forward declarations. The rest is minor tidying up.