### PR TITLE
yuzu: Remove explicit types from locks where applicable

### DIFF
--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -118,7 +118,7 @@ void SynchState::WaitForSynchronization(u64 fence) {
     // Wait for the GPU to be idle (all commands to be executed)
     {
         MICROPROFILE_SCOPE(GPU_wait);
-        std::unique_lock<std::mutex> lock{synchronization_mutex};
+        std::unique_lock lock{synchronization_mutex};
         synchronization_condition.wait(lock, [this, fence] { return signaled_fence >= fence; });
     }
 }

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -109,7 +109,7 @@ struct SynchState final {
 
     void TrySynchronize() {
         if (IsSynchronized()) {
-            std::lock_guard<std::mutex> lock{synchronization_mutex};
+            std::lock_guard lock{synchronization_mutex};
             synchronization_condition.notify_one();
         }
     }

--- a/src/yuzu/applets/error.cpp
+++ b/src/yuzu/applets/error.cpp
@@ -54,6 +54,6 @@ void QtErrorDisplay::ShowCustomErrorText(ResultCode error, std::string dialog_te
 
 void QtErrorDisplay::MainWindowFinishedError() {
     // Acquire the HLE mutex
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     callback();
 }


### PR DESCRIPTION
With C++17's deduction guides, the type doesn't need to be explicitly
specified within locking primitives anymore.