### PR TITLE
video_core/engines/maxwell_3d: Add is_trivially_copyable_v check for Regs 

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <bitset>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -1107,6 +1108,7 @@ public:
     } regs{};
 
     static_assert(sizeof(Regs) == Regs::NUM_REGS * sizeof(u32), "Maxwell3D Regs has wrong size");
+    static_assert(std::is_trivially_copyable_v<Regs>, "Maxwell3D Regs must be trivially copyable");
 
     struct State {
         struct ConstBufferInfo {


### PR DESCRIPTION
std::memset is used to clear the entire register structure, which requires that the Regs struct be trivially copyable (otherwise undefined behavior is invoked). This prevents the case where a non-trivial type is potentially added to the struct.