### PR TITLE
yuzu/bootmanager: Explicitly enable deprecated OpenGL features on compat

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -379,6 +379,7 @@ void GRenderWindow::InitRenderTarget() {
     fmt.setVersion(4, 3);
     if (Settings::values.use_compatibility_profile) {
         fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
+        fmt.setOption(QSurfaceFormat::FormatOption::DeprecatedFunctions);
     } else {
         fmt.setProfile(QSurfaceFormat::CoreProfile);
     }


### PR DESCRIPTION
Nvidia's proprietary driver creates a real OpenGL compatibility profile
without this option, meanwhile Intel (and probably AMD, I haven't tested
it) require that QSurfaceFormat::FormatOption::DeprecatedFunctions is
explicitly enabled.