### PR TITLE
yuzu_cmd: Make OpenGL's context current

### DIFF
--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -222,6 +222,7 @@ int main(int argc, char** argv) {
 
     system.TelemetrySession().AddField(Telemetry::FieldType::App, "Frontend", "SDL");
 
+    emu_window->MakeCurrent();
     system.Renderer().Rasterizer().LoadDiskResources();
 
     while (emu_window->IsOpen()) {


### PR DESCRIPTION
The SDL2 frontend never bound the OpenGL context, resulting on a white
screen and no-ops all over the backend.