### PR TITLE
ipc_helpers: Amend floating-point type in Pop<double> specialization

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -438,7 +438,7 @@ inline float RequestParser::Pop() {
 template <>
 inline double RequestParser::Pop() {
     const u64 value = Pop<u64>();
-    float real;
+    double real;
     std::memcpy(&real, &value, sizeof(real));
     return real;
 }


### PR DESCRIPTION
Currently, this overload isn't used, so this wasn't actually hit in any
code, only the float overload is used.