### PR TITLE
yuzu/configuration: Specify string conversions explicitly 

### DIFF
--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -28,8 +28,9 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     connect(ui->output_sink_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &ConfigureAudio::updateAudioDevices);
 
-    ui->output_sink_combo_box->setEnabled(!Core::System::GetInstance().IsPoweredOn());
-    ui->audio_device_combo_box->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    const bool is_powered_on = Core::System::GetInstance().IsPoweredOn();
+    ui->output_sink_combo_box->setEnabled(!is_powered_on);
+    ui->audio_device_combo_box->setEnabled(!is_powered_on);
 }
 
 ConfigureAudio::~ConfigureAudio() = default;

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -16,9 +16,9 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     ui->setupUi(this);
 
     ui->output_sink_combo_box->clear();
-    ui->output_sink_combo_box->addItem("auto");
+    ui->output_sink_combo_box->addItem(QString::fromUtf8(AudioCore::auto_device_name));
     for (const char* id : AudioCore::GetSinkIDs()) {
-        ui->output_sink_combo_box->addItem(id);
+        ui->output_sink_combo_box->addItem(QString::fromUtf8(id));
     }
 
     connect(ui->volume_slider, &QSlider::valueChanged, this,
@@ -94,7 +94,7 @@ void ConfigureAudio::applyConfiguration() {
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {
     ui->audio_device_combo_box->clear();
-    ui->audio_device_combo_box->addItem(AudioCore::auto_device_name);
+    ui->audio_device_combo_box->addItem(QString::fromUtf8(AudioCore::auto_device_name));
 
     const std::string sink_id = ui->output_sink_combo_box->itemText(sink_index).toStdString();
     for (const auto& device : AudioCore::GetDeviceListForSink(sink_id)) {

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -25,8 +25,7 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
             &ConfigureAudio::setVolumeIndicatorText);
 
     this->setConfiguration();
-    connect(ui->output_sink_combo_box,
-            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+    connect(ui->output_sink_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &ConfigureAudio::updateAudioDevices);
 
     ui->output_sink_combo_box->setEnabled(!Core::System::GetInstance().IsPoweredOn());

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -100,13 +100,15 @@ void ConfigureGameList::RetranslateUI() {
 
 void ConfigureGameList::InitializeIconSizeComboBox() {
     for (const auto& size : default_icon_sizes) {
-        ui->icon_size_combobox->addItem(size.second, size.first);
+        ui->icon_size_combobox->addItem(QString::fromUtf8(size.second), size.first);
     }
 }
 
 void ConfigureGameList::InitializeRowComboBoxes() {
     for (std::size_t i = 0; i < row_text_names.size(); ++i) {
-        ui->row_1_text_combobox->addItem(row_text_names[i], QVariant::fromValue(i));
-        ui->row_2_text_combobox->addItem(row_text_names[i], QVariant::fromValue(i));
+        const QString row_text_name = QString::fromUtf8(row_text_names[i]);
+
+        ui->row_1_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
+        ui->row_2_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
     }
 }

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -14,7 +14,8 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     ui->setupUi(this);
 
     for (const auto& theme : UISettings::themes) {
-        ui->theme_combobox->addItem(theme.first, theme.second);
+        ui->theme_combobox->addItem(QString::fromUtf8(theme.first),
+                                    QString::fromUtf8(theme.second));
     }
 
     this->setConfiguration();

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -75,8 +75,8 @@ ConfigureInput::ConfigureInput(QWidget* parent)
     };
 
     for (auto* controller_box : players_controller) {
-        controller_box->addItems({"None", "Pro Controller", "Dual Joycons", "Single Right Joycon",
-                                  "Single Left Joycon"});
+        controller_box->addItems({tr("None"), tr("Pro Controller"), tr("Dual Joycons"),
+                                  tr("Single Right Joycon"), tr("Single Left Joycon")});
     }
 
     this->loadConfiguration();
@@ -85,9 +85,10 @@ ConfigureInput::ConfigureInput(QWidget* parent)
     connect(ui->restore_defaults_button, &QPushButton::pressed, this,
             &ConfigureInput::restoreDefaults);
 
-    for (auto* enabled : players_controller)
+    for (auto* enabled : players_controller) {
         connect(enabled, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
                 &ConfigureInput::updateUIEnabled);
+    }
     connect(ui->use_docked_mode, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
     connect(ui->handheld_connected, &QCheckBox::stateChanged, this,
             &ConfigureInput::updateUIEnabled);
@@ -147,10 +148,12 @@ void ConfigureInput::updateUIEnabled() {
     bool hit_disabled = false;
     for (auto* player : players_controller) {
         player->setDisabled(hit_disabled);
-        if (hit_disabled)
+        if (hit_disabled) {
             player->setCurrentIndex(0);
-        if (!hit_disabled && player->currentIndex() == 0)
+        }
+        if (!hit_disabled && player->currentIndex() == 0) {
             hit_disabled = true;
+        }
     }
 
     for (std::size_t i = 0; i < players_controller.size(); ++i) {

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -45,7 +45,7 @@ static QString GetKeyName(int key_code) {
     case Qt::Key_Alt:
         return QObject::tr("Alt");
     case Qt::Key_Meta:
-        return "";
+        return {};
     default:
         return QKeySequence(key_code).toString();
     }
@@ -65,46 +65,70 @@ static void SetAnalogButton(const Common::ParamPackage& input_param,
 static QString ButtonToText(const Common::ParamPackage& param) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "keyboard") {
-        return GetKeyName(param.Get("code", 0));
-    } else if (param.Get("engine", "") == "sdl") {
-        if (param.Has("hat")) {
-            return QString(QObject::tr("Hat %1 %2"))
-                .arg(param.Get("hat", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("axis")) {
-            return QString(QObject::tr("Axis %1%2"))
-                .arg(param.Get("axis", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("button")) {
-            return QString(QObject::tr("Button %1")).arg(param.Get("button", "").c_str());
-        }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
     }
-};
+
+    if (param.Get("engine", "") == "keyboard") {
+        return GetKeyName(param.Get("code", 0));
+    }
+
+    if (param.Get("engine", "") == "sdl") {
+        if (param.Has("hat")) {
+            const QString hat_str = QString::fromStdString(param.Get("hat", ""));
+            const QString direction_str = QString::fromStdString(param.Get("direction", ""));
+
+            return QObject::tr("Hat %1 %2").arg(hat_str, direction_str);
+        }
+
+        if (param.Has("axis")) {
+            const QString axis_str = QString::fromStdString(param.Get("axis", ""));
+            const QString direction_str = QString::fromStdString(param.Get("direction", ""));
+
+            return QObject::tr("Axis %1%2").arg(axis_str, direction_str);
+        }
+
+        if (param.Has("button")) {
+            const QString button_str = QString::fromStdString(param.Get("button", ""));
+
+            return QObject::tr("Button %1").arg(button_str);
+        }
+
+        return {};
+    }
+
+    return QObject::tr("[unknown]");
+}
 
 static QString AnalogToText(const Common::ParamPackage& param, const std::string& dir) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "analog_from_button") {
+    }
+
+    if (param.Get("engine", "") == "analog_from_button") {
         return ButtonToText(Common::ParamPackage{param.Get(dir, "")});
-    } else if (param.Get("engine", "") == "sdl") {
+    }
+
+    if (param.Get("engine", "") == "sdl") {
         if (dir == "modifier") {
-            return QString(QObject::tr("[unused]"));
+            return QObject::tr("[unused]");
         }
 
         if (dir == "left" || dir == "right") {
-            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_x", "").c_str());
-        } else if (dir == "up" || dir == "down") {
-            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_y", "").c_str());
+            const QString axis_x_str = QString::fromStdString(param.Get("axis_x", ""));
+
+            return QObject::tr("Axis %1").arg(axis_x_str);
         }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
+
+        if (dir == "up" || dir == "down") {
+            const QString axis_y_str = QString::fromStdString(param.Get("axis_y", ""));
+
+            return QObject::tr("Axis %1").arg(axis_y_str);
+        }
+
+        return {};
     }
-};
+
+    return QObject::tr("[unknown]");
+}
 
 ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_index, bool debug)
     : QDialog(parent), ui(std::make_unique<Ui::ConfigureInputPlayer>()), player_index(player_index),
@@ -351,7 +375,7 @@ void ConfigureInputPlayer::OnControllerButtonClick(int i) {
         return;
     controller_colors[i] = new_bg_color;
     controller_color_buttons[i]->setStyleSheet(
-        QString("QPushButton { background-color: %1 }").arg(controller_colors[i].name()));
+        QStringLiteral("QPushButton { background-color: %1 }").arg(controller_colors[i].name()));
 }
 
 void ConfigureInputPlayer::loadConfiguration() {
@@ -388,7 +412,8 @@ void ConfigureInputPlayer::loadConfiguration() {
 
     for (std::size_t i = 0; i < colors.size(); ++i) {
         controller_color_buttons[i]->setStyleSheet(
-            QString("QPushButton { background-color: %1 }").arg(controller_colors[i].name()));
+            QStringLiteral("QPushButton { background-color: %1 }")
+                .arg(controller_colors[i].name()));
     }
 }
 

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -25,7 +25,7 @@ static QString GetKeyName(int key_code) {
     case Qt::Key_Alt:
         return QObject::tr("Alt");
     case Qt::Key_Meta:
-        return "";
+        return {};
     default:
         return QKeySequence(key_code).toString();
     }
@@ -34,24 +34,36 @@ static QString GetKeyName(int key_code) {
 static QString ButtonToText(const Common::ParamPackage& param) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "keyboard") {
-        return GetKeyName(param.Get("code", 0));
-    } else if (param.Get("engine", "") == "sdl") {
-        if (param.Has("hat")) {
-            return QString(QObject::tr("Hat %1 %2"))
-                .arg(param.Get("hat", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("axis")) {
-            return QString(QObject::tr("Axis %1%2"))
-                .arg(param.Get("axis", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("button")) {
-            return QString(QObject::tr("Button %1")).arg(param.Get("button", "").c_str());
-        }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
     }
+
+    if (param.Get("engine", "") == "keyboard") {
+        return GetKeyName(param.Get("code", 0));
+    }
+
+    if (param.Get("engine", "") == "sdl") {
+        if (param.Has("hat")) {
+            const QString hat_str = QString::fromStdString(param.Get("hat", ""));
+            const QString direction_str = QString::fromStdString(param.Get("direction", ""));
+
+            return QObject::tr("Hat %1 %2").arg(hat_str, direction_str);
+        }
+
+        if (param.Has("axis")) {
+            const QString axis_str = QString::fromStdString(param.Get("axis", ""));
+            const QString direction_str = QString::fromStdString(param.Get("direction", ""));
+
+            return QObject::tr("Axis %1%2").arg(axis_str, direction_str);
+        }
+
+        if (param.Has("button")) {
+            const QString button_str = QString::fromStdString(param.Get("button", ""));
+
+            return QObject::tr("Button %1").arg(button_str);
+        }
+        return {};
+    }
+
+    return QObject::tr("[unknown]");
 }
 
 ConfigureMouseAdvanced::ConfigureMouseAdvanced(QWidget* parent)

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -88,15 +88,15 @@ void ConfigurePerGameGeneral::loadFromFile(FileSys::VirtualFile file) {
 }
 
 void ConfigurePerGameGeneral::loadConfiguration() {
-    if (file == nullptr)
+    if (file == nullptr) {
         return;
+    }
 
-    const auto loader = Loader::GetLoader(file);
-
-    ui->display_title_id->setText(fmt::format("{:016X}", title_id).c_str());
+    ui->display_title_id->setText(QString::fromStdString(fmt::format("{:016X}", title_id)));
 
     FileSys::PatchManager pm{title_id};
     const auto control = pm.GetControlMetadata();
+    const auto loader = Loader::GetLoader(file);
 
     if (control.first != nullptr) {
         ui->display_version->setText(QString::fromStdString(control.first->GetVersionString()));
@@ -142,8 +142,10 @@ void ConfigurePerGameGeneral::loadConfiguration() {
     const auto& disabled = Settings::values.disabled_addons[title_id];
 
     for (const auto& patch : pm.GetPatchVersionNames(update_raw)) {
-        QStandardItem* first_item = new QStandardItem;
-        const auto name = QString::fromStdString(patch.first).replace("[D] ", "");
+        const auto name =
+            QString::fromStdString(patch.first).replace(QStringLiteral("[D] "), QString{});
+
+        auto* const first_item = new QStandardItem;
         first_item->setText(name);
         first_item->setCheckable(true);
 

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -98,7 +98,7 @@ ConfigureProfileManager ::ConfigureProfileManager(QWidget* parent)
     tree_view->setContextMenuPolicy(Qt::NoContextMenu);
 
     item_model->insertColumns(0, 1);
-    item_model->setHeaderData(0, Qt::Horizontal, "Users");
+    item_model->setHeaderData(0, Qt::Horizontal, tr("Users"));
 
     // We must register all custom types with the Qt Automoc system so that we are able to use it
     // with signals/slots. In this case, QList falls under the umbrells of custom types.

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -66,8 +66,9 @@ void ConfigureSystem::setConfiguration() {
     ui->rng_seed_checkbox->setChecked(Settings::values.rng_seed.has_value());
     ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.has_value());
 
-    const auto rng_seed =
-        QString("%1").arg(Settings::values.rng_seed.value_or(0), 8, 16, QLatin1Char{'0'}).toUpper();
+    const auto rng_seed = QStringLiteral("%1")
+                              .arg(Settings::values.rng_seed.value_or(0), 8, 16, QLatin1Char{'0'})
+                              .toUpper();
     ui->rng_seed_edit->setText(rng_seed);
 
     ui->custom_rtc_checkbox->setChecked(Settings::values.custom_rtc.has_value());

--- a/src/yuzu/configuration/configure_web.cpp
+++ b/src/yuzu/configuration/configure_web.cpp
@@ -78,12 +78,16 @@ void ConfigureWeb::RefreshTelemetryID() {
 void ConfigureWeb::OnLoginChanged() {
     if (ui->edit_username->text().isEmpty() && ui->edit_token->text().isEmpty()) {
         user_verified = true;
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
+
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("checked")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
     } else {
         user_verified = false;
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
+
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("failed")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
     }
 }
 
@@ -101,11 +105,15 @@ void ConfigureWeb::OnLoginVerified() {
     ui->button_verify_login->setText(tr("Verify"));
     if (verify_watcher.result()) {
         user_verified = true;
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
+
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("checked")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
     } else {
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("failed")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
+
         QMessageBox::critical(
             this, tr("Verification failed"),
             tr("Verification failed. Check that you have entered your username and token "


### PR DESCRIPTION
Like the previous changes in the same vein, this moves the UI code a step closer to disabling implicit string conversions. This makes the configuration window compatible with disabled implicit QString conversions. After this, all that's left is to deal with some of the top-level source files in the project directory and the conversions can be disabled.

This also uncovered some strings that weren't marked as translatable but should have been. These are also corrected.