### PR TITLE
yuzu/game_list: Specify string conversions explicitly 

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -188,7 +188,9 @@ private:
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
     : QWidget(parent), emu_thread(emu_thread) {
     setWindowTitle(QStringLiteral("yuzu %1 | %2-%3")
-                       .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
+                       .arg(QString::fromUtf8(Common::g_build_name),
+                            QString::fromUtf8(Common::g_scm_branch),
+                            QString::fromUtf8(Common::g_scm_desc)));
     setAttribute(Qt::WA_AcceptTouchEvents);
 
     InputCommon::Init();
@@ -217,7 +219,7 @@ void GRenderWindow::SwapBuffers() {
     // However:
     // - The Qt debug runtime prints a bogus warning on the console if `makeCurrent` wasn't called
     // since the last time `swapBuffers` was executed;
-    // - On macOS, if `makeCurrent` isn't called explicitely, resizing the buffer breaks.
+    // - On macOS, if `makeCurrent` isn't called explicitly, resizing the buffer breaks.
     context->makeCurrent(child);
 
     context->swapBuffers(child);

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -76,7 +76,7 @@ signals:
     void OpenPerGameGeneralRequested(const std::string& file);
 
 private slots:
-    void onTextChanged(const QString& newText);
+    void onTextChanged(const QString& new_text);
     void onFilterCloseClicked();
 
 private:

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -23,8 +23,8 @@
 #include "yuzu/util/util.h"
 
 /**
- * Gets the default icon (for games without valid SMDH)
- * @param large If true, returns large icon (48x48), otherwise returns small icon (24x24)
+ * Gets the default icon (for games without valid title metadata)
+ * @param size The desired width and height of the default icon.
  * @return QPixmap default icon
  */
 static QPixmap GetDefaultIcon(u32 size) {
@@ -44,7 +44,7 @@ public:
  * A specialization of GameListItem for path values.
  * This class ensures that for every full path value it holds, a correct string representation
  * of just the filename (with no extension) will be displayed to the user.
- * If this class receives valid SMDH data, it will also display game icons and titles.
+ * If this class receives valid title metadata, it will also display game icons and titles.
  */
 class GameListItemPath : public GameListItem {
 public:

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -4,11 +4,9 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <map>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 #include <QCoreApplication>
@@ -95,7 +93,7 @@ public:
             if (row2.isEmpty())
                 return row1;
 
-            return QString(row1 + "\n    " + row2);
+            return QString(row1 + QStringLiteral("\n    ") + row2);
         }
 
         return GameListItem::data(role);
@@ -115,13 +113,14 @@ public:
         };
         // clang-format off
         static const std::map<QString, CompatStatus> status_data = {
-        {"0",  {"#5c93ed", QT_TR_NOOP("Perfect"),    QT_TR_NOOP("Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
-        {"1",  {"#47d35c", QT_TR_NOOP("Great"),      QT_TR_NOOP("Game functions with minor graphical or audio glitches and is playable from start to finish. May require some\nworkarounds.")}},
-        {"2",  {"#94b242", QT_TR_NOOP("Okay"),       QT_TR_NOOP("Game functions with major graphical or audio glitches, but game is playable from start to finish with\nworkarounds.")}},
-        {"3",  {"#f2d624", QT_TR_NOOP("Bad"),        QT_TR_NOOP("Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches\neven with workarounds.")}},
-        {"4",  {"#FF0000", QT_TR_NOOP("Intro/Menu"), QT_TR_NOOP("Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start\nScreen.")}},
-        {"5",  {"#828282", QT_TR_NOOP("Won't Boot"), QT_TR_NOOP("The game crashes when attempting to startup.")}},
-        {"99", {"#000000", QT_TR_NOOP("Not Tested"), QT_TR_NOOP("The game has not yet been tested.")}}};
+            {QStringLiteral("0"),  {QStringLiteral("#5c93ed"), QT_TR_NOOP("Perfect"),    QT_TR_NOOP("Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
+            {QStringLiteral("1"),  {QStringLiteral("#47d35c"), QT_TR_NOOP("Great"),      QT_TR_NOOP("Game functions with minor graphical or audio glitches and is playable from start to finish. May require some\nworkarounds.")}},
+            {QStringLiteral("2"),  {QStringLiteral("#94b242"), QT_TR_NOOP("Okay"),       QT_TR_NOOP("Game functions with major graphical or audio glitches, but game is playable from start to finish with\nworkarounds.")}},
+            {QStringLiteral("3"),  {QStringLiteral("#f2d624"), QT_TR_NOOP("Bad"),        QT_TR_NOOP("Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches\neven with workarounds.")}},
+            {QStringLiteral("4"),  {QStringLiteral("#FF0000"), QT_TR_NOOP("Intro/Menu"), QT_TR_NOOP("Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start\nScreen.")}},
+            {QStringLiteral("5"),  {QStringLiteral("#828282"), QT_TR_NOOP("Won't Boot"), QT_TR_NOOP("The game crashes when attempting to startup.")}},
+            {QStringLiteral("99"), {QStringLiteral("#000000"), QT_TR_NOOP("Not Tested"), QT_TR_NOOP("The game has not yet been tested.")}},
+        };
         // clang-format on
 
         auto iterator = status_data.find(compatibility);

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -45,7 +45,7 @@ bool HasSupportedFileExtension(const std::string& file_name) {
 }
 
 bool IsExtractedNCAMain(const std::string& file_name) {
-    return QFileInfo(QString::fromStdString(file_name)).fileName() == "main";
+    return QFileInfo(QString::fromStdString(file_name)).fileName() == QStringLiteral("main");
 }
 
 QString FormatGameName(const std::string& physical_name) {
@@ -97,7 +97,7 @@ QList<QStandardItem*> MakeGameListEntry(const std::string& path, const std::stri
     const auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
 
     // The game list uses this as compatibility number for untested games
-    QString compatibility{"99"};
+    QString compatibility{QStringLiteral("99")};
     if (it != compatibility_list.end()) {
         compatibility = it->second.first;
     }

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -30,11 +30,11 @@
 #include <QMovie>
 #endif
 
-constexpr const char PROGRESSBAR_STYLE_PREPARE[] = R"(
+constexpr char PROGRESSBAR_STYLE_PREPARE[] = R"(
 QProgressBar {}
 QProgressBar::chunk {})";
 
-constexpr const char PROGRESSBAR_STYLE_DECOMPILE[] = R"(
+constexpr char PROGRESSBAR_STYLE_DECOMPILE[] = R"(
 QProgressBar {
   background-color: black;
   border: 2px solid white;
@@ -46,7 +46,7 @@ QProgressBar::chunk {
   width: 1px;
 })";
 
-constexpr const char PROGRESSBAR_STYLE_BUILD[] = R"(
+constexpr char PROGRESSBAR_STYLE_BUILD[] = R"(
 QProgressBar {
   background-color: black;
   border: 2px solid white;
@@ -58,7 +58,7 @@ QProgressBar::chunk {
   width: 1px;
 })";
 
-constexpr const char PROGRESSBAR_STYLE_COMPLETE[] = R"(
+constexpr char PROGRESSBAR_STYLE_COMPLETE[] = R"(
 QProgressBar {
   background-color: #0ab9e6;
   border: 2px solid white;
@@ -149,10 +149,10 @@ void LoadingScreen::OnLoadComplete() {
 void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value,
                                    std::size_t total) {
     using namespace std::chrono;
-    auto now = high_resolution_clock::now();
+    const auto now = high_resolution_clock::now();
     // reset the timer if the stage changes
     if (stage != previous_stage) {
-        ui->progress_bar->setStyleSheet(progressbar_style[stage]);
+        ui->progress_bar->setStyleSheet(QString::fromUtf8(progressbar_style[stage]));
         // Hide the progress bar during the prepare stage
         if (stage == VideoCore::LoadCallbackStage::Prepare) {
             ui->progress_bar->hide();
@@ -178,16 +178,16 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
             slow_shader_first_value = value;
         }
         // only calculate an estimate time after a second has passed since stage change
-        auto diff = duration_cast<milliseconds>(now - slow_shader_start);
+        const auto diff = duration_cast<milliseconds>(now - slow_shader_start);
         if (diff > seconds{1}) {
-            auto eta_mseconds =
+            const auto eta_mseconds =
                 static_cast<long>(static_cast<double>(total - slow_shader_first_value) /
                                   (value - slow_shader_first_value) * diff.count());
             estimate =
                 tr("Estimated Time %1")
                     .arg(QTime(0, 0, 0, 0)
                              .addMSecs(std::max<long>(eta_mseconds - diff.count() + 1000, 1000))
-                             .toString("mm:ss"));
+                             .toString(QStringLiteral("mm:ss")));
         }
     }
 

--- a/src/yuzu/util/util.cpp
+++ b/src/yuzu/util/util.cpp
@@ -8,7 +8,7 @@
 #include "yuzu/util/util.h"
 
 QFont GetMonospaceFont() {
-    QFont font("monospace");
+    QFont font(QStringLiteral("monospace"));
     // Automatic fallback to a monospace font on on platforms without a font called "monospace"
     font.setStyleHint(QFont::Monospace);
     font.setFixedPitch(true);
@@ -16,14 +16,16 @@ QFont GetMonospaceFont() {
 }
 
 QString ReadableByteSize(qulonglong size) {
-    static const std::array<const char*, 6> units = {"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
-    if (size == 0)
-        return "0";
-    int digit_groups = std::min<int>(static_cast<int>(std::log10(size) / std::log10(1024)),
-                                     static_cast<int>(units.size()));
-    return QString("%L1 %2")
+    static constexpr std::array units{"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
+    if (size == 0) {
+        return QStringLiteral("0");
+    }
+
+    const int digit_groups = std::min(static_cast<int>(std::log10(size) / std::log10(1024)),
+                                      static_cast<int>(units.size()));
+    return QStringLiteral("%L1 %2")
         .arg(size / std::pow(1024, digit_groups), 0, 'f', 1)
-        .arg(units[digit_groups]);
+        .arg(QString::fromUtf8(units[digit_groups]));
 }
 
 QPixmap CreateCirclePixmapFromColor(const QColor& color) {


### PR DESCRIPTION
Makes all top-level source files compilable with implicit Qt string conversions disabled. Now all that's left is to address main.cpp, which I'll do in a follow-up PR, as it's quite a large file, and would like to have those changes reviewed separately. The follow up change will also finally pass compilation flags that disable implicit Qt string conversions.