### PR TITLE
configure_hotkeys: Minor cleanup

### DIFF
--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -25,9 +25,6 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry)
 
     adjustSize();
     ui->selectorList->setCurrentRow(0);
-
-    // Synchronise lists upon initialisation
-    ui->hotkeysTab->EmitHotkeysChanged();
 }
 
 ConfigureDialog::~ConfigureDialog() = default;

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -31,18 +31,6 @@ ConfigureHotkeys::ConfigureHotkeys(QWidget* parent)
 
 ConfigureHotkeys::~ConfigureHotkeys() = default;
 
-QList<QKeySequence> ConfigureHotkeys::GetUsedKeyList() const {
-    QList<QKeySequence> list;
-    for (int r = 0; r < model->rowCount(); r++) {
-        const QStandardItem* parent = model->item(r, 0);
-        for (int r2 = 0; r2 < parent->rowCount(); r2++) {
-            const QStandardItem* keyseq = parent->child(r2, 1);
-            list << QKeySequence::fromString(keyseq->text(), QKeySequence::NativeText);
-        }
-    }
-    return list;
-}
-
 void ConfigureHotkeys::Populate(const HotkeyRegistry& registry) {
     for (const auto& group : registry.hotkey_groups) {
         auto* parent_item = new QStandardItem(group.first);
@@ -87,7 +75,21 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
 }
 
 bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) const {
-    return GetUsedKeyList().contains(key_sequence);
+    for (int r = 0; r < model->rowCount(); r++) {
+        const QStandardItem* const parent = model->item(r, 0);
+
+        for (int r2 = 0; r2 < parent->rowCount(); r2++) {
+            const QStandardItem* const key_seq_item = parent->child(r2, 1);
+            const auto key_seq_str = key_seq_item->text();
+            const auto key_seq = QKeySequence::fromString(key_seq_str, QKeySequence::NativeText);
+
+            if (key_sequence == key_seq) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 void ConfigureHotkeys::applyConfiguration(HotkeyRegistry& registry) {

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -111,7 +111,6 @@ void ConfigureHotkeys::applyConfiguration(HotkeyRegistry& registry) {
     }
 
     registry.SaveHotkeys();
-    Settings::Apply();
 }
 
 void ConfigureHotkeys::retranslateUi() {

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -67,8 +67,8 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 
     if (IsUsedKey(key_sequence) && key_sequence != QKeySequence(previous_key.toString())) {
-        QMessageBox::warning(this, tr("Error in inputted key"),
-                             tr("You're using a key that's already bound."));
+        QMessageBox::warning(this, tr("Conflicting Key Sequence"),
+                             tr("The entered key sequence is already assigned to another hotkey."));
     } else {
         model->setData(index, key_sequence.toString(QKeySequence::NativeText));
     }

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -67,8 +67,8 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 
     if (IsUsedKey(key_sequence) && key_sequence != QKeySequence(previous_key.toString())) {
-        QMessageBox::critical(this, tr("Error in inputted key"),
-                              tr("You're using a key that's already bound."));
+        QMessageBox::warning(this, tr("Error in inputted key"),
+                             tr("You're using a key that's already bound."));
     } else {
         model->setData(index, key_sequence.toString(QKeySequence::NativeText));
     }

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -31,10 +31,6 @@ ConfigureHotkeys::ConfigureHotkeys(QWidget* parent)
 
 ConfigureHotkeys::~ConfigureHotkeys() = default;
 
-void ConfigureHotkeys::EmitHotkeysChanged() {
-    emit HotkeysChanged(GetUsedKeyList());
-}
-
 QList<QKeySequence> ConfigureHotkeys::GetUsedKeyList() const {
     QList<QKeySequence> list;
     for (int r = 0; r < model->rowCount(); r++) {
@@ -87,7 +83,6 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
                               tr("You're using a key that's already bound."));
     } else {
         model->setData(index, key_sequence.toString(QKeySequence::NativeText));
-        EmitHotkeysChanged();
     }
 }
 

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -34,7 +34,6 @@ public:
 private:
     void Configure(QModelIndex index);
     bool IsUsedKey(QKeySequence key_sequence) const;
-    QList<QKeySequence> GetUsedKeyList() const;
 
     std::unique_ptr<Ui::ConfigureHotkeys> ui;
 

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -24,17 +24,12 @@ public:
     void applyConfiguration(HotkeyRegistry& registry);
     void retranslateUi();
 
-    void EmitHotkeysChanged();
-
     /**
      * Populates the hotkey list widget using data from the provided registry.
      * Called everytime the Configure dialog is opened.
      * @param registry The HotkeyRegistry whose data is used to populate the list.
      */
     void Populate(const HotkeyRegistry& registry);
-
-signals:
-    void HotkeysChanged(QList<QKeySequence> new_key_list);
 
 private:
     void Configure(QModelIndex index);

--- a/src/yuzu/util/sequence_dialog/sequence_dialog.cpp
+++ b/src/yuzu/util/sequence_dialog/sequence_dialog.cpp
@@ -9,15 +9,19 @@
 
 SequenceDialog::SequenceDialog(QWidget* parent) : QDialog(parent) {
     setWindowTitle(tr("Enter a hotkey"));
-    auto* layout = new QVBoxLayout(this);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
     key_sequence = new QKeySequenceEdit;
-    layout->addWidget(key_sequence);
-    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+
+    auto* const buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     buttons->setCenterButtons(true);
+
+    auto* const layout = new QVBoxLayout(this);
+    layout->addWidget(key_sequence);
     layout->addWidget(buttons);
+
     connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 SequenceDialog::~SequenceDialog() = default;

--- a/src/yuzu/util/sequence_dialog/sequence_dialog.cpp
+++ b/src/yuzu/util/sequence_dialog/sequence_dialog.cpp
@@ -12,8 +12,7 @@ SequenceDialog::SequenceDialog(QWidget* parent) : QDialog(parent) {
     auto* layout = new QVBoxLayout(this);
     key_sequence = new QKeySequenceEdit;
     layout->addWidget(key_sequence);
-    auto* buttons =
-        new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal);
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     buttons->setCenterButtons(true);
     layout->addWidget(buttons);
     connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);


### PR DESCRIPTION
Cleans up a bit of the code related to managing hotkeys. This is in preparation for making the titles of hotkeys actually translatable, which will be useful in the future once translation support gets merged in.