### PR TITLE
mii: Implement MiiManager backend and several mii service commands

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -123,6 +123,8 @@ add_library(common STATIC
     timer.h
     uint128.cpp
     uint128.h
+    uuid.cpp
+    uuid.h
     vector_math.h
     web_result.h
     zstd_compression.cpp

--- a/src/common/uuid.cpp
+++ b/src/common/uuid.cpp
@@ -1,0 +1,33 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <random>
+
+#include <fmt/format.h>
+
+#include "common/uuid.h"
+
+namespace Common {
+
+UUID UUID::Generate() {
+    std::random_device device;
+    std::mt19937 gen(device());
+    std::uniform_int_distribution<u64> distribution(1, std::numeric_limits<u64>::max());
+    return UUID{distribution(gen), distribution(gen)};
+}
+
+std::string UUID::Format() const {
+    return fmt::format("0x{:016X}{:016X}", uuid[1], uuid[0]);
+}
+
+std::string UUID::FormatSwitch() const {
+    std::array<u8, 16> s{};
+    std::memcpy(s.data(), uuid.data(), sizeof(u128));
+    return fmt::format("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{"
+                       ":02x}{:02x}{:02x}{:02x}{:02x}",
+                       s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8], s[9], s[10], s[11],
+                       s[12], s[13], s[14], s[15]);
+}
+
+} // namespace Common

--- a/src/common/uuid.cpp
+++ b/src/common/uuid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright 2018 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -19,15 +19,16 @@ struct UUID {
     constexpr explicit UUID(const u128& id) : uuid{id} {}
     constexpr explicit UUID(const u64 lo, const u64 hi) : uuid{{lo, hi}} {}
 
-    explicit operator bool() const {
-        return uuid != INVALID_UUID;
+    constexpr explicit operator bool() const {
+        return uuid[0] != INVALID_UUID[0] && uuid[1] != INVALID_UUID[1];
     }
 
-    bool operator==(const UUID& rhs) const {
-        return uuid == rhs.uuid;
+    constexpr bool operator==(const UUID& rhs) const {
+        // TODO(DarkLordZach): Replace with uuid == rhs.uuid with C++20
+        return uuid[0] == rhs.uuid[0] && uuid[1] == rhs.uuid[1];
     }
 
-    bool operator!=(const UUID& rhs) const {
+    constexpr bool operator!=(const UUID& rhs) const {
         return !operator==(rhs);
     }
 

--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -1,0 +1,45 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Common {
+
+constexpr u128 INVALID_UUID{{0, 0}};
+
+struct UUID {
+    // UUIDs which are 0 are considered invalid!
+    u128 uuid = INVALID_UUID;
+    constexpr UUID() = default;
+    constexpr explicit UUID(const u128& id) : uuid{id} {}
+    constexpr explicit UUID(const u64 lo, const u64 hi) : uuid{{lo, hi}} {}
+
+    explicit operator bool() const {
+        return uuid != INVALID_UUID;
+    }
+
+    bool operator==(const UUID& rhs) const {
+        return uuid == rhs.uuid;
+    }
+
+    bool operator!=(const UUID& rhs) const {
+        return !operator==(rhs);
+    }
+
+    // TODO(ogniK): Properly generate uuids based on RFC-4122
+    static UUID Generate();
+
+    // Set the UUID to {0,0} to be considered an invalid user
+    void Invalidate() {
+        uuid = INVALID_UUID;
+    }
+
+    std::string Format() const;
+    std::string FormatSwitch() const;
+};
+static_assert(sizeof(UUID) == 16, "UUID is an invalid size!");
+
+} // namespace Common

--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -1,8 +1,10 @@
-// Copyright 2018 Citra Emulator Project
+// Copyright 2018 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
+
+#include <string>
 
 #include "common/common_types.h"
 
@@ -33,7 +35,7 @@ struct UUID {
     static UUID Generate();
 
     // Set the UUID to {0,0} to be considered an invalid user
-    void Invalidate() {
+    constexpr void Invalidate() {
         uuid = INVALID_UUID;
     }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -310,6 +310,8 @@ add_library(core STATIC
     hle/service/mig/mig.h
     hle/service/mii/mii.cpp
     hle/service/mii/mii.h
+    hle/service/mii/mii_manager.cpp
+    hle/service/mii/mii_manager.h
     hle/service/mm/mm_u.cpp
     hle/service/mm/mm_u.h
     hle/service/ncm/ncm.cpp

--- a/src/core/frontend/applets/profile_select.cpp
+++ b/src/core/frontend/applets/profile_select.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "core/frontend/applets/profile_select.h"
+#include "core/hle/service/acc/profile_manager.h"
 #include "core/settings.h"
 
 namespace Core::Frontend {
@@ -10,9 +11,9 @@ namespace Core::Frontend {
 ProfileSelectApplet::~ProfileSelectApplet() = default;
 
 void DefaultProfileSelectApplet::SelectProfile(
-    std::function<void(std::optional<Service::Account::UUID>)> callback) const {
+    std::function<void(std::optional<Common::UUID>)> callback) const {
     Service::Account::ProfileManager manager;
-    callback(manager.GetUser(Settings::values.current_user).value_or(Service::Account::UUID{}));
+    callback(manager.GetUser(Settings::values.current_user).value_or(Common::UUID{}));
     LOG_INFO(Service_ACC, "called, selecting current user instead of prompting...");
 }
 

--- a/src/core/frontend/applets/profile_select.h
+++ b/src/core/frontend/applets/profile_select.h
@@ -6,7 +6,7 @@
 
 #include <functional>
 #include <optional>
-#include "core/hle/service/acc/profile_manager.h"
+#include "common/uuid.h"
 
 namespace Core::Frontend {
 
@@ -14,14 +14,12 @@ class ProfileSelectApplet {
 public:
     virtual ~ProfileSelectApplet();
 
-    virtual void SelectProfile(
-        std::function<void(std::optional<Service::Account::UUID>)> callback) const = 0;
+    virtual void SelectProfile(std::function<void(std::optional<Common::UUID>)> callback) const = 0;
 };
 
 class DefaultProfileSelectApplet final : public ProfileSelectApplet {
 public:
-    void SelectProfile(
-        std::function<void(std::optional<Service::Account::UUID>)> callback) const override;
+    void SelectProfile(std::function<void(std::optional<Common::UUID>)> callback) const override;
 };
 
 } // namespace Core::Frontend

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -34,7 +34,7 @@ constexpr std::array<u8, backup_jpeg_size> backup_jpeg{{
     0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0xd2, 0xcf, 0x20, 0xff, 0xd9,
 }};
 
-static std::string GetImagePath(UUID uuid) {
+static std::string GetImagePath(Common::UUID uuid) {
     return FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
            "/system/save/8000000000000010/su/avators/" + uuid.FormatSwitch() + ".jpg";
 }
@@ -46,7 +46,7 @@ static constexpr u32 SanitizeJPEGSize(std::size_t size) {
 
 class IProfile final : public ServiceFramework<IProfile> {
 public:
-    explicit IProfile(UUID user_id, ProfileManager& profile_manager)
+    explicit IProfile(Common::UUID user_id, ProfileManager& profile_manager)
         : ServiceFramework("IProfile"), profile_manager(profile_manager), user_id(user_id) {
         static const FunctionInfo functions[] = {
             {0, &IProfile::Get, "Get"},
@@ -131,7 +131,7 @@ private:
     }
 
     const ProfileManager& profile_manager;
-    UUID user_id; ///< The user id this profile refers to.
+    Common::UUID user_id; ///< The user id this profile refers to.
 };
 
 class IManagerForApplication final : public ServiceFramework<IManagerForApplication> {
@@ -179,7 +179,7 @@ void Module::Interface::GetUserCount(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::GetUserExistence(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    UUID user_id = rp.PopRaw<UUID>();
+    Common::UUID user_id = rp.PopRaw<Common::UUID>();
     LOG_INFO(Service_ACC, "called user_id={}", user_id.Format());
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -205,12 +205,12 @@ void Module::Interface::GetLastOpenedUser(Kernel::HLERequestContext& ctx) {
     LOG_INFO(Service_ACC, "called");
     IPC::ResponseBuilder rb{ctx, 6};
     rb.Push(RESULT_SUCCESS);
-    rb.PushRaw<UUID>(profile_manager->GetLastOpenedUser());
+    rb.PushRaw<Common::UUID>(profile_manager->GetLastOpenedUser());
 }
 
 void Module::Interface::GetProfile(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    UUID user_id = rp.PopRaw<UUID>();
+    Common::UUID user_id = rp.PopRaw<Common::UUID>();
     LOG_DEBUG(Service_ACC, "called user_id={}", user_id.Format());
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
@@ -245,15 +245,15 @@ void Module::Interface::TrySelectUserWithoutInteraction(Kernel::HLERequestContex
     IPC::ResponseBuilder rb{ctx, 6};
     if (profile_manager->GetUserCount() != 1) {
         rb.Push(RESULT_SUCCESS);
-        rb.PushRaw<u128>(INVALID_UUID);
+        rb.PushRaw<u128>(Common::INVALID_UUID);
         return;
     }
 
     const auto user_list = profile_manager->GetAllUsers();
     if (std::all_of(user_list.begin(), user_list.end(),
-                    [](const auto& user) { return user.uuid == INVALID_UUID; })) {
+                    [](const auto& user) { return user.uuid == Common::INVALID_UUID; })) {
         rb.Push(ResultCode(-1)); // TODO(ogniK): Find the correct error code
-        rb.PushRaw<u128>(INVALID_UUID);
+        rb.PushRaw<u128>(Common::INVALID_UUID);
         return;
     }
 

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -13,6 +13,8 @@
 
 namespace Service::Account {
 
+using namespace Common;
+
 struct UserRaw {
     UUID uuid;
     UUID uuid2;
@@ -34,26 +36,6 @@ constexpr ResultCode ERROR_USER_ALREADY_EXISTS(ErrorModule::Account, -2);
 constexpr ResultCode ERROR_ARGUMENT_IS_NULL(ErrorModule::Account, 20);
 
 constexpr char ACC_SAVE_AVATORS_BASE_PATH[] = "/system/save/8000000000000010/su/avators/";
-
-UUID UUID::Generate() {
-    std::random_device device;
-    std::mt19937 gen(device());
-    std::uniform_int_distribution<u64> distribution(1, std::numeric_limits<u64>::max());
-    return UUID{distribution(gen), distribution(gen)};
-}
-
-std::string UUID::Format() const {
-    return fmt::format("0x{:016X}{:016X}", uuid[1], uuid[0]);
-}
-
-std::string UUID::FormatSwitch() const {
-    std::array<u8, 16> s{};
-    std::memcpy(s.data(), uuid.data(), sizeof(u128));
-    return fmt::format("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{"
-                       ":02x}{:02x}{:02x}{:02x}{:02x}",
-                       s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8], s[9], s[10], s[11],
-                       s[12], s[13], s[14], s[15]);
-}
 
 ProfileManager::ProfileManager() {
     ParseUserSaveFile();

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -13,7 +13,7 @@
 
 namespace Service::Account {
 
-using namespace Common;
+using Common::UUID;
 
 struct UserRaw {
     UUID uuid;
@@ -199,7 +199,7 @@ bool ProfileManager::UserExists(UUID uuid) const {
 bool ProfileManager::UserExistsIndex(std::size_t index) const {
     if (index >= MAX_USERS)
         return false;
-    return profiles[index].user_uuid.uuid != INVALID_UUID;
+    return profiles[index].user_uuid.uuid != Common::INVALID_UUID;
 }
 
 /// Opens a specific user
@@ -293,7 +293,7 @@ bool ProfileManager::RemoveUser(UUID uuid) {
 
 bool ProfileManager::SetProfileBase(UUID uuid, const ProfileBase& profile_new) {
     const auto index = GetUserIndex(uuid);
-    if (!index || profile_new.user_uuid == UUID(INVALID_UUID)) {
+    if (!index || profile_new.user_uuid == UUID(Common::INVALID_UUID)) {
         return false;
     }
 
@@ -324,7 +324,7 @@ void ProfileManager::ParseUserSaveFile() {
     }
 
     for (const auto& user : data.users) {
-        if (user.uuid == UUID(INVALID_UUID)) {
+        if (user.uuid == UUID(Common::INVALID_UUID)) {
             continue;
         }
 

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -9,47 +9,15 @@
 
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "common/uuid.h"
 #include "core/hle/result.h"
 
 namespace Service::Account {
 constexpr std::size_t MAX_USERS = 8;
-constexpr u128 INVALID_UUID{{0, 0}};
-
-struct UUID {
-    // UUIDs which are 0 are considered invalid!
-    u128 uuid = INVALID_UUID;
-    UUID() = default;
-    explicit UUID(const u128& id) : uuid{id} {}
-    explicit UUID(const u64 lo, const u64 hi) : uuid{{lo, hi}} {}
-
-    explicit operator bool() const {
-        return uuid != INVALID_UUID;
-    }
-
-    bool operator==(const UUID& rhs) const {
-        return uuid == rhs.uuid;
-    }
-
-    bool operator!=(const UUID& rhs) const {
-        return !operator==(rhs);
-    }
-
-    // TODO(ogniK): Properly generate uuids based on RFC-4122
-    static UUID Generate();
-
-    // Set the UUID to {0,0} to be considered an invalid user
-    void Invalidate() {
-        uuid = INVALID_UUID;
-    }
-
-    std::string Format() const;
-    std::string FormatSwitch() const;
-};
-static_assert(sizeof(UUID) == 16, "UUID is an invalid size!");
 
 constexpr std::size_t profile_username_size = 32;
 using ProfileUsername = std::array<u8, profile_username_size>;
-using UserIDArray = std::array<UUID, MAX_USERS>;
+using UserIDArray = std::array<Common::UUID, MAX_USERS>;
 
 /// Contains extra data related to a user.
 /// TODO: RE this structure
@@ -66,7 +34,7 @@ static_assert(sizeof(ProfileData) == 0x80, "ProfileData structure has incorrect 
 /// This holds general information about a users profile. This is where we store all the information
 /// based on a specific user
 struct ProfileInfo {
-    UUID user_uuid;
+    Common::UUID user_uuid;
     ProfileUsername username;
     u64 creation_time;
     ProfileData data; // TODO(ognik): Work out what this is
@@ -74,7 +42,7 @@ struct ProfileInfo {
 };
 
 struct ProfileBase {
-    UUID user_uuid;
+    Common::UUID user_uuid;
     u64_le timestamp;
     ProfileUsername username;
 
@@ -96,33 +64,33 @@ public:
     ~ProfileManager();
 
     ResultCode AddUser(const ProfileInfo& user);
-    ResultCode CreateNewUser(UUID uuid, const ProfileUsername& username);
-    ResultCode CreateNewUser(UUID uuid, const std::string& username);
-    std::optional<UUID> GetUser(std::size_t index) const;
-    std::optional<std::size_t> GetUserIndex(const UUID& uuid) const;
+    ResultCode CreateNewUser(Common::UUID uuid, const ProfileUsername& username);
+    ResultCode CreateNewUser(Common::UUID uuid, const std::string& username);
+    std::optional<Common::UUID> GetUser(std::size_t index) const;
+    std::optional<std::size_t> GetUserIndex(const Common::UUID& uuid) const;
     std::optional<std::size_t> GetUserIndex(const ProfileInfo& user) const;
     bool GetProfileBase(std::optional<std::size_t> index, ProfileBase& profile) const;
-    bool GetProfileBase(UUID uuid, ProfileBase& profile) const;
+    bool GetProfileBase(Common::UUID uuid, ProfileBase& profile) const;
     bool GetProfileBase(const ProfileInfo& user, ProfileBase& profile) const;
     bool GetProfileBaseAndData(std::optional<std::size_t> index, ProfileBase& profile,
                                ProfileData& data) const;
-    bool GetProfileBaseAndData(UUID uuid, ProfileBase& profile, ProfileData& data) const;
+    bool GetProfileBaseAndData(Common::UUID uuid, ProfileBase& profile, ProfileData& data) const;
     bool GetProfileBaseAndData(const ProfileInfo& user, ProfileBase& profile,
                                ProfileData& data) const;
     std::size_t GetUserCount() const;
     std::size_t GetOpenUserCount() const;
-    bool UserExists(UUID uuid) const;
+    bool UserExists(Common::UUID uuid) const;
     bool UserExistsIndex(std::size_t index) const;
-    void OpenUser(UUID uuid);
-    void CloseUser(UUID uuid);
+    void OpenUser(Common::UUID uuid);
+    void CloseUser(Common::UUID uuid);
     UserIDArray GetOpenUsers() const;
     UserIDArray GetAllUsers() const;
-    UUID GetLastOpenedUser() const;
+    Common::UUID GetLastOpenedUser() const;
 
     bool CanSystemRegisterUser() const;
 
-    bool RemoveUser(UUID uuid);
-    bool SetProfileBase(UUID uuid, const ProfileBase& profile_new);
+    bool RemoveUser(Common::UUID uuid);
+    bool SetProfileBase(Common::UUID uuid, const ProfileBase& profile_new);
 
 private:
     void ParseUserSaveFile();
@@ -132,7 +100,7 @@ private:
 
     std::array<ProfileInfo, MAX_USERS> profiles{};
     std::size_t user_count = 0;
-    UUID last_opened_user{INVALID_UUID};
+    Common::UUID last_opened_user{Common::INVALID_UUID};
 };
 
 }; // namespace Service::Account

--- a/src/core/hle/service/am/applets/profile_select.cpp
+++ b/src/core/hle/service/am/applets/profile_select.cpp
@@ -53,7 +53,7 @@ void ProfileSelect::Execute() {
         return;
     }
 
-    frontend.SelectProfile([this](std::optional<Account::UUID> uuid) { SelectionComplete(uuid); });
+    frontend.SelectProfile([this](std::optional<Common::UUID> uuid) { SelectionComplete(uuid); });
 }
 
 void ProfileSelect::SelectionComplete(std::optional<Common::UUID> uuid) {

--- a/src/core/hle/service/am/applets/profile_select.cpp
+++ b/src/core/hle/service/am/applets/profile_select.cpp
@@ -56,16 +56,16 @@ void ProfileSelect::Execute() {
     frontend.SelectProfile([this](std::optional<Account::UUID> uuid) { SelectionComplete(uuid); });
 }
 
-void ProfileSelect::SelectionComplete(std::optional<Account::UUID> uuid) {
+void ProfileSelect::SelectionComplete(std::optional<Common::UUID> uuid) {
     UserSelectionOutput output{};
 
-    if (uuid.has_value() && uuid->uuid != Account::INVALID_UUID) {
+    if (uuid.has_value() && uuid->uuid != Common::INVALID_UUID) {
         output.result = 0;
         output.uuid_selected = uuid->uuid;
     } else {
         status = ERR_USER_CANCELLED_SELECTION;
         output.result = ERR_USER_CANCELLED_SELECTION.raw;
-        output.uuid_selected = Account::INVALID_UUID;
+        output.uuid_selected = Common::INVALID_UUID;
     }
 
     final_data = std::vector<u8>(sizeof(UserSelectionOutput));

--- a/src/core/hle/service/am/applets/profile_select.h
+++ b/src/core/hle/service/am/applets/profile_select.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "common/common_funcs.h"
-#include "core/hle/service/acc/profile_manager.h"
+#include "common/uuid.h"
 #include "core/hle/service/am/applets/applets.h"
 
 namespace Service::AM::Applets {
@@ -38,7 +38,7 @@ public:
     void ExecuteInteractive() override;
     void Execute() override;
 
-    void SelectionComplete(std::optional<Account::UUID> uuid);
+    void SelectionComplete(std::optional<Common::UUID> uuid);
 
 private:
     const Core::Frontend::ProfileSelectApplet& frontend;

--- a/src/core/hle/service/am/applets/profile_select.h
+++ b/src/core/hle/service/am/applets/profile_select.h
@@ -8,6 +8,7 @@
 
 #include "common/common_funcs.h"
 #include "common/uuid.h"
+#include "core/hle/result.h"
 #include "core/hle/service/am/applets/applets.h"
 
 namespace Service::AM::Applets {

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -68,13 +68,14 @@ private:
 
     void IsUpdated(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        const auto unknown{rp.PopRaw<u32>()};
+        const auto source{rp.PopRaw<Source>()};
 
-        LOG_WARNING(Service_Mii, "(STUBBED) called with unknown={:08X}", unknown);
+        LOG_DEBUG(Service_Mii, "called with source={}", source);
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push(false);
+        rb.Push(db.CheckUpdatedFlag());
+        db.ResetUpdatedFlag();
     }
 
     void IsFullDatabase(Kernel::HLERequestContext& ctx) {
@@ -87,9 +88,9 @@ private:
 
     void GetCount(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        const auto unknown{rp.PopRaw<u32>()};
+        const auto source{rp.PopRaw<Source>()};
 
-        LOG_DEBUG(Service_Mii, "called with unknown={:08X}", unknown);
+        LOG_DEBUG(Service_Mii, "called with source={}", source);
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -100,8 +101,10 @@ private:
     void Get(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto size{rp.PopRaw<u32>()};
+        const auto source{rp.PopRaw<Source>()};
 
-        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[0]);
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}, source={}", size,
+                  offsets[0], source);
 
         u32 read_size{};
         ctx.WriteBuffer(SerializeArray(&MiiManager::GetInfoElement, offsets[0], size, read_size));
@@ -116,8 +119,10 @@ private:
     void Get1(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto size{rp.PopRaw<u32>()};
+        const auto source{rp.PopRaw<Source>()};
 
-        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[1]);
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}, source={}", size,
+                  offsets[1], source);
 
         u32 read_size{};
         ctx.WriteBuffer(SerializeArray(&MiiManager::GetInfo, offsets[1], size, read_size));
@@ -157,8 +162,10 @@ private:
     void Get2(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto size{rp.PopRaw<u32>()};
+        const auto source{rp.PopRaw<Source>()};
 
-        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[2]);
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}, source={}", size,
+                  offsets[2], source);
 
         u32 read_size{};
         ctx.WriteBuffer(
@@ -174,8 +181,10 @@ private:
     void Get3(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto size{rp.PopRaw<u32>()};
+        const auto source{rp.PopRaw<Source>()};
 
-        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[3]);
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}, source={}", size,
+                  offsets[3], source);
 
         u32 read_size{};
         ctx.WriteBuffer(SerializeArray(&MiiManager::GetStoreData, offsets[3], size, read_size));

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -5,9 +5,11 @@
 #include <memory>
 
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/mii/mii.h"
+#include "core/hle/service/mii/mii_manager.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
 
@@ -18,28 +20,28 @@ public:
     explicit IDatabaseService() : ServiceFramework{"IDatabaseService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "IsUpdated"},
-            {1, nullptr, "IsFullDatabase"},
-            {2, nullptr, "GetCount"},
-            {3, nullptr, "Get"},
-            {4, nullptr, "Get1"},
+            {0, &IDatabaseService::IsUpdated, "IsUpdated"},
+            {1, &IDatabaseService::IsFullDatabase, "IsFullDatabase"},
+            {2, &IDatabaseService::GetCount, "GetCount"},
+            {3, &IDatabaseService::Get, "Get"},
+            {4, &IDatabaseService::Get1, "Get1"},
             {5, nullptr, "UpdateLatest"},
-            {6, nullptr, "BuildRandom"},
-            {7, nullptr, "BuildDefault"},
-            {8, nullptr, "Get2"},
-            {9, nullptr, "Get3"},
+            {6, &IDatabaseService::BuildRandom, "BuildRandom"},
+            {7, &IDatabaseService::BuildDefault, "BuildDefault"},
+            {8, &IDatabaseService::Get2, "Get2"},
+            {9, &IDatabaseService::Get3, "Get3"},
             {10, nullptr, "UpdateLatest1"},
-            {11, nullptr, "FindIndex"},
-            {12, nullptr, "Move"},
-            {13, nullptr, "AddOrReplace"},
-            {14, nullptr, "Delete"},
+            {11, &IDatabaseService::FindIndex, "FindIndex"},
+            {12, &IDatabaseService::Move, "Move"},
+            {13, &IDatabaseService::AddOrReplace, "AddOrReplace"},
+            {14, &IDatabaseService::Delete, "Delete"},
             {15, nullptr, "DestroyFile"},
             {16, nullptr, "DeleteFile"},
-            {17, nullptr, "Format"},
+            {17, &IDatabaseService::Format, "Format"},
             {18, nullptr, "Import"},
             {19, nullptr, "Export"},
             {20, nullptr, "IsBrokenDatabaseWithClearFlag"},
-            {21, nullptr, "GetIndex"},
+            {21, &IDatabaseService::GetIndex, "GetIndex"},
             {22, nullptr, "SetInterfaceVersion"},
             {23, nullptr, "Convert"},
         };
@@ -47,6 +49,231 @@ public:
 
         RegisterHandlers(functions);
     }
+
+private:
+    template <typename OutType>
+    std::vector<u8> SerializeArray(OutType (MiiManager::*getter)(u32) const, u32 offset,
+                                   u32 requested_size, u32& read_size) {
+        read_size = std::min(requested_size, db.Size() - offset);
+
+        std::vector<u8> out(read_size * sizeof(OutType));
+
+        for (u32 i = 0; i < read_size; ++i) {
+            const auto obj = (db.*getter)(offset + i);
+            std::memcpy(out.data() + i * sizeof(OutType), &obj, sizeof(OutType));
+        }
+
+        return out;
+    }
+
+    void IsUpdated(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto unknown{rp.PopRaw<u32>()};
+
+        LOG_WARNING(Service_Mii, "(STUBBED) called with unknown={:08X}", unknown);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(false);
+    }
+
+    void IsFullDatabase(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service_Mii, "called");
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(db.Full());
+    }
+
+    void GetCount(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto unknown{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with unknown={:08X}", unknown);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(db.Size());
+    }
+
+    // Gets Miis from database at offset and index in format MiiInfoElement
+    void Get(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto size{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[0]);
+
+        u32 read_size{};
+        ctx.WriteBuffer(SerializeArray(&MiiManager::GetInfoElement, offsets[0], size, read_size));
+        offsets[0] += read_size;
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(read_size);
+    }
+
+    // Gets Miis from database at offset and index in format MiiInfo
+    void Get1(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto size{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[1]);
+
+        u32 read_size{};
+        ctx.WriteBuffer(SerializeArray(&MiiManager::GetInfo, offsets[1], size, read_size));
+        offsets[1] += read_size;
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(read_size);
+    }
+
+    void BuildRandom(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto random_params{rp.PopRaw<RandomParameters>()};
+
+        LOG_DEBUG(Service_Mii, "called with param_1={:08X}, param_2={:08X}, param_3={:08X}",
+                  random_params.unknown_1, random_params.unknown_2, random_params.unknown_3);
+
+        const auto info = db.CreateRandom(random_params);
+        IPC::ResponseBuilder rb{ctx, 2 + sizeof(MiiInfo) / sizeof(u32)};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushRaw<MiiInfo>(info);
+    }
+
+    void BuildDefault(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto index{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with index={:08X}", index);
+
+        const auto info = db.CreateDefault(index);
+        IPC::ResponseBuilder rb{ctx, 2 + sizeof(MiiInfo) / sizeof(u32)};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushRaw<MiiInfo>(info);
+    }
+
+    // Gets Miis from database at offset and index in format MiiStoreDataElement
+    void Get2(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto size{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[2]);
+
+        u32 read_size{};
+        ctx.WriteBuffer(
+            SerializeArray(&MiiManager::GetStoreDataElement, offsets[2], size, read_size));
+        offsets[2] += read_size;
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(read_size);
+    }
+
+    // Gets Miis from database at offset and index in format MiiStoreData
+    void Get3(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto size{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with size={:08X}, offset={:08X}", size, offsets[3]);
+
+        u32 read_size{};
+        ctx.WriteBuffer(SerializeArray(&MiiManager::GetStoreData, offsets[3], size, read_size));
+        offsets[3] += read_size;
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(read_size);
+    }
+
+    void FindIndex(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto uuid{rp.PopRaw<Common::UUID>()};
+        const auto unknown{rp.PopRaw<bool>()};
+
+        LOG_DEBUG(Service_Mii, "called with uuid={}, unknown={}", uuid.FormatSwitch(), unknown);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+
+        const auto index = db.IndexOf(uuid);
+        if (index > MAX_MIIS) {
+            // TODO(DarkLordZach): Find a better error code
+            rb.Push(ResultCode(-1));
+            rb.Push(index);
+        } else {
+            rb.Push(RESULT_SUCCESS);
+            rb.Push(index);
+        }
+    }
+
+    void Move(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto uuid{rp.PopRaw<Common::UUID>()};
+        const auto index{rp.PopRaw<u32>()};
+
+        LOG_DEBUG(Service_Mii, "called with uuid={}, index={:08X}", uuid.FormatSwitch(), index);
+
+        const auto success = db.Move(uuid, index);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        // TODO(DarkLordZach): Find a better error code
+        rb.Push(success ? RESULT_SUCCESS : ResultCode(-1));
+    }
+
+    void AddOrReplace(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto data{rp.PopRaw<MiiStoreData>()};
+
+        LOG_DEBUG(Service_Mii, "called with Mii data uuid={}, name={}", data.uuid.FormatSwitch(),
+                  Common::UTF16ToUTF8(data.Name()));
+
+        const auto success = db.AddOrReplace(data);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        // TODO(DarkLordZach): Find a better error code
+        rb.Push(success ? RESULT_SUCCESS : ResultCode(-1));
+    }
+
+    void Delete(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto uuid{rp.PopRaw<Common::UUID>()};
+
+        LOG_DEBUG(Service_Mii, "called with uuid={}", uuid.FormatSwitch());
+
+        const auto success = db.Remove(uuid);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        // TODO(DarkLordZach): Find a better error code
+        rb.Push(success ? RESULT_SUCCESS : ResultCode(-1));
+    }
+
+    void Format(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service_Mii, "called");
+
+        db.Clear();
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void GetIndex(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto info{rp.PopRaw<MiiInfo>()};
+
+        LOG_DEBUG(Service_Mii, "called with Mii info uuid={}, name={}", info.uuid.FormatSwitch(),
+                  Common::UTF16ToUTF8(info.Name()));
+
+        const auto index = db.IndexOf(info);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(index);
+    }
+
+    MiiManager db;
+
+    // Last read offsets of Get functions
+    std::array<u32, 4> offsets{};
 };
 
 class MiiDBModule final : public ServiceFramework<MiiDBModule> {

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -403,7 +403,7 @@ MiiStoreData MiiManager::CreateMiiWithUniqueUUID() const {
 
     do {
         new_mii.uuid = Common::UUID::Generate();
-    } while (IndexOf(new_mii.uuid) == INVALID_INDEX);
+    } while (IndexOf(new_mii.uuid) != INVALID_INDEX);
 
     return new_mii;
 }

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -32,6 +32,13 @@ constexpr MiiStoreData DEFAULT_MII = {
 // Default values taken from multiple real databases
 const MiiDatabase DEFAULT_MII_DATABASE{Common::MakeMagic('N', 'F', 'D', 'B'), {}, {1}, 0, 0};
 
+constexpr std::array<const char*, 4> SOURCE_NAMES{
+    "Database",
+    "Default",
+    "Account",
+    "Friend",
+};
+
 template <typename T, std::size_t SourceArraySize, std::size_t DestArraySize>
 std::array<T, DestArraySize> ResizeArray(const std::array<T, SourceArraySize>& in) {
     std::array<T, DestArraySize> out{};
@@ -167,6 +174,11 @@ MiiStoreData ConvertInfoToStoreData(const MiiInfo& info) {
 
 } // namespace
 
+std::ostream& operator<<(std::ostream& os,Source source) {
+    os << SOURCE_NAMES.at(static_cast<std::size_t>(source));
+    return os;
+}
+
 std::u16string MiiInfo::Name() const {
     return Common::UTF16StringFromFixedZeroTerminatedBuffer(name.data(), name.size());
 }
@@ -210,6 +222,10 @@ bool MiiManager::CheckUpdatedFlag() const {
 
 void MiiManager::ResetUpdatedFlag() {
     updated_flag = false;
+}
+
+bool MiiManager::IsTestModeEnabled() const {
+    return is_test_mode_enabled;
 }
 
 bool MiiManager::Empty() const {
@@ -316,6 +332,17 @@ bool MiiManager::AddOrReplace(const MiiStoreData& data) {
     }
 
     return true;
+}
+
+bool MiiManager::DestroyFile() {
+    database = DEFAULT_MII_DATABASE;
+    updated_flag = false;
+    return DeleteFile();
+}
+
+bool MiiManager::DeleteFile() {
+    const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + MII_SAVE_DATABASE_PATH;
+    return FileUtil::Exists(path) && FileUtil::Delete(path);
 }
 
 void MiiManager::WriteToFile() {

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -174,7 +174,7 @@ MiiStoreData ConvertInfoToStoreData(const MiiInfo& info) {
 
 } // namespace
 
-std::ostream& operator<<(std::ostream& os,Source source) {
+std::ostream& operator<<(std::ostream& os, Source source) {
     os << SOURCE_NAMES.at(static_cast<std::size_t>(source));
     return os;
 }

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -1,0 +1,369 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cstring>
+#include "common/assert.h"
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/string_util.h"
+#include "core/hle/service/mii/mii_manager.h"
+
+namespace Service::Mii {
+
+constexpr char MII_SAVE_DATABASE_PATH[] = "/system/save/8000000000000030/MiiDatabase.dat";
+constexpr std::array<char16_t, 11> DEFAULT_MII_NAME = {'y', 'u', 'z', 'u', '\0'};
+
+// This value was retrieved from HW test
+constexpr MiiStoreData DEFAULT_MII = {
+    {
+        0x21, 0x40, 0x40, 0x01, 0x08, 0x01, 0x13, 0x08, 0x08, 0x02, 0x17, 0x8C, 0x06, 0x01,
+        0x69, 0x6D, 0x8A, 0x6A, 0x82, 0x14, 0x00, 0x00, 0x00, 0x20, 0x64, 0x72, 0x44, 0x44,
+    },
+    {'y', 'u', 'z', 'u', '\0'},
+    Common::UUID{1, 0},
+    0,
+    0,
+};
+
+// Default values taken from multiple real databases
+const MiiDatabase DEFAULT_MII_DATABASE{Common::MakeMagic('N', 'F', 'D', 'B'), {}, {1}, 0, 0};
+
+template <typename T, std::size_t s1, std::size_t s2>
+std::array<T, s2> ResizeArray(const std::array<T, s1>& in) {
+    std::array<T, s2> out{};
+    std::memcpy(out.data(), in.data(), sizeof(T) * std::min(s1, s2));
+    return out;
+}
+
+MiiInfo ConvertStoreDataToInfo(const MiiStoreData& data) {
+    MiiStoreBitFields bf{};
+    std::memcpy(&bf, data.data.data(), sizeof(MiiStoreBitFields));
+    return {
+        data.uuid,
+        ResizeArray<char16_t, 10, 11>(data.name),
+        static_cast<u8>(bf.font_region.Value()),
+        static_cast<u8>(bf.favorite_color.Value()),
+        static_cast<u8>(bf.gender.Value()),
+        static_cast<u8>(bf.height.Value()),
+        static_cast<u8>(bf.weight.Value()),
+        static_cast<u8>(bf.mii_type.Value()),
+        static_cast<u8>(bf.mii_region.Value()),
+        static_cast<u8>(bf.face_type.Value()),
+        static_cast<u8>(bf.face_color.Value()),
+        static_cast<u8>(bf.face_wrinkle.Value()),
+        static_cast<u8>(bf.face_makeup.Value()),
+        static_cast<u8>(bf.hair_type.Value()),
+        static_cast<u8>(bf.hair_color.Value()),
+        static_cast<bool>(bf.hair_flip.Value()),
+        static_cast<u8>(bf.eye_type.Value()),
+        static_cast<u8>(bf.eye_color.Value()),
+        static_cast<u8>(bf.eye_scale.Value()),
+        static_cast<u8>(bf.eye_aspect.Value()),
+        static_cast<u8>(bf.eye_rotate.Value()),
+        static_cast<u8>(bf.eye_x.Value()),
+        static_cast<u8>(bf.eye_y.Value()),
+        static_cast<u8>(bf.eyebrow_type.Value()),
+        static_cast<u8>(bf.eyebrow_color.Value()),
+        static_cast<u8>(bf.eyebrow_scale.Value()),
+        static_cast<u8>(bf.eyebrow_aspect.Value()),
+        static_cast<u8>(bf.eyebrow_rotate.Value()),
+        static_cast<u8>(bf.eyebrow_x.Value()),
+        static_cast<u8>(bf.eyebrow_y.Value()),
+        static_cast<u8>(bf.nose_type.Value()),
+        static_cast<u8>(bf.nose_scale.Value()),
+        static_cast<u8>(bf.nose_y.Value()),
+        static_cast<u8>(bf.mouth_type.Value()),
+        static_cast<u8>(bf.mouth_color.Value()),
+        static_cast<u8>(bf.mouth_scale.Value()),
+        static_cast<u8>(bf.mouth_aspect.Value()),
+        static_cast<u8>(bf.mouth_y.Value()),
+        static_cast<u8>(bf.facial_hair_color.Value()),
+        static_cast<u8>(bf.beard_type.Value()),
+        static_cast<u8>(bf.mustache_type.Value()),
+        static_cast<u8>(bf.mustache_scale.Value()),
+        static_cast<u8>(bf.mustache_y.Value()),
+        static_cast<u8>(bf.glasses_type.Value()),
+        static_cast<u8>(bf.glasses_color.Value()),
+        static_cast<u8>(bf.glasses_scale.Value()),
+        static_cast<u8>(bf.glasses_y.Value()),
+        static_cast<u8>(bf.mole_type.Value()),
+        static_cast<u8>(bf.mole_scale.Value()),
+        static_cast<u8>(bf.mole_x.Value()),
+        static_cast<u8>(bf.mole_y.Value()),
+        0x00,
+    };
+}
+MiiStoreData ConvertInfoToStoreData(const MiiInfo& info) {
+    MiiStoreData out{};
+    out.name = ResizeArray<char16_t, 11, 10>(info.name);
+    out.uuid = info.uuid;
+
+    MiiStoreBitFields bf{};
+
+    bf.hair_type.Assign(info.hair_type);
+    bf.mole_type.Assign(info.mole_type);
+    bf.height.Assign(info.height);
+    bf.hair_flip.Assign(info.hair_flip);
+    bf.weight.Assign(info.weight);
+    bf.hair_color.Assign(info.hair_color);
+
+    bf.gender.Assign(info.gender);
+    bf.eye_color.Assign(info.eye_color);
+    bf.eyebrow_color.Assign(info.eyebrow_color);
+    bf.mouth_color.Assign(info.mouth_color);
+    bf.facial_hair_color.Assign(info.facial_hair_color);
+
+    bf.mii_type.Assign(info.mii_type);
+    bf.glasses_color.Assign(info.glasses_color);
+    bf.font_region.Assign(info.font_region);
+    bf.eye_type.Assign(info.eye_type);
+    bf.mii_region.Assign(info.mii_region);
+    bf.mouth_type.Assign(info.mouth_type);
+    bf.glasses_scale.Assign(info.glasses_scale);
+    bf.eye_y.Assign(info.eye_y);
+
+    bf.mustache_type.Assign(info.mustache_type);
+    bf.eyebrow_type.Assign(info.eyebrow_type);
+    bf.beard_type.Assign(info.beard_type);
+    bf.nose_type.Assign(info.nose_type);
+    bf.mouth_aspect.Assign(info.mouth_aspect_ratio);
+    bf.nose_y.Assign(info.nose_y);
+    bf.eyebrow_aspect.Assign(info.eyebrow_aspect_ratio);
+    bf.mouth_y.Assign(info.mouth_y);
+
+    bf.eye_rotate.Assign(info.eye_rotate);
+    bf.mustache_y.Assign(info.mustache_y);
+    bf.eye_aspect.Assign(info.eye_aspect_ratio);
+    bf.glasses_y.Assign(info.glasses_y);
+    bf.eye_scale.Assign(info.eye_scale);
+    bf.mole_x.Assign(info.mole_x);
+    bf.mole_y.Assign(info.mole_y);
+
+    bf.glasses_type.Assign(info.glasses_type);
+    bf.face_type.Assign(info.face_type);
+    bf.favorite_color.Assign(info.favorite_color);
+    bf.face_wrinkle.Assign(info.face_wrinkle);
+    bf.face_color.Assign(info.face_color);
+    bf.eye_x.Assign(info.eye_x);
+    bf.face_makeup.Assign(info.face_makeup);
+
+    bf.eyebrow_rotate.Assign(info.eyebrow_rotate);
+    bf.eyebrow_scale.Assign(info.eyebrow_scale);
+    bf.eyebrow_y.Assign(info.eyebrow_y);
+    bf.eyebrow_x.Assign(info.eyebrow_x);
+    bf.mouth_scale.Assign(info.mouth_scale);
+    bf.nose_scale.Assign(info.nose_scale);
+    bf.mole_scale.Assign(info.mole_scale);
+    bf.mustache_scale.Assign(info.mustache_scale);
+
+    std::memcpy(out.data.data(), &bf, sizeof(MiiStoreBitFields));
+
+    return out;
+}
+
+std::u16string MiiInfo::Name() const {
+    return Common::UTF16StringFromFixedZeroTerminatedBuffer(name.data(), name.size());
+}
+
+bool operator==(const MiiInfo& lhs, const MiiInfo& rhs) {
+    return std::memcmp(&lhs, &rhs, sizeof(MiiInfo));
+}
+
+bool operator!=(const MiiInfo& lhs, const MiiInfo& rhs) {
+    return !operator==(lhs, rhs);
+}
+
+std::u16string MiiStoreData::Name() const {
+    return Common::UTF16StringFromFixedZeroTerminatedBuffer(name.data(), name.size());
+}
+
+MiiManager::MiiManager() = default;
+
+MiiManager::~MiiManager() = default;
+
+MiiInfo MiiManager::CreateRandom(RandomParameters params) {
+    LOG_WARNING(Service_Mii,
+                "(STUBBED) called with params={:08X}{:08X}{:08X}, returning default Mii",
+                params.unknown_1, params.unknown_2, params.unknown_3);
+
+    auto new_mii = DEFAULT_MII;
+
+    do {
+        new_mii.uuid = Common::UUID::Generate();
+    } while (IndexOf(new_mii.uuid) == INVALID_INDEX);
+
+    return ConvertStoreDataToInfo(new_mii);
+}
+
+MiiInfo MiiManager::CreateDefault(u32 index) {
+    auto new_mii = DEFAULT_MII;
+
+    do {
+        new_mii.uuid = Common::UUID::Generate();
+    } while (IndexOf(new_mii.uuid) == INVALID_INDEX);
+
+    ASSERT(index < MAX_MIIS);
+    database.miis[index] = new_mii;
+    std::stable_partition(database.miis.begin(), database.miis.end(),
+                          [](const MiiStoreData& elem) { return elem.uuid; });
+
+    return ConvertStoreDataToInfo(new_mii);
+}
+
+bool MiiManager::Empty() const {
+    return Size() == 0;
+}
+
+bool MiiManager::Full() const {
+    return Size() == MAX_MIIS;
+}
+
+void MiiManager::Clear() {
+    std::fill(database.miis.begin(), database.miis.end(), MiiStoreData{});
+}
+
+u32 MiiManager::Size() const {
+    return static_cast<u32>(std::count_if(database.miis.begin(), database.miis.end(),
+                                          [](const MiiStoreData& elem) { return elem.uuid; }));
+}
+
+MiiInfo MiiManager::GetInfo(u32 index) const {
+    return ConvertStoreDataToInfo(GetStoreData(index));
+}
+
+MiiInfoElement MiiManager::GetInfoElement(u32 index) const {
+    return {GetInfo(index), Source::Database};
+}
+
+MiiStoreData MiiManager::GetStoreData(u32 index) const {
+    return database.miis.at(index);
+}
+
+MiiStoreDataElement MiiManager::GetStoreDataElement(u32 index) const {
+    return {GetStoreData(index), Source::Database};
+}
+
+bool MiiManager::Remove(Common::UUID uuid) {
+    const auto iter = std::find_if(database.miis.begin(), database.miis.end(),
+                                   [uuid](const MiiStoreData& elem) { return elem.uuid == uuid; });
+
+    if (iter == database.miis.end())
+        return false;
+
+    *iter = MiiStoreData{};
+    std::stable_partition(database.miis.begin(), database.miis.end(),
+                          [](const MiiStoreData& elem) { return elem.uuid; });
+    return true;
+}
+
+u32 MiiManager::IndexOf(Common::UUID uuid) const {
+    const auto iter = std::find_if(database.miis.begin(), database.miis.end(),
+                                   [uuid](const MiiStoreData& elem) { return elem.uuid == uuid; });
+
+    if (iter == database.miis.end())
+        return INVALID_INDEX;
+
+    return static_cast<u32>(std::distance(database.miis.begin(), iter));
+}
+
+u32 MiiManager::IndexOf(MiiInfo info) const {
+    const auto iter =
+        std::find_if(database.miis.begin(), database.miis.end(), [info](const MiiStoreData& elem) {
+            return ConvertStoreDataToInfo(elem) == info;
+        });
+
+    if (iter == database.miis.end())
+        return INVALID_INDEX;
+
+    return static_cast<u32>(std::distance(database.miis.begin(), iter));
+}
+
+bool MiiManager::Move(Common::UUID uuid, u32 new_index) {
+    const auto index = IndexOf(uuid);
+
+    if (index == INVALID_INDEX || new_index >= MAX_MIIS)
+        return false;
+
+    const auto moving = database.miis[index];
+    const auto replacing = database.miis[new_index];
+    if (replacing.uuid) {
+        database.miis[index] = replacing;
+        database.miis[new_index] = moving;
+    } else {
+        database.miis[index] = MiiStoreData{};
+        database.miis[new_index] = moving;
+    }
+
+    std::stable_partition(database.miis.begin(), database.miis.end(),
+                          [](const MiiStoreData& elem) { return elem.uuid; });
+    return true;
+}
+
+bool MiiManager::AddOrReplace(MiiStoreData data) {
+    const auto index = IndexOf(data.uuid);
+
+    if (index == INVALID_INDEX) {
+        const auto size = Size();
+        if (size == MAX_MIIS)
+            return false;
+        database.miis[size] = data;
+    } else {
+        database.miis[index] = data;
+    }
+
+    return true;
+}
+
+void MiiManager::WriteToFile() {
+    const auto raw_path =
+        FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + "/system/save/8000000000000030";
+    if (FileUtil::Exists(raw_path) && !FileUtil::IsDirectory(raw_path))
+        FileUtil::Delete(raw_path);
+
+    const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + MII_SAVE_DATABASE_PATH;
+
+    if (!FileUtil::CreateFullPath(path)) {
+        LOG_WARNING(Service_Mii,
+                    "Failed to create full path of MiiDatabase.dat. Create the directory "
+                    "nand/system/save/8000000000000030 to mitigate this "
+                    "issue.");
+        return;
+    }
+
+    FileUtil::IOFile save(path, "wb");
+
+    if (!save.IsOpen()) {
+        LOG_WARNING(Service_Mii, "Failed to write save data to file... No changes to user data "
+                                 "made in current session will be saved.");
+        return;
+    }
+
+    save.Resize(sizeof(MiiDatabase));
+    save.WriteBytes(&database, sizeof(MiiDatabase));
+}
+
+void MiiManager::ReadFromFile() {
+    FileUtil::IOFile save(
+        FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + MII_SAVE_DATABASE_PATH, "rb");
+
+    if (!save.IsOpen()) {
+        LOG_WARNING(Service_ACC, "Failed to load profile data from save data... Generating new "
+                                 "blank Mii database with no Miis.");
+        std::memcpy(&database, &DEFAULT_MII_DATABASE, sizeof(MiiDatabase));
+        return;
+    }
+
+    if (save.ReadBytes(&database, sizeof(MiiDatabase)) != sizeof(MiiDatabase)) {
+        LOG_WARNING(Service_ACC, "MiiDatabase.dat is smaller than expected... Generating new blank "
+                                 "Mii database with no Miis.");
+        std::memcpy(&database, &DEFAULT_MII_DATABASE, sizeof(MiiDatabase));
+        return;
+    }
+
+    std::stable_partition(database.miis.begin(), database.miis.end(),
+                          [](const MiiStoreData& elem) { return elem.uuid; });
+}
+
+} // namespace Service::Mii

--- a/src/core/hle/service/mii/mii_manager.cpp
+++ b/src/core/hle/service/mii/mii_manager.cpp
@@ -204,6 +204,14 @@ MiiInfo MiiManager::CreateDefault(u32 index) {
     return ConvertStoreDataToInfo(new_mii);
 }
 
+bool MiiManager::CheckUpdatedFlag() const {
+    return updated_flag;
+}
+
+void MiiManager::ResetUpdatedFlag() {
+    updated_flag = false;
+}
+
 bool MiiManager::Empty() const {
     return Size() == 0;
 }
@@ -213,6 +221,7 @@ bool MiiManager::Full() const {
 }
 
 void MiiManager::Clear() {
+    updated_flag = true;
     std::fill(database.miis.begin(), database.miis.end(), MiiStoreData{});
 }
 
@@ -244,6 +253,7 @@ bool MiiManager::Remove(Common::UUID uuid) {
     if (iter == database.miis.end())
         return false;
 
+    updated_flag = true;
     *iter = MiiStoreData{};
     EnsureDatabasePartition();
     return true;
@@ -277,6 +287,7 @@ bool MiiManager::Move(Common::UUID uuid, u32 new_index) {
     if (index == INVALID_INDEX || new_index >= MAX_MIIS)
         return false;
 
+    updated_flag = true;
     const auto moving = database.miis[index];
     const auto replacing = database.miis[new_index];
     if (replacing.uuid) {
@@ -294,6 +305,7 @@ bool MiiManager::Move(Common::UUID uuid, u32 new_index) {
 bool MiiManager::AddOrReplace(const MiiStoreData& data) {
     const auto index = IndexOf(data.uuid);
 
+    updated_flag = true;
     if (index == INVALID_INDEX) {
         const auto size = Size();
         if (size == MAX_MIIS)

--- a/src/core/hle/service/mii/mii_manager.h
+++ b/src/core/hle/service/mii/mii_manager.h
@@ -1,0 +1,253 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/bit_field.h"
+#include "common/common_funcs.h"
+#include "common/uuid.h"
+
+namespace Service::Mii {
+
+constexpr std::size_t MAX_MIIS = 100;
+constexpr u32 INVALID_INDEX = 0xFFFFFFFF;
+
+struct RandomParameters {
+    u32 unknown_1;
+    u32 unknown_2;
+    u32 unknown_3;
+};
+static_assert(sizeof(RandomParameters) == 0xC, "RandomParameters has incorrect size.");
+
+enum class Source : u32 {
+    Database = 0,
+    Default = 1,
+    Account = 2,
+    Friend = 3,
+};
+
+struct MiiInfo {
+    Common::UUID uuid;
+    std::array<char16_t, 11> name;
+    u8 font_region;
+    u8 favorite_color;
+    u8 gender;
+    u8 height;
+    u8 weight;
+    u8 mii_type;
+    u8 mii_region;
+    u8 face_type;
+    u8 face_color;
+    u8 face_wrinkle;
+    u8 face_makeup;
+    u8 hair_type;
+    u8 hair_color;
+    bool hair_flip;
+    u8 eye_type;
+    u8 eye_color;
+    u8 eye_scale;
+    u8 eye_aspect_ratio;
+    u8 eye_rotate;
+    u8 eye_x;
+    u8 eye_y;
+    u8 eyebrow_type;
+    u8 eyebrow_color;
+    u8 eyebrow_scale;
+    u8 eyebrow_aspect_ratio;
+    u8 eyebrow_rotate;
+    u8 eyebrow_x;
+    u8 eyebrow_y;
+    u8 nose_type;
+    u8 nose_scale;
+    u8 nose_y;
+    u8 mouth_type;
+    u8 mouth_color;
+    u8 mouth_scale;
+    u8 mouth_aspect_ratio;
+    u8 mouth_y;
+    u8 facial_hair_color;
+    u8 beard_type;
+    u8 mustache_type;
+    u8 mustache_scale;
+    u8 mustache_y;
+    u8 glasses_type;
+    u8 glasses_color;
+    u8 glasses_scale;
+    u8 glasses_y;
+    u8 mole_type;
+    u8 mole_scale;
+    u8 mole_x;
+    u8 mole_y;
+    INSERT_PADDING_BYTES(1);
+
+    std::u16string Name() const;
+};
+static_assert(sizeof(MiiInfo) == 0x58, "MiiInfo has incorrect size.");
+
+bool operator==(const MiiInfo& lhs, const MiiInfo& rhs);
+bool operator!=(const MiiInfo& lhs, const MiiInfo& rhs);
+
+#pragma pack(push, 4)
+struct MiiInfoElement {
+    MiiInfo info;
+    Source source;
+};
+static_assert(sizeof(MiiInfoElement) == 0x5C, "MiiInfoElement has incorrect size.");
+
+struct MiiStoreBitFields {
+    union {
+        u32 word_0;
+
+        BitField<24, 8, u32> hair_type;
+        BitField<23, 1, u32> mole_type;
+        BitField<16, 7, u32> height;
+        BitField<15, 1, u32> hair_flip;
+        BitField<8, 7, u32> weight;
+        BitField<0, 7, u32> hair_color;
+    };
+
+    union {
+        u32 word_1;
+
+        BitField<31, 1, u32> gender;
+        BitField<24, 7, u32> eye_color;
+        BitField<16, 7, u32> eyebrow_color;
+        BitField<8, 7, u32> mouth_color;
+        BitField<0, 7, u32> facial_hair_color;
+    };
+
+    union {
+        u32 word_2;
+
+        BitField<31, 1, u32> mii_type;
+        BitField<24, 7, u32> glasses_color;
+        BitField<22, 2, u32> font_region;
+        BitField<16, 6, u32> eye_type;
+        BitField<14, 2, u32> mii_region;
+        BitField<8, 6, u32> mouth_type;
+        BitField<5, 3, u32> glasses_scale;
+        BitField<0, 5, u32> eye_y;
+    };
+
+    union {
+        u32 word_3;
+
+        BitField<29, 3, u32> mustache_type;
+        BitField<24, 5, u32> eyebrow_type;
+        BitField<21, 3, u32> beard_type;
+        BitField<16, 5, u32> nose_type;
+        BitField<13, 3, u32> mouth_aspect;
+        BitField<8, 5, u32> nose_y;
+        BitField<5, 3, u32> eyebrow_aspect;
+        BitField<0, 5, u32> mouth_y;
+    };
+
+    union {
+        u32 word_4;
+
+        BitField<29, 3, u32> eye_rotate;
+        BitField<24, 5, u32> mustache_y;
+        BitField<21, 3, u32> eye_aspect;
+        BitField<16, 5, u32> glasses_y;
+        BitField<13, 3, u32> eye_scale;
+        BitField<8, 5, u32> mole_x;
+        BitField<0, 5, u32> mole_y;
+    };
+
+    union {
+        u32 word_5;
+
+        BitField<24, 5, u32> glasses_type;
+        BitField<20, 4, u32> face_type;
+        BitField<16, 4, u32> favorite_color;
+        BitField<12, 4, u32> face_wrinkle;
+        BitField<8, 4, u32> face_color;
+        BitField<4, 4, u32> eye_x;
+        BitField<0, 4, u32> face_makeup;
+    };
+
+    union {
+        u32 word_6;
+
+        BitField<28, 4, u32> eyebrow_rotate;
+        BitField<24, 4, u32> eyebrow_scale;
+        BitField<20, 4, u32> eyebrow_y;
+        BitField<16, 4, u32> eyebrow_x;
+        BitField<12, 4, u32> mouth_scale;
+        BitField<8, 4, u32> nose_scale;
+        BitField<4, 4, u32> mole_scale;
+        BitField<0, 4, u32> mustache_scale;
+    };
+};
+static_assert(sizeof(MiiStoreBitFields) == 0x1C, "MiiStoreBitFields has incorrect size.");
+
+struct MiiStoreData {
+    // This corresponds to the above structure MiiStoreBitFields. I did it like this because the
+    // BitField<> type makes this (and any thing that contains it) not trivially copyable, which is
+    // not suitable for our uses.
+    std::array<u8, 0x1C> data;
+    static_assert(sizeof(MiiStoreBitFields) == sizeof(data), "data field has incorrect size.");
+
+    std::array<char16_t, 10> name;
+    Common::UUID uuid;
+    u16 crc_1;
+    u16 crc_2;
+
+    std::u16string Name() const;
+};
+static_assert(sizeof(MiiStoreData) == 0x44, "MiiStoreData has incorrect size.");
+
+struct MiiStoreDataElement {
+    MiiStoreData data;
+    Source source;
+};
+static_assert(sizeof(MiiStoreDataElement) == 0x48, "MiiStoreDataElement has incorrect size.");
+
+struct MiiDatabase {
+    u32 magic; // 'NFDB'
+    std::array<MiiStoreData, MAX_MIIS> miis;
+    INSERT_PADDING_BYTES(1);
+    u8 count;
+    u16 crc;
+};
+static_assert(sizeof(MiiDatabase) == 0x1A98, "MiiDatabase has incorrect size.");
+#pragma pack(pop)
+
+// The Mii manager is responsible for loading and storing the Miis to the database in NAND along
+// with providing an easy interface for HLE emulation of the mii service.
+class MiiManager {
+public:
+    MiiManager();
+    ~MiiManager();
+
+    MiiInfo CreateRandom(RandomParameters params);
+    MiiInfo CreateDefault(u32 index);
+
+    bool Empty() const;
+    bool Full() const;
+
+    void Clear();
+
+    u32 Size() const;
+
+    MiiInfo GetInfo(u32 index) const;
+    MiiInfoElement GetInfoElement(u32 index) const;
+    MiiStoreData GetStoreData(u32 index) const;
+    MiiStoreDataElement GetStoreDataElement(u32 index) const;
+
+    bool Remove(Common::UUID uuid);
+    u32 IndexOf(Common::UUID uuid) const;
+    u32 IndexOf(MiiInfo info) const;
+
+    bool Move(Common::UUID uuid, u32 new_index);
+    bool AddOrReplace(MiiStoreData data);
+
+private:
+    void WriteToFile();
+    void ReadFromFile();
+
+    MiiDatabase database;
+};
+
+}; // namespace Service::Mii

--- a/src/core/hle/service/mii/mii_manager.h
+++ b/src/core/hle/service/mii/mii_manager.h
@@ -226,6 +226,9 @@ public:
     MiiInfo CreateRandom(RandomParameters params);
     MiiInfo CreateDefault(u32 index);
 
+    bool CheckUpdatedFlag() const;
+    void ResetUpdatedFlag();
+
     bool Empty() const;
     bool Full() const;
 
@@ -254,6 +257,7 @@ private:
     void EnsureDatabasePartition();
 
     MiiDatabase database;
+    bool updated_flag = false;
 };
 
 }; // namespace Service::Mii

--- a/src/core/hle/service/mii/mii_manager.h
+++ b/src/core/hle/service/mii/mii_manager.h
@@ -84,6 +84,8 @@ struct MiiInfo {
     std::u16string Name() const;
 };
 static_assert(sizeof(MiiInfo) == 0x58, "MiiInfo has incorrect size.");
+static_assert(std::has_unique_object_representations_v<MiiInfo>,
+              "All bits of MiiInfo must contribute to its value.");
 
 bool operator==(const MiiInfo& lhs, const MiiInfo& rhs);
 bool operator!=(const MiiInfo& lhs, const MiiInfo& rhs);
@@ -238,14 +240,18 @@ public:
 
     bool Remove(Common::UUID uuid);
     u32 IndexOf(Common::UUID uuid) const;
-    u32 IndexOf(MiiInfo info) const;
+    u32 IndexOf(const MiiInfo& info) const;
 
     bool Move(Common::UUID uuid, u32 new_index);
-    bool AddOrReplace(MiiStoreData data);
+    bool AddOrReplace(const MiiStoreData& data);
 
 private:
     void WriteToFile();
     void ReadFromFile();
+
+    MiiStoreData CreateMiiWithUniqueUUID() const;
+
+    void EnsureDatabasePartition();
 
     MiiDatabase database;
 };

--- a/src/core/hle/service/mii/mii_manager.h
+++ b/src/core/hle/service/mii/mii_manager.h
@@ -27,6 +27,8 @@ enum class Source : u32 {
     Friend = 3,
 };
 
+std::ostream& operator<<(std::ostream& os, Source source);
+
 struct MiiInfo {
     Common::UUID uuid;
     std::array<char16_t, 11> name;
@@ -183,6 +185,8 @@ struct MiiStoreBitFields {
     };
 };
 static_assert(sizeof(MiiStoreBitFields) == 0x1C, "MiiStoreBitFields has incorrect size.");
+static_assert(std::is_trivially_copyable_v<MiiStoreBitFields>,
+              "MiiStoreBitFields is not trivially copyable.");
 
 struct MiiStoreData {
     // This corresponds to the above structure MiiStoreBitFields. I did it like this because the
@@ -229,6 +233,8 @@ public:
     bool CheckUpdatedFlag() const;
     void ResetUpdatedFlag();
 
+    bool IsTestModeEnabled() const;
+
     bool Empty() const;
     bool Full() const;
 
@@ -248,6 +254,9 @@ public:
     bool Move(Common::UUID uuid, u32 new_index);
     bool AddOrReplace(const MiiStoreData& data);
 
+    bool DestroyFile();
+    bool DeleteFile();
+
 private:
     void WriteToFile();
     void ReadFromFile();
@@ -258,6 +267,7 @@ private:
 
     MiiDatabase database;
     bool updated_flag = false;
+    bool is_test_mode_enabled = false;
 };
 
 }; // namespace Service::Mii

--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -27,20 +27,20 @@ constexpr std::array<u8, 107> backup_jpeg{
     0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0xd2, 0xcf, 0x20, 0xff, 0xd9,
 };
 
-QString FormatUserEntryText(const QString& username, Service::Account::UUID uuid) {
+QString FormatUserEntryText(const QString& username, Common::UUID uuid) {
     return QtProfileSelectionDialog::tr(
                "%1\n%2", "%1 is the profile username, %2 is the formatted UUID (e.g. "
                          "00112233-4455-6677-8899-AABBCCDDEEFF))")
         .arg(username, QString::fromStdString(uuid.FormatSwitch()));
 }
 
-QString GetImagePath(Service::Account::UUID uuid) {
+QString GetImagePath(Common::UUID uuid) {
     const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
                       "/system/save/8000000000000010/su/avators/" + uuid.FormatSwitch() + ".jpg";
     return QString::fromStdString(path);
 }
 
-QPixmap GetIcon(Service::Account::UUID uuid) {
+QPixmap GetIcon(Common::UUID uuid) {
     QPixmap icon{GetImagePath(uuid)};
 
     if (!icon) {
@@ -154,12 +154,12 @@ QtProfileSelector::QtProfileSelector(GMainWindow& parent) {
 QtProfileSelector::~QtProfileSelector() = default;
 
 void QtProfileSelector::SelectProfile(
-    std::function<void(std::optional<Service::Account::UUID>)> callback) const {
+    std::function<void(std::optional<Common::UUID>)> callback) const {
     this->callback = std::move(callback);
     emit MainWindowSelectProfile();
 }
 
-void QtProfileSelector::MainWindowFinishedSelection(std::optional<Service::Account::UUID> uuid) {
+void QtProfileSelector::MainWindowFinishedSelection(std::optional<Common::UUID> uuid) {
     // Acquire the HLE mutex
     std::lock_guard lock{HLE::g_hle_lock};
     callback(uuid);

--- a/src/yuzu/applets/profile_select.h
+++ b/src/yuzu/applets/profile_select.h
@@ -9,6 +9,7 @@
 #include <QList>
 #include <QTreeView>
 #include "core/frontend/applets/profile_select.h"
+#include "core/hle/service/acc/profile_manager.h"
 
 class GMainWindow;
 class QDialogButtonBox;
@@ -60,14 +61,13 @@ public:
     explicit QtProfileSelector(GMainWindow& parent);
     ~QtProfileSelector() override;
 
-    void SelectProfile(
-        std::function<void(std::optional<Service::Account::UUID>)> callback) const override;
+    void SelectProfile(std::function<void(std::optional<Common::UUID>)> callback) const override;
 
 signals:
     void MainWindowSelectProfile() const;
 
 private:
-    void MainWindowFinishedSelection(std::optional<Service::Account::UUID> uuid);
+    void MainWindowFinishedSelection(std::optional<Common::UUID> uuid);
 
-    mutable std::function<void(std::optional<Service::Account::UUID>)> callback;
+    mutable std::function<void(std::optional<Common::UUID>)> callback;
 };

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -33,14 +33,13 @@ constexpr std::array<u8, 107> backup_jpeg{
     0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0xd2, 0xcf, 0x20, 0xff, 0xd9,
 };
 
-QString GetImagePath(Service::Account::UUID uuid) {
+QString GetImagePath(Common::UUID uuid) {
     const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
                       "/system/save/8000000000000010/su/avators/" + uuid.FormatSwitch() + ".jpg";
     return QString::fromStdString(path);
 }
 
-QString GetAccountUsername(const Service::Account::ProfileManager& manager,
-                           Service::Account::UUID uuid) {
+QString GetAccountUsername(const Service::Account::ProfileManager& manager, Common::UUID uuid) {
     Service::Account::ProfileBase profile;
     if (!manager.GetProfileBase(uuid, profile)) {
         return {};
@@ -51,14 +50,14 @@ QString GetAccountUsername(const Service::Account::ProfileManager& manager,
     return QString::fromStdString(text);
 }
 
-QString FormatUserEntryText(const QString& username, Service::Account::UUID uuid) {
+QString FormatUserEntryText(const QString& username, Common::UUID uuid) {
     return ConfigureProfileManager::tr("%1\n%2",
                                        "%1 is the profile username, %2 is the formatted UUID (e.g. "
                                        "00112233-4455-6677-8899-AABBCCDDEEFF))")
         .arg(username, QString::fromStdString(uuid.FormatSwitch()));
 }
 
-QPixmap GetIcon(Service::Account::UUID uuid) {
+QPixmap GetIcon(Common::UUID uuid) {
     QPixmap icon{GetImagePath(uuid)};
 
     if (!icon) {
@@ -190,7 +189,7 @@ void ConfigureProfileManager::AddUser() {
         return;
     }
 
-    const auto uuid = Service::Account::UUID::Generate();
+    const auto uuid = Common::UUID::Generate();
     profile_manager->CreateNewUser(uuid, username.toStdString());
 
     item_model->appendRow(new QStandardItem{GetIcon(uuid), FormatUserEntryText(username, uuid)});

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -104,7 +104,7 @@ signals:
 
     void ErrorDisplayFinished();
 
-    void ProfileSelectorFinishedSelection(std::optional<Service::Account::UUID> uuid);
+    void ProfileSelectorFinishedSelection(std::optional<Common::UUID> uuid);
     void SoftwareKeyboardFinishedText(std::optional<std::u16string> text);
     void SoftwareKeyboardFinishedCheckDialog();
 


### PR DESCRIPTION
DO NOT MERGE - Awaiting SSBU to become bootable for further testing

Implements a MiiManager class to serialize/deserialize the Mii database to saves, and perform operations upon it. Provides conversions between MiiInfo (unpacked format -- used by games usually) and MiiStoreData (packed bitfield format -- used for storage).

The format conversion was 'HW tested' by creating 50 miis with one physical difference from default and then comparing the serialized versions. This is also how the default mii was obtained.

This also extracts the Service::Account::UUID class to Common::UUID as other services make use of it to.