### PR TITLE
yuzu/configuration/configure_graphics: Eliminate type narrowing in a connect call

### DIFF
--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -51,17 +51,15 @@ Resolution FromResolutionFactor(float factor) {
 
 ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGraphics) {
-
     ui->setupUi(this);
-    this->setConfiguration();
+    setConfiguration();
 
-    ui->frame_limit->setEnabled(Settings::values.use_frame_limit);
-    connect(ui->toggle_frame_limit, &QCheckBox::stateChanged, ui->frame_limit,
-            &QSpinBox::setEnabled);
+    connect(ui->toggle_frame_limit, &QCheckBox::toggled, ui->frame_limit, &QSpinBox::setEnabled);
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
-        if (!new_bg_color.isValid())
+        if (!new_bg_color.isValid()) {
             return;
+        }
         UpdateBackgroundColorButton(new_bg_color);
     });
 }
@@ -74,6 +72,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->resolution_factor_combobox->setCurrentIndex(
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
+    ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked());
     ui->frame_limit->setValue(Settings::values.frame_limit);
     ui->use_compatibility_profile->setEnabled(runtime_lock);
     ui->use_compatibility_profile->setChecked(Settings::values.use_compatibility_profile);


### PR DESCRIPTION
A checkbox is able to be tri-state, giving it three possible activity types, so in the connect call here, it would actually be truncating an int into a bool, when calling QSpinbox::setEnabled

Instead, we can just listen on the toggled() signal, which passes along a bool, not an int.