### PR TITLE
gl_shader_decompiler: Remove guest "position" varying

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -45,7 +45,6 @@ struct TextureAoffi {};
 using TextureArgument = std::pair<Type, Node>;
 using TextureIR = std::variant<TextureAoffi, TextureArgument>;
 
-enum : u32 { POSITION_VARYING_LOCATION = 0, GENERIC_VARYING_START_LOCATION = 1 };
 constexpr u32 MAX_CONSTBUFFER_ELEMENTS =
     static_cast<u32>(RasterizerOpenGL::MaxConstbufferSize) / (4 * sizeof(float));
 
@@ -247,6 +246,12 @@ private:
         code.AddLine("layout ({}, max_vertices = {}) out;", topology, max_vertices);
         code.AddNewLine();
 
+        code.AddLine("in gl_PerVertex {{");
+        ++code.scope;
+        code.AddLine("vec4 gl_Position;");
+        --code.scope;
+        code.AddLine("}} gl_in[];");
+
         DeclareVertexRedeclarations();
     }
 
@@ -349,7 +354,7 @@ private:
     }
 
     void DeclareInputAttribute(Attribute::Index index, bool skip_unused) {
-        const u32 generic_index{GetGenericAttributeIndex(index)};
+        const u32 location{GetGenericAttributeIndex(index)};
 
         std::string name{GetInputAttribute(index)};
         if (stage == ShaderStage::Geometry) {
@@ -358,17 +363,11 @@ private:
 
         std::string suffix;
         if (stage == ShaderStage::Fragment) {
-            const auto input_mode{header.ps.GetAttributeUse(generic_index)};
+            const auto input_mode{header.ps.GetAttributeUse(location)};
             if (skip_unused && input_mode == AttributeUse::Unused) {
                 return;
             }
             suffix = GetInputFlags(input_mode);
-        }
-
-        u32 location = generic_index;
-        if (stage != ShaderStage::Vertex) {
-            // If inputs are varyings, add an offset
-            location += GENERIC_VARYING_START_LOCATION;
         }
 
         code.AddLine("layout (location = {}) {} in vec4 {};", location, suffix, name);
@@ -395,7 +394,7 @@ private:
     }
 
     void DeclareOutputAttribute(Attribute::Index index) {
-        const u32 location{GetGenericAttributeIndex(index) + GENERIC_VARYING_START_LOCATION};
+        const u32 location{GetGenericAttributeIndex(index)};
         code.AddLine("layout (location = {}) out vec4 {};", location, GetOutputAttribute(index));
     }
 
@@ -633,10 +632,14 @@ private:
 
         switch (attribute) {
         case Attribute::Index::Position:
-            if (stage != ShaderStage::Fragment) {
-                return GeometryPass("position") + GetSwizzle(element);
-            } else {
+            switch (stage) {
+            case ShaderStage::Geometry:
+                return fmt::format("gl_in[ftou({})].gl_Position{}", Visit(buffer),
+                                   GetSwizzle(element));
+            case ShaderStage::Fragment:
                 return element == 3 ? "1.0f" : ("gl_FragCoord"s + GetSwizzle(element));
+            default:
+                UNREACHABLE();
             }
         case Attribute::Index::PointCoord:
             switch (element) {
@@ -921,7 +924,7 @@ private:
             target = [&]() -> std::string {
                 switch (const auto attribute = abuf->GetIndex(); abuf->GetIndex()) {
                 case Attribute::Index::Position:
-                    return "position"s + GetSwizzle(abuf->GetElement());
+                    return "gl_Position"s + GetSwizzle(abuf->GetElement());
                 case Attribute::Index::PointSize:
                     return "gl_PointSize";
                 case Attribute::Index::ClipDistances0123:
@@ -1506,9 +1509,7 @@ private:
 
         // If a geometry shader is attached, it will always flip (it's the last stage before
         // fragment). For more info about flipping, refer to gl_shader_gen.cpp.
-        code.AddLine("position.xy *= viewport_flip.xy;");
-        code.AddLine("gl_Position = position;");
-        code.AddLine("position.w = 1.0;");
+        code.AddLine("gl_Position.xy *= viewport_flip.xy;");
         code.AddLine("EmitVertex();");
         return {};
     }
@@ -1746,8 +1747,7 @@ private:
     }
 
     u32 GetNumPhysicalVaryings() const {
-        return std::min<u32>(device.GetMaxVaryings() - GENERIC_VARYING_START_LOCATION,
-                             Maxwell::NumVaryings);
+        return std::min<u32>(device.GetMaxVaryings(), Maxwell::NumVaryings);
     }
 
     const Device& device;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -23,8 +23,6 @@ ProgramResult GenerateVertexShader(const Device& device, const ShaderSetup& setu
     out += GetCommonDeclarations();
 
     out += R"(
-layout (location = 0) out vec4 position;
-
 layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
     vec4 viewport_flip;
     uvec4 config_pack; // instance_id, flip_stage, y_direction, padding
@@ -48,7 +46,6 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
 
     out += R"(
 void main() {
-    position = vec4(0.0, 0.0, 0.0, 0.0);
     execute_vertex();
 )";
 
@@ -59,19 +56,12 @@ void main() {
     out += R"(
 
     // Set Position Y direction
-    position.y *= utof(config_pack[2]);
+    gl_Position.y *= utof(config_pack[2]);
     // Check if the flip stage is VertexB
     // Config pack's second value is flip_stage
     if (config_pack[1] == 1) {
         // Viewport can be flipped, which is unsupported by glViewport
-        position.xy *= viewport_flip.xy;
-    }
-    gl_Position = position;
-
-    // TODO(bunnei): This is likely a hack, position.w should be interpolated as 1.0
-    // For now, this is here to bring order in lieu of proper emulation
-    if (config_pack[1] == 1) {
-        position.w = 1.0;
+        gl_Position.xy *= viewport_flip.xy;
     }
 })";
 
@@ -85,9 +75,6 @@ ProgramResult GenerateGeometryShader(const Device& device, const ShaderSetup& se
     out += GetCommonDeclarations();
 
     out += R"(
-layout (location = 0) in vec4 gs_position[];
-layout (location = 0) out vec4 position;
-
 layout (std140, binding = EMULATION_UBO_BINDING) uniform gs_config {
     vec4 viewport_flip;
     uvec4 config_pack; // instance_id, flip_stage, y_direction, padding
@@ -123,8 +110,6 @@ layout (location = 4) out vec4 FragColor4;
 layout (location = 5) out vec4 FragColor5;
 layout (location = 6) out vec4 FragColor6;
 layout (location = 7) out vec4 FragColor7;
-
-layout (location = 0) in noperspective vec4 position;
 
 layout (std140, binding = EMULATION_UBO_BINDING) uniform fs_config {
     vec4 viewport_flip;


### PR DESCRIPTION
"position" was being written but not read anywhere besides geometry shaders, where it had the same value as gl_Position.

This commit replaces "position" with gl_Position, reducing the complexity of our code and the emitted GLSL code.