### PR TITLE
input_common/sdl/sdl_impl: Minor cleanup

### DIFF
--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -6,14 +6,7 @@
 
 #include <memory>
 #include <vector>
-#include "core/frontend/input.h"
 #include "input_common/main.h"
-
-union SDL_Event;
-
-namespace Common {
-class ParamPackage;
-} // namespace Common
 
 namespace InputCommon::Polling {
 class DevicePoller;

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -33,14 +33,16 @@ static std::string GetGUID(SDL_Joystick* joystick) {
 /// Creates a ParamPackage from an SDL_Event that can directly be used to create a ButtonDevice
 static Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Event& event);
 
-static int SDLEventWatcher(void* userdata, SDL_Event* event) {
-    SDLState* sdl_state = reinterpret_cast<SDLState*>(userdata);
+static int SDLEventWatcher(void* user_data, SDL_Event* event) {
+    auto* const sdl_state = static_cast<SDLState*>(user_data);
+
     // Don't handle the event if we are configuring
     if (sdl_state->polling) {
         sdl_state->event_queue.Push(*event);
     } else {
         sdl_state->HandleGameControllerEvent(*event);
     }
+
     return 0;
 }
 

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -51,7 +51,7 @@ public:
 
     void SetButton(int button, bool value) {
         std::lock_guard lock{mutex};
-        state.buttons[button] = value;
+        state.buttons.insert_or_assign(button, value);
     }
 
     bool GetButton(int button) const {
@@ -61,7 +61,7 @@ public:
 
     void SetAxis(int axis, Sint16 value) {
         std::lock_guard lock{mutex};
-        state.axes[axis] = value;
+        state.axes.insert_or_assign(axis, value);
     }
 
     float GetAxis(int axis) const {
@@ -88,7 +88,7 @@ public:
 
     void SetHat(int hat, Uint8 direction) {
         std::lock_guard lock{mutex};
-        state.hats[hat] = direction;
+        state.hats.insert_or_assign(hat, direction);
     }
 
     bool GetHatDirection(int hat, Uint8 direction) const {

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -24,7 +24,7 @@
 namespace InputCommon::SDL {
 
 static std::string GetGUID(SDL_Joystick* joystick) {
-    SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
+    const SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
     char guid_str[33];
     SDL_JoystickGetGUIDString(guid, guid_str, sizeof(guid_str));
     return guid_str;
@@ -158,7 +158,7 @@ std::shared_ptr<SDLJoystick> SDLState::GetSDLJoystickBySDLID(SDL_JoystickID sdl_
     const std::string guid = GetGUID(sdl_joystick);
 
     std::lock_guard lock{joystick_map_mutex};
-    auto map_it = joystick_map.find(guid);
+    const auto map_it = joystick_map.find(guid);
     if (map_it != joystick_map.end()) {
         const auto vec_it =
             std::find_if(map_it->second.begin(), map_it->second.end(),
@@ -320,9 +320,10 @@ public:
           trigger_if_greater(trigger_if_greater_) {}
 
     bool GetStatus() const override {
-        float axis_value = joystick->GetAxis(axis);
-        if (trigger_if_greater)
+        const float axis_value = joystick->GetAxis(axis);
+        if (trigger_if_greater) {
             return axis_value > threshold;
+        }
         return axis_value < threshold;
     }
 
@@ -447,7 +448,7 @@ public:
         const int port = params.Get("port", 0);
         const int axis_x = params.Get("axis_x", 0);
         const int axis_y = params.Get("axis_y", 1);
-        float deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, .99f);
+        const float deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, .99f);
 
         auto joystick = state.GetSDLJoystickByGUID(guid, port);
 
@@ -515,7 +516,7 @@ static Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const 
 
     switch (event.type) {
     case SDL_JOYAXISMOTION: {
-        auto joystick = state.GetSDLJoystickBySDLID(event.jaxis.which);
+        const auto joystick = state.GetSDLJoystickBySDLID(event.jaxis.which);
         params.Set("port", joystick->GetPort());
         params.Set("guid", joystick->GetGUID());
         params.Set("axis", event.jaxis.axis);
@@ -529,14 +530,14 @@ static Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const 
         break;
     }
     case SDL_JOYBUTTONUP: {
-        auto joystick = state.GetSDLJoystickBySDLID(event.jbutton.which);
+        const auto joystick = state.GetSDLJoystickBySDLID(event.jbutton.which);
         params.Set("port", joystick->GetPort());
         params.Set("guid", joystick->GetGUID());
         params.Set("button", event.jbutton.button);
         break;
     }
     case SDL_JOYHATMOTION: {
-        auto joystick = state.GetSDLJoystickBySDLID(event.jhat.which);
+        const auto joystick = state.GetSDLJoystickBySDLID(event.jhat.which);
         params.Set("port", joystick->GetPort());
         params.Set("guid", joystick->GetGUID());
         params.Set("hat", event.jhat.hat);
@@ -623,7 +624,7 @@ public:
             }
             // An analog device needs two axes, so we need to store the axis for later and wait for
             // a second SDL event. The axes also must be from the same joystick.
-            int axis = event.jaxis.axis;
+            const int axis = event.jaxis.axis;
             if (analog_xaxis == -1) {
                 analog_xaxis = axis;
                 analog_axes_joystick = event.jaxis.which;
@@ -634,7 +635,7 @@ public:
         }
         Common::ParamPackage params;
         if (analog_xaxis != -1 && analog_yaxis != -1) {
-            auto joystick = state.GetSDLJoystickBySDLID(event.jaxis.which);
+            const auto joystick = state.GetSDLJoystickBySDLID(event.jaxis.which);
             params.Set("engine", "sdl");
             params.Set("port", joystick->GetPort());
             params.Set("guid", joystick->GetGUID());

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -510,7 +510,7 @@ SDLState::~SDLState() {
     }
 }
 
-Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Event& event) {
+static Common::ParamPackage SDLEventToButtonParamPackage(SDLState& state, const SDL_Event& event) {
     Common::ParamPackage params({{"engine", "sdl"}});
 
     switch (event.type) {

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -467,7 +467,7 @@ SDLState::SDLState() {
         return;
     }
     if (SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1") == SDL_FALSE) {
-        LOG_ERROR(Input, "Failed to set Hint for background events", SDL_GetError());
+        LOG_ERROR(Input, "Failed to set hint for background events with: {}", SDL_GetError());
     }
 
     SDL_AddEventWatch(&SDLEventWatcher, this);

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -611,8 +611,8 @@ public:
         SDLPoller::Start();
 
         // Reset stored axes
-        analog_xaxis = -1;
-        analog_yaxis = -1;
+        analog_x_axis = -1;
+        analog_y_axis = -1;
         analog_axes_joystick = -1;
     }
 
@@ -625,24 +625,24 @@ public:
             // An analog device needs two axes, so we need to store the axis for later and wait for
             // a second SDL event. The axes also must be from the same joystick.
             const int axis = event.jaxis.axis;
-            if (analog_xaxis == -1) {
-                analog_xaxis = axis;
+            if (analog_x_axis == -1) {
+                analog_x_axis = axis;
                 analog_axes_joystick = event.jaxis.which;
-            } else if (analog_yaxis == -1 && analog_xaxis != axis &&
+            } else if (analog_y_axis == -1 && analog_x_axis != axis &&
                        analog_axes_joystick == event.jaxis.which) {
-                analog_yaxis = axis;
+                analog_y_axis = axis;
             }
         }
         Common::ParamPackage params;
-        if (analog_xaxis != -1 && analog_yaxis != -1) {
+        if (analog_x_axis != -1 && analog_y_axis != -1) {
             const auto joystick = state.GetSDLJoystickBySDLID(event.jaxis.which);
             params.Set("engine", "sdl");
             params.Set("port", joystick->GetPort());
             params.Set("guid", joystick->GetGUID());
-            params.Set("axis_x", analog_xaxis);
-            params.Set("axis_y", analog_yaxis);
-            analog_xaxis = -1;
-            analog_yaxis = -1;
+            params.Set("axis_x", analog_x_axis);
+            params.Set("axis_y", analog_y_axis);
+            analog_x_axis = -1;
+            analog_y_axis = -1;
             analog_axes_joystick = -1;
             return params;
         }
@@ -650,8 +650,8 @@ public:
     }
 
 private:
-    int analog_xaxis = -1;
-    int analog_yaxis = -1;
+    int analog_x_axis = -1;
+    int analog_y_axis = -1;
     SDL_JoystickID analog_axes_joystick = -1;
 };
 } // namespace Polling

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -6,7 +6,6 @@
 #include <atomic>
 #include <cmath>
 #include <functional>
-#include <iterator>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -15,7 +14,6 @@
 #include <utility>
 #include <vector>
 #include <SDL.h>
-#include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/param_package.h"

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -23,9 +23,7 @@
 #include "core/frontend/input.h"
 #include "input_common/sdl/sdl_impl.h"
 
-namespace InputCommon {
-
-namespace SDL {
+namespace InputCommon::SDL {
 
 static std::string GetGUID(SDL_Joystick* joystick) {
     SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
@@ -667,5 +665,4 @@ SDLState::Pollers SDLState::GetPollers(InputCommon::Polling::DeviceType type) {
     return pollers;
 }
 
-} // namespace SDL
-} // namespace InputCommon
+} // namespace InputCommon::SDL

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -131,9 +131,6 @@ private:
     mutable std::mutex mutex;
 };
 
-/**
- * Get the nth joystick with the corresponding GUID
- */
 std::shared_ptr<SDLJoystick> SDLState::GetSDLJoystickByGUID(const std::string& guid, int port) {
     std::lock_guard lock{joystick_map_mutex};
     const auto it = joystick_map.find(guid);
@@ -149,10 +146,6 @@ std::shared_ptr<SDLJoystick> SDLState::GetSDLJoystickByGUID(const std::string& g
     return joystick_map[guid].emplace_back(std::move(joystick));
 }
 
-/**
- * Check how many identical joysticks (by guid) were connected before the one with sdl_id and so tie
- * it to a SDLJoystick with the same guid and that port
- */
 std::shared_ptr<SDLJoystick> SDLState::GetSDLJoystickBySDLID(SDL_JoystickID sdl_id) {
     auto sdl_joystick = SDL_JoystickFromInstanceID(sdl_id);
     const std::string guid = GetGUID(sdl_joystick);

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -6,7 +6,10 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <thread>
+#include <unordered_map>
+#include "common/common_types.h"
 #include "common/threadsafe_queue.h"
 #include "input_common/sdl/sdl.h"
 
@@ -16,9 +19,9 @@ using SDL_JoystickID = s32;
 
 namespace InputCommon::SDL {
 
-class SDLJoystick;
-class SDLButtonFactory;
 class SDLAnalogFactory;
+class SDLButtonFactory;
+class SDLJoystick;
 
 class SDLState : public State {
 public:

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -34,7 +34,13 @@ public:
     /// Handle SDL_Events for joysticks from SDL_PollEvent
     void HandleGameControllerEvent(const SDL_Event& event);
 
+    /// Get the nth joystick with the corresponding GUID
     std::shared_ptr<SDLJoystick> GetSDLJoystickBySDLID(SDL_JoystickID sdl_id);
+
+    /**
+     * Check how many identical joysticks (by guid) were connected before the one with sdl_id and so
+     * tie it to a SDLJoystick with the same guid and that port
+     */
     std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const std::string& guid, int port);
 
     /// Get all DevicePoller that use the SDL backend for a specific device type


### PR DESCRIPTION
Performs a little bit of miscellaneous tidying up. Notably, this simplifies deleter handling for joystick instances and prevents a crash in the event a particular failure path is taken within the SDLState constructor.