### PR TITLE
kernel/process: Remove unused boost header include

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -10,7 +10,6 @@
 #include <list>
 #include <string>
 #include <vector>
-#include <boost/container/static_vector.hpp>
 #include "common/common_types.h"
 #include "core/hle/kernel/address_arbiter.h"
 #include "core/hle/kernel/handle_table.h"


### PR DESCRIPTION
Boost headers typically include a lot of other headers, so removing this can prevent a bit of unnecessary compiler churn when building.