### PR TITLE
yuzu/configuration: Make function naming consistent

### DIFF
--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -22,11 +22,11 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     }
 
     connect(ui->volume_slider, &QSlider::valueChanged, this,
-            &ConfigureAudio::setVolumeIndicatorText);
+            &ConfigureAudio::SetVolumeIndicatorText);
 
-    this->setConfiguration();
+    SetConfiguration();
     connect(ui->output_sink_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
-            &ConfigureAudio::updateAudioDevices);
+            &ConfigureAudio::UpdateAudioDevices);
 
     const bool is_powered_on = Core::System::GetInstance().IsPoweredOn();
     ui->output_sink_combo_box->setEnabled(!is_powered_on);
@@ -35,20 +35,20 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
 
 ConfigureAudio::~ConfigureAudio() = default;
 
-void ConfigureAudio::setConfiguration() {
-    setOutputSinkFromSinkID();
+void ConfigureAudio::SetConfiguration() {
+    SetOutputSinkFromSinkID();
 
     // The device list cannot be pre-populated (nor listed) until the output sink is known.
-    updateAudioDevices(ui->output_sink_combo_box->currentIndex());
+    UpdateAudioDevices(ui->output_sink_combo_box->currentIndex());
 
-    setAudioDeviceFromDeviceID();
+    SetAudioDeviceFromDeviceID();
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching);
     ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
-    setVolumeIndicatorText(ui->volume_slider->sliderPosition());
+    SetVolumeIndicatorText(ui->volume_slider->sliderPosition());
 }
 
-void ConfigureAudio::setOutputSinkFromSinkID() {
+void ConfigureAudio::SetOutputSinkFromSinkID() {
     int new_sink_index = 0;
 
     const QString sink_id = QString::fromStdString(Settings::values.sink_id);
@@ -62,7 +62,7 @@ void ConfigureAudio::setOutputSinkFromSinkID() {
     ui->output_sink_combo_box->setCurrentIndex(new_sink_index);
 }
 
-void ConfigureAudio::setAudioDeviceFromDeviceID() {
+void ConfigureAudio::SetAudioDeviceFromDeviceID() {
     int new_device_index = -1;
 
     const QString device_id = QString::fromStdString(Settings::values.audio_device_id);
@@ -76,11 +76,11 @@ void ConfigureAudio::setAudioDeviceFromDeviceID() {
     ui->audio_device_combo_box->setCurrentIndex(new_device_index);
 }
 
-void ConfigureAudio::setVolumeIndicatorText(int percentage) {
+void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
     ui->volume_indicator->setText(tr("%1%", "Volume percentage (e.g. 50%)").arg(percentage));
 }
 
-void ConfigureAudio::applyConfiguration() {
+void ConfigureAudio::ApplyConfiguration() {
     Settings::values.sink_id =
         ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
             .toStdString();
@@ -92,7 +92,7 @@ void ConfigureAudio::applyConfiguration() {
         static_cast<float>(ui->volume_slider->sliderPosition()) / ui->volume_slider->maximum();
 }
 
-void ConfigureAudio::updateAudioDevices(int sink_index) {
+void ConfigureAudio::UpdateAudioDevices(int sink_index) {
     ui->audio_device_combo_box->clear();
     ui->audio_device_combo_box->addItem(QString::fromUtf8(AudioCore::auto_device_name));
 
@@ -102,6 +102,6 @@ void ConfigureAudio::updateAudioDevices(int sink_index) {
     }
 }
 
-void ConfigureAudio::retranslateUi() {
+void ConfigureAudio::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -18,16 +18,16 @@ public:
     explicit ConfigureAudio(QWidget* parent = nullptr);
     ~ConfigureAudio() override;
 
-    void applyConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
+    void RetranslateUI();
 
 private:
-    void updateAudioDevices(int sink_index);
+    void UpdateAudioDevices(int sink_index);
 
-    void setConfiguration();
-    void setOutputSinkFromSinkID();
-    void setAudioDeviceFromDeviceID();
-    void setVolumeIndicatorText(int percentage);
+    void SetConfiguration();
+    void SetOutputSinkFromSinkID();
+    void SetAudioDeviceFromDeviceID();
+    void SetVolumeIndicatorText(int percentage);
 
     std::unique_ptr<Ui::ConfigureAudio> ui;
 };

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -16,7 +16,8 @@
 
 ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureDebug) {
     ui->setupUi(this);
-    this->setConfiguration();
+    SetConfiguration();
+
     connect(ui->open_log_button, &QPushButton::pressed, []() {
         QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
@@ -25,7 +26,7 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
 
 ConfigureDebug::~ConfigureDebug() = default;
 
-void ConfigureDebug::setConfiguration() {
+void ConfigureDebug::SetConfiguration() {
     ui->toggle_gdbstub->setChecked(Settings::values.use_gdbstub);
     ui->gdbport_spinbox->setEnabled(Settings::values.use_gdbstub);
     ui->gdbport_spinbox->setValue(Settings::values.gdbstub_port);
@@ -37,7 +38,7 @@ void ConfigureDebug::setConfiguration() {
     ui->dump_decompressed_nso->setChecked(Settings::values.dump_nso);
 }
 
-void ConfigureDebug::applyConfiguration() {
+void ConfigureDebug::ApplyConfiguration() {
     Settings::values.use_gdbstub = ui->toggle_gdbstub->isChecked();
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     UISettings::values.show_console = ui->toggle_console->isChecked();

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -18,10 +18,10 @@ public:
     explicit ConfigureDebug(QWidget* parent = nullptr);
     ~ConfigureDebug() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
-    void setConfiguration();
+    void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureDebug> ui;
 };

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -15,10 +15,10 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry)
     : QDialog(parent), ui(new Ui::ConfigureDialog), registry(registry) {
     ui->setupUi(this);
     ui->hotkeysTab->Populate(registry);
-    this->setConfiguration();
-    this->PopulateSelectionList();
-
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    SetConfiguration();
+    PopulateSelectionList();
 
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);
@@ -29,19 +29,19 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry)
 
 ConfigureDialog::~ConfigureDialog() = default;
 
-void ConfigureDialog::setConfiguration() {}
+void ConfigureDialog::SetConfiguration() {}
 
-void ConfigureDialog::applyConfiguration() {
-    ui->generalTab->applyConfiguration();
-    ui->gameListTab->applyConfiguration();
-    ui->systemTab->applyConfiguration();
-    ui->profileManagerTab->applyConfiguration();
-    ui->inputTab->applyConfiguration();
-    ui->hotkeysTab->applyConfiguration(registry);
-    ui->graphicsTab->applyConfiguration();
-    ui->audioTab->applyConfiguration();
-    ui->debugTab->applyConfiguration();
-    ui->webTab->applyConfiguration();
+void ConfigureDialog::ApplyConfiguration() {
+    ui->generalTab->ApplyConfiguration();
+    ui->gameListTab->ApplyConfiguration();
+    ui->systemTab->ApplyConfiguration();
+    ui->profileManagerTab->ApplyConfiguration();
+    ui->inputTab->ApplyConfiguration();
+    ui->hotkeysTab->ApplyConfiguration(registry);
+    ui->graphicsTab->ApplyConfiguration();
+    ui->audioTab->ApplyConfiguration();
+    ui->debugTab->ApplyConfiguration();
+    ui->webTab->ApplyConfiguration();
     Settings::Apply();
     Settings::LogSettings();
 }

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -20,10 +20,10 @@ public:
     explicit ConfigureDialog(QWidget* parent, HotkeyRegistry& registry);
     ~ConfigureDialog() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
-    void setConfiguration();
+    void SetConfiguration();
     void UpdateVisibleTabs();
     void PopulateSelectionList();
 

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -12,20 +12,20 @@
 #include "yuzu/ui_settings.h"
 
 namespace {
-constexpr std::array<std::pair<u32, const char*>, 5> default_icon_sizes{{
+constexpr std::array default_icon_sizes{
     std::make_pair(0, QT_TR_NOOP("None")),
     std::make_pair(32, QT_TR_NOOP("Small (32x32)")),
     std::make_pair(64, QT_TR_NOOP("Standard (64x64)")),
     std::make_pair(128, QT_TR_NOOP("Large (128x128)")),
     std::make_pair(256, QT_TR_NOOP("Full Size (256x256)")),
-}};
+};
 
-constexpr std::array<const char*, 4> row_text_names{{
+constexpr std::array row_text_names{
     QT_TR_NOOP("Filename"),
     QT_TR_NOOP("Filetype"),
     QT_TR_NOOP("Title ID"),
     QT_TR_NOOP("Title Name"),
-}};
+};
 } // Anonymous namespace
 
 ConfigureGameList::ConfigureGameList(QWidget* parent)
@@ -35,7 +35,7 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
     InitializeIconSizeComboBox();
     InitializeRowComboBoxes();
 
-    this->setConfiguration();
+    SetConfiguration();
 
     // Force game list reload if any of the relevant settings are changed.
     connect(ui->show_unknown, &QCheckBox::stateChanged, this,
@@ -50,7 +50,7 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
 
 ConfigureGameList::~ConfigureGameList() = default;
 
-void ConfigureGameList::applyConfiguration() {
+void ConfigureGameList::ApplyConfiguration() {
     UISettings::values.show_unknown = ui->show_unknown->isChecked();
     UISettings::values.show_add_ons = ui->show_add_ons->isChecked();
     UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
@@ -63,7 +63,7 @@ void ConfigureGameList::RequestGameListUpdate() {
     UISettings::values.is_game_list_reload_pending.exchange(true);
 }
 
-void ConfigureGameList::setConfiguration() {
+void ConfigureGameList::SetConfiguration() {
     ui->show_unknown->setChecked(UISettings::values.show_unknown);
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons);
     ui->icon_size_combobox->setCurrentIndex(

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -18,12 +18,12 @@ public:
     explicit ConfigureGameList(QWidget* parent = nullptr);
     ~ConfigureGameList() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
     void RequestGameListUpdate();
 
-    void setConfiguration();
+    void SetConfiguration();
 
     void changeEvent(QEvent*) override;
     void RetranslateUI();

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -18,7 +18,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
                                     QString::fromUtf8(theme.second));
     }
 
-    this->setConfiguration();
+    SetConfiguration();
 
     connect(ui->toggle_deepscan, &QCheckBox::stateChanged, this,
             [] { UISettings::values.is_game_list_reload_pending.exchange(true); });
@@ -28,7 +28,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
 ConfigureGeneral::~ConfigureGeneral() = default;
 
-void ConfigureGeneral::setConfiguration() {
+void ConfigureGeneral::SetConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.game_directory_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot);
@@ -36,7 +36,7 @@ void ConfigureGeneral::setConfiguration() {
     ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
 }
 
-void ConfigureGeneral::applyConfiguration() {
+void ConfigureGeneral::ApplyConfiguration() {
     UISettings::values.game_directory_deepscan = ui->toggle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
     UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -20,10 +20,10 @@ public:
     explicit ConfigureGeneral(QWidget* parent = nullptr);
     ~ConfigureGeneral() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
-    void setConfiguration();
+    void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureGeneral> ui;
 };

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -52,7 +52,8 @@ Resolution FromResolutionFactor(float factor) {
 ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGraphics) {
     ui->setupUi(this);
-    setConfiguration();
+
+    SetConfiguration();
 
     connect(ui->toggle_frame_limit, &QCheckBox::toggled, ui->frame_limit, &QSpinBox::setEnabled);
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
@@ -66,7 +67,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 
 ConfigureGraphics::~ConfigureGraphics() = default;
 
-void ConfigureGraphics::setConfiguration() {
+void ConfigureGraphics::SetConfiguration() {
     const bool runtime_lock = !Core::System::GetInstance().IsPoweredOn();
 
     ui->resolution_factor_combobox->setCurrentIndex(
@@ -87,7 +88,7 @@ void ConfigureGraphics::setConfiguration() {
                                                  Settings::values.bg_blue));
 }
 
-void ConfigureGraphics::applyConfiguration() {
+void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.resolution_factor =
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.use_frame_limit = ui->toggle_frame_limit->isChecked();

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -18,10 +18,10 @@ public:
     explicit ConfigureGraphics(QWidget* parent = nullptr);
     ~ConfigureGraphics() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
-    void setConfiguration();
+    void SetConfiguration();
 
     void UpdateBackgroundColorButton(QColor color);
 

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -92,7 +92,7 @@ bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) const {
     return false;
 }
 
-void ConfigureHotkeys::applyConfiguration(HotkeyRegistry& registry) {
+void ConfigureHotkeys::ApplyConfiguration(HotkeyRegistry& registry) {
     for (int key_id = 0; key_id < model->rowCount(); key_id++) {
         const QStandardItem* parent = model->item(key_id, 0);
         for (int key_column_id = 0; key_column_id < parent->rowCount(); key_column_id++) {
@@ -113,6 +113,6 @@ void ConfigureHotkeys::applyConfiguration(HotkeyRegistry& registry) {
     registry.SaveHotkeys();
 }
 
-void ConfigureHotkeys::retranslateUi() {
+void ConfigureHotkeys::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -21,8 +21,8 @@ public:
     explicit ConfigureHotkeys(QWidget* parent = nullptr);
     ~ConfigureHotkeys() override;
 
-    void applyConfiguration(HotkeyRegistry& registry);
-    void retranslateUi();
+    void ApplyConfiguration(HotkeyRegistry& registry);
+    void RetranslateUI();
 
     /**
      * Populates the hotkey list widget using data from the provided registry.

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -50,12 +50,12 @@ void OnDockedModeChanged(bool last_state, bool new_state) {
 namespace {
 template <typename Dialog, typename... Args>
 void CallConfigureDialog(ConfigureInput& parent, Args&&... args) {
-    parent.applyConfiguration();
+    parent.ApplyConfiguration();
     Dialog dialog(&parent, std::forward<Args>(args)...);
 
     const auto res = dialog.exec();
     if (res == QDialog::Accepted) {
-        dialog.applyConfiguration();
+        dialog.ApplyConfiguration();
     }
 }
 } // Anonymous namespace
@@ -79,24 +79,24 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                                   tr("Single Right Joycon"), tr("Single Left Joycon")});
     }
 
-    this->loadConfiguration();
-    updateUIEnabled();
+    LoadConfiguration();
+    UpdateUIEnabled();
 
     connect(ui->restore_defaults_button, &QPushButton::pressed, this,
-            &ConfigureInput::restoreDefaults);
+            &ConfigureInput::RestoreDefaults);
 
     for (auto* enabled : players_controller) {
         connect(enabled, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-                &ConfigureInput::updateUIEnabled);
+                &ConfigureInput::UpdateUIEnabled);
     }
-    connect(ui->use_docked_mode, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+    connect(ui->use_docked_mode, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
     connect(ui->handheld_connected, &QCheckBox::stateChanged, this,
-            &ConfigureInput::updateUIEnabled);
-    connect(ui->mouse_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
-    connect(ui->keyboard_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
-    connect(ui->debug_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+            &ConfigureInput::UpdateUIEnabled);
+    connect(ui->mouse_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
+    connect(ui->keyboard_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
+    connect(ui->debug_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
     connect(ui->touchscreen_enabled, &QCheckBox::stateChanged, this,
-            &ConfigureInput::updateUIEnabled);
+            &ConfigureInput::UpdateUIEnabled);
 
     for (std::size_t i = 0; i < players_configure.size(); ++i) {
         connect(players_configure[i], &QPushButton::pressed, this,
@@ -118,7 +118,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
 
 ConfigureInput::~ConfigureInput() = default;
 
-void ConfigureInput::applyConfiguration() {
+void ConfigureInput::ApplyConfiguration() {
     for (std::size_t i = 0; i < players_controller.size(); ++i) {
         const auto controller_type_index = players_controller[i]->currentIndex();
 
@@ -144,7 +144,7 @@ void ConfigureInput::applyConfiguration() {
     Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
 }
 
-void ConfigureInput::updateUIEnabled() {
+void ConfigureInput::UpdateUIEnabled() {
     bool hit_disabled = false;
     for (auto* player : players_controller) {
         player->setDisabled(hit_disabled);
@@ -168,7 +168,7 @@ void ConfigureInput::updateUIEnabled() {
     ui->touchscreen_advanced->setEnabled(ui->touchscreen_enabled->isChecked());
 }
 
-void ConfigureInput::loadConfiguration() {
+void ConfigureInput::LoadConfiguration() {
     std::stable_partition(
         Settings::values.players.begin(),
         Settings::values.players.begin() +
@@ -191,10 +191,10 @@ void ConfigureInput::loadConfiguration() {
     ui->keyboard_enabled->setChecked(Settings::values.keyboard_enabled);
     ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
 
-    updateUIEnabled();
+    UpdateUIEnabled();
 }
 
-void ConfigureInput::restoreDefaults() {
+void ConfigureInput::RestoreDefaults() {
     players_controller[0]->setCurrentIndex(2);
 
     for (std::size_t i = 1; i < players_controller.size(); ++i) {
@@ -207,5 +207,5 @@ void ConfigureInput::restoreDefaults() {
     ui->keyboard_enabled->setCheckState(Qt::Unchecked);
     ui->debug_enabled->setCheckState(Qt::Unchecked);
     ui->touchscreen_enabled->setCheckState(Qt::Checked);
-    updateUIEnabled();
+    UpdateUIEnabled();
 }

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -30,15 +30,15 @@ public:
     ~ConfigureInput() override;
 
     /// Save all button configurations to settings file
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
-    void updateUIEnabled();
+    void UpdateUIEnabled();
 
     /// Load configuration settings.
-    void loadConfiguration();
+    void LoadConfiguration();
     /// Restore all buttons to their default values.
-    void restoreDefaults();
+    void RestoreDefaults();
 
     std::unique_ptr<Ui::ConfigureInput> ui;
 

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -38,28 +38,28 @@ public:
     ~ConfigureInputPlayer() override;
 
     /// Save all button configurations to settings file
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
     void OnControllerButtonClick(int i);
 
     /// Load configuration settings.
-    void loadConfiguration();
+    void LoadConfiguration();
     /// Restore all buttons to their default values.
-    void restoreDefaults();
+    void RestoreDefaults();
     /// Clear all input configuration
     void ClearAll();
 
     /// Update UI to reflect current configuration.
-    void updateButtonLabels();
+    void UpdateButtonLabels();
 
     /// Called when the button was pressed.
-    void handleClick(QPushButton* button,
+    void HandleClick(QPushButton* button,
                      std::function<void(const Common::ParamPackage&)> new_input_setter,
                      InputCommon::Polling::DeviceType type);
 
     /// Finish polling and configure input using the input_setter
-    void setPollingResult(const Common::ParamPackage& params, bool abort);
+    void SetPollingResult(const Common::ParamPackage& params, bool abort);
 
     /// Handle key press events.
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/yuzu/configuration/configure_input_simple.cpp
+++ b/src/yuzu/configuration/configure_input_simple.cpp
@@ -15,12 +15,12 @@ namespace {
 
 template <typename Dialog, typename... Args>
 void CallConfigureDialog(ConfigureInputSimple* caller, Args&&... args) {
-    caller->applyConfiguration();
+    caller->ApplyConfiguration();
     Dialog dialog(caller, std::forward<Args>(args)...);
 
     const auto res = dialog.exec();
     if (res == QDialog::Accepted) {
-        dialog.applyConfiguration();
+        dialog.ApplyConfiguration();
     }
 }
 
@@ -103,27 +103,29 @@ ConfigureInputSimple::ConfigureInputSimple(QWidget* parent)
             &ConfigureInputSimple::OnSelectProfile);
     connect(ui->profile_configure, &QPushButton::pressed, this, &ConfigureInputSimple::OnConfigure);
 
-    this->loadConfiguration();
+    LoadConfiguration();
 }
 
 ConfigureInputSimple::~ConfigureInputSimple() = default;
 
-void ConfigureInputSimple::applyConfiguration() {
+void ConfigureInputSimple::ApplyConfiguration() {
     auto index = ui->profile_combobox->currentIndex();
     // Make the stored index for "Custom" very large so that if new profiles are added it
     // doesn't change.
-    if (index >= static_cast<int>(INPUT_PROFILES.size() - 1))
+    if (index >= static_cast<int>(INPUT_PROFILES.size() - 1)) {
         index = std::numeric_limits<int>::max();
+    }
 
     UISettings::values.profile_index = index;
 }
 
-void ConfigureInputSimple::loadConfiguration() {
+void ConfigureInputSimple::LoadConfiguration() {
     const auto index = UISettings::values.profile_index;
-    if (index >= static_cast<int>(INPUT_PROFILES.size()) || index < 0)
+    if (index >= static_cast<int>(INPUT_PROFILES.size()) || index < 0) {
         ui->profile_combobox->setCurrentIndex(static_cast<int>(INPUT_PROFILES.size() - 1));
-    else
+    } else {
         ui->profile_combobox->setCurrentIndex(index);
+    }
 }
 
 void ConfigureInputSimple::OnSelectProfile(int index) {

--- a/src/yuzu/configuration/configure_input_simple.h
+++ b/src/yuzu/configuration/configure_input_simple.h
@@ -27,11 +27,11 @@ public:
     ~ConfigureInputSimple() override;
 
     /// Save all button configurations to settings file
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
     /// Load configuration settings.
-    void loadConfiguration();
+    void LoadConfiguration();
 
     void OnSelectProfile(int index);
     void OnConfigure();

--- a/src/yuzu/configuration/configure_mouse_advanced.h
+++ b/src/yuzu/configuration/configure_mouse_advanced.h
@@ -25,26 +25,26 @@ public:
     explicit ConfigureMouseAdvanced(QWidget* parent);
     ~ConfigureMouseAdvanced() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
     /// Load configuration settings.
-    void loadConfiguration();
+    void LoadConfiguration();
     /// Restore all buttons to their default values.
-    void restoreDefaults();
+    void RestoreDefaults();
     /// Clear all input configuration
     void ClearAll();
 
     /// Update UI to reflect current configuration.
-    void updateButtonLabels();
+    void UpdateButtonLabels();
 
     /// Called when the button was pressed.
-    void handleClick(QPushButton* button,
+    void HandleClick(QPushButton* button,
                      std::function<void(const Common::ParamPackage&)> new_input_setter,
                      InputCommon::Polling::DeviceType type);
 
     /// Finish polling and configure input using the input_setter
-    void setPollingResult(const Common::ParamPackage& params, bool abort);
+    void SetPollingResult(const Common::ParamPackage& params, bool abort);
 
     /// Handle key press events.
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -67,12 +67,12 @@ ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent, u64 title_id)
     connect(item_model, &QStandardItemModel::itemChanged,
             [] { UISettings::values.is_game_list_reload_pending.exchange(true); });
 
-    this->loadConfiguration();
+    LoadConfiguration();
 }
 
 ConfigurePerGameGeneral::~ConfigurePerGameGeneral() = default;
 
-void ConfigurePerGameGeneral::applyConfiguration() {
+void ConfigurePerGameGeneral::ApplyConfiguration() {
     std::vector<std::string> disabled_addons;
 
     for (const auto& item : list_items) {
@@ -92,12 +92,12 @@ void ConfigurePerGameGeneral::applyConfiguration() {
     Settings::values.disabled_addons[title_id] = disabled_addons;
 }
 
-void ConfigurePerGameGeneral::loadFromFile(FileSys::VirtualFile file) {
+void ConfigurePerGameGeneral::LoadFromFile(FileSys::VirtualFile file) {
     this->file = std::move(file);
-    this->loadConfiguration();
+    LoadConfiguration();
 }
 
-void ConfigurePerGameGeneral::loadConfiguration() {
+void ConfigurePerGameGeneral::LoadConfiguration() {
     if (file == nullptr) {
         return;
     }

--- a/src/yuzu/configuration/configure_per_general.h
+++ b/src/yuzu/configuration/configure_per_general.h
@@ -30,11 +30,13 @@ public:
     ~ConfigurePerGameGeneral() override;
 
     /// Save all button configurations to settings file
-    void applyConfiguration();
+    void ApplyConfiguration();
 
-    void loadFromFile(FileSys::VirtualFile file);
+    void LoadFromFile(FileSys::VirtualFile file);
 
 private:
+    void LoadConfiguration();
+
     std::unique_ptr<Ui::ConfigurePerGameGeneral> ui;
     FileSys::VirtualFile file;
     u64 title_id;
@@ -45,6 +47,4 @@ private:
     QGraphicsScene* scene;
 
     std::vector<QList<QStandardItem*>> list_items;
-
-    void loadConfiguration();
 };

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -119,12 +119,12 @@ ConfigureProfileManager ::ConfigureProfileManager(QWidget* parent)
     scene = new QGraphicsScene;
     ui->current_user_icon->setScene(scene);
 
-    this->setConfiguration();
+    SetConfiguration();
 }
 
 ConfigureProfileManager::~ConfigureProfileManager() = default;
 
-void ConfigureProfileManager::setConfiguration() {
+void ConfigureProfileManager::SetConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
     item_model->removeRows(0, item_model->rowCount());
     list_items.clear();
@@ -164,9 +164,10 @@ void ConfigureProfileManager::UpdateCurrentUser() {
     ui->current_user_username->setText(username);
 }
 
-void ConfigureProfileManager::applyConfiguration() {
-    if (!enabled)
+void ConfigureProfileManager::ApplyConfiguration() {
+    if (!enabled) {
         return;
+    }
 
     Settings::Apply();
 }

--- a/src/yuzu/configuration/configure_profile_manager.h
+++ b/src/yuzu/configuration/configure_profile_manager.h
@@ -30,10 +30,11 @@ public:
     explicit ConfigureProfileManager(QWidget* parent = nullptr);
     ~ConfigureProfileManager() override;
 
-    void applyConfiguration();
-    void setConfiguration();
+    void ApplyConfiguration();
 
 private:
+    void SetConfiguration();
+
     void PopulateUserList();
     void UpdateCurrentUser();
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -23,22 +23,24 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
 
     connect(ui->rng_seed_checkbox, &QCheckBox::stateChanged, this, [this](bool checked) {
         ui->rng_seed_edit->setEnabled(checked);
-        if (!checked)
+        if (!checked) {
             ui->rng_seed_edit->setText(QStringLiteral("00000000"));
+        }
     });
 
     connect(ui->custom_rtc_checkbox, &QCheckBox::stateChanged, this, [this](bool checked) {
         ui->custom_rtc_edit->setEnabled(checked);
-        if (!checked)
+        if (!checked) {
             ui->custom_rtc_edit->setDateTime(QDateTime::currentDateTime());
+        }
     });
 
-    this->setConfiguration();
+    SetConfiguration();
 }
 
 ConfigureSystem::~ConfigureSystem() = default;
 
-void ConfigureSystem::setConfiguration() {
+void ConfigureSystem::SetConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
 
     ui->combo_language->setCurrentIndex(Settings::values.language_index);
@@ -61,22 +63,25 @@ void ConfigureSystem::setConfiguration() {
 
 void ConfigureSystem::ReadSystemSettings() {}
 
-void ConfigureSystem::applyConfiguration() {
-    if (!enabled)
+void ConfigureSystem::ApplyConfiguration() {
+    if (!enabled) {
         return;
+    }
 
     Settings::values.language_index = ui->combo_language->currentIndex();
 
-    if (ui->rng_seed_checkbox->isChecked())
+    if (ui->rng_seed_checkbox->isChecked()) {
         Settings::values.rng_seed = ui->rng_seed_edit->text().toULongLong(nullptr, 16);
-    else
+    } else {
         Settings::values.rng_seed = std::nullopt;
+    }
 
-    if (ui->custom_rtc_checkbox->isChecked())
+    if (ui->custom_rtc_checkbox->isChecked()) {
         Settings::values.custom_rtc =
             std::chrono::seconds(ui->custom_rtc_edit->dateTime().toSecsSinceEpoch());
-    else
+    } else {
         Settings::values.custom_rtc = std::nullopt;
+    }
 
     Settings::Apply();
 }
@@ -89,8 +94,10 @@ void ConfigureSystem::RefreshConsoleID() {
                               "if you use an outdated config savegame. Continue?");
     reply = QMessageBox::critical(this, tr("Warning"), warning_text,
                                   QMessageBox::No | QMessageBox::Yes);
-    if (reply == QMessageBox::No)
+    if (reply == QMessageBox::No) {
         return;
+    }
+
     u64 console_id{};
     ui->label_console_id->setText(
         tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -20,10 +20,11 @@ public:
     explicit ConfigureSystem(QWidget* parent = nullptr);
     ~ConfigureSystem() override;
 
-    void applyConfiguration();
-    void setConfiguration();
+    void ApplyConfiguration();
 
 private:
+    void SetConfiguration();
+
     void ReadSystemSettings();
 
     void RefreshConsoleID();

--- a/src/yuzu/configuration/configure_touchscreen_advanced.cpp
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.cpp
@@ -12,29 +12,29 @@ ConfigureTouchscreenAdvanced::ConfigureTouchscreenAdvanced(QWidget* parent)
     ui->setupUi(this);
 
     connect(ui->restore_defaults_button, &QPushButton::pressed, this,
-            &ConfigureTouchscreenAdvanced::restoreDefaults);
+            &ConfigureTouchscreenAdvanced::RestoreDefaults);
 
-    loadConfiguration();
+    LoadConfiguration();
     resize(0, 0);
 }
 
 ConfigureTouchscreenAdvanced::~ConfigureTouchscreenAdvanced() = default;
 
-void ConfigureTouchscreenAdvanced::applyConfiguration() {
+void ConfigureTouchscreenAdvanced::ApplyConfiguration() {
     Settings::values.touchscreen.finger = ui->finger_box->value();
     Settings::values.touchscreen.diameter_x = ui->diameter_x_box->value();
     Settings::values.touchscreen.diameter_y = ui->diameter_y_box->value();
     Settings::values.touchscreen.rotation_angle = ui->angle_box->value();
 }
 
-void ConfigureTouchscreenAdvanced::loadConfiguration() {
+void ConfigureTouchscreenAdvanced::LoadConfiguration() {
     ui->finger_box->setValue(Settings::values.touchscreen.finger);
     ui->diameter_x_box->setValue(Settings::values.touchscreen.diameter_x);
     ui->diameter_y_box->setValue(Settings::values.touchscreen.diameter_y);
     ui->angle_box->setValue(Settings::values.touchscreen.rotation_angle);
 }
 
-void ConfigureTouchscreenAdvanced::restoreDefaults() {
+void ConfigureTouchscreenAdvanced::RestoreDefaults() {
     ui->finger_box->setValue(0);
     ui->diameter_x_box->setValue(15);
     ui->diameter_y_box->setValue(15);

--- a/src/yuzu/configuration/configure_touchscreen_advanced.h
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.h
@@ -18,13 +18,13 @@ public:
     explicit ConfigureTouchscreenAdvanced(QWidget* parent);
     ~ConfigureTouchscreenAdvanced() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private:
     /// Load configuration settings.
-    void loadConfiguration();
+    void LoadConfiguration();
     /// Restore all buttons to their default values.
-    void restoreDefaults();
+    void RestoreDefaults();
 
     std::unique_ptr<Ui::ConfigureTouchscreenAdvanced> ui;
 };

--- a/src/yuzu/configuration/configure_web.cpp
+++ b/src/yuzu/configuration/configure_web.cpp
@@ -22,12 +22,12 @@ ConfigureWeb::ConfigureWeb(QWidget* parent)
 #ifndef USE_DISCORD_PRESENCE
     ui->discord_group->setVisible(false);
 #endif
-    this->setConfiguration();
+    SetConfiguration();
 }
 
 ConfigureWeb::~ConfigureWeb() = default;
 
-void ConfigureWeb::setConfiguration() {
+void ConfigureWeb::SetConfiguration() {
     ui->web_credentials_disclaimer->setWordWrap(true);
     ui->telemetry_learn_more->setOpenExternalLinks(true);
     ui->telemetry_learn_more->setText(
@@ -56,7 +56,7 @@ void ConfigureWeb::setConfiguration() {
     ui->toggle_discordrpc->setChecked(UISettings::values.enable_discord_presence);
 }
 
-void ConfigureWeb::applyConfiguration() {
+void ConfigureWeb::ApplyConfiguration() {
     Settings::values.enable_telemetry = ui->toggle_telemetry->isChecked();
     UISettings::values.enable_discord_presence = ui->toggle_discordrpc->isChecked();
     if (user_verified) {
@@ -121,6 +121,6 @@ void ConfigureWeb::OnLoginVerified() {
     }
 }
 
-void ConfigureWeb::retranslateUi() {
+void ConfigureWeb::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/yuzu/configuration/configure_web.h
+++ b/src/yuzu/configuration/configure_web.h
@@ -19,8 +19,8 @@ public:
     explicit ConfigureWeb(QWidget* parent = nullptr);
     ~ConfigureWeb() override;
 
-    void applyConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
+    void RetranslateUI();
 
 private:
     void RefreshTelemetryID();
@@ -28,7 +28,7 @@ private:
     void VerifyLogin();
     void OnLoginVerified();
 
-    void setConfiguration();
+    void SetConfiguration();
 
     bool user_verified = true;
     QFutureWatcher<bool> verify_watcher;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1294,10 +1294,10 @@ void GMainWindow::OnGameListOpenPerGameProperties(const std::string& file) {
     }
 
     ConfigurePerGameGeneral dialog(this, title_id);
-    dialog.loadFromFile(v_file);
+    dialog.LoadFromFile(v_file);
     auto result = dialog.exec();
     if (result == QDialog::Accepted) {
-        dialog.applyConfiguration();
+        dialog.ApplyConfiguration();
 
         const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
         if (reload) {
@@ -1688,26 +1688,31 @@ void GMainWindow::ToggleWindowMode() {
 }
 
 void GMainWindow::OnConfigure() {
-    ConfigureDialog configureDialog(this, hotkey_registry);
-    auto old_theme = UISettings::values.theme;
+    const auto old_theme = UISettings::values.theme;
     const bool old_discord_presence = UISettings::values.enable_discord_presence;
-    auto result = configureDialog.exec();
-    if (result == QDialog::Accepted) {
-        configureDialog.applyConfiguration();
-        InitializeHotkeys();
-        if (UISettings::values.theme != old_theme)
-            UpdateUITheme();
-        if (UISettings::values.enable_discord_presence != old_discord_presence)
-            SetDiscordEnabled(UISettings::values.enable_discord_presence);
 
-        const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
-        if (reload) {
-            game_list->PopulateAsync(UISettings::values.game_directory_path,
-                                     UISettings::values.game_directory_deepscan);
-        }
-
-        config->Save();
+    ConfigureDialog configure_dialog(this, hotkey_registry);
+    const auto result = configure_dialog.exec();
+    if (result != QDialog::Accepted) {
+        return;
     }
+
+    configure_dialog.ApplyConfiguration();
+    InitializeHotkeys();
+    if (UISettings::values.theme != old_theme) {
+        UpdateUITheme();
+    }
+    if (UISettings::values.enable_discord_presence != old_discord_presence) {
+        SetDiscordEnabled(UISettings::values.enable_discord_presence);
+    }
+
+    const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
+    if (reload) {
+        game_list->PopulateAsync(UISettings::values.game_directory_path,
+                                 UISettings::values.game_directory_deepscan);
+    }
+
+    config->Save();
 }
 
 void GMainWindow::OnLoadAmiibo() {


### PR DESCRIPTION
Makes the naming of functions match our project style (CamelCase), unless a Qt function is being overridden. Figured I'd get this out of the way before performing future work on making the configuration dialog itself more friendly when it comes to future handling translations (handling LanguageChanged events, which only one dialog tab handles properly right now; the game list tab)