### PR TITLE
yuzu/CMakeLists: Pass compilation flags that make it more difficult to cause bugs in Qt code 

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -159,6 +159,9 @@ target_compile_definitions(yuzu PRIVATE
     # Disable implicit conversions from/to C strings
     -DQT_NO_CAST_FROM_ASCII
     -DQT_NO_CAST_TO_ASCII
+
+    # Disable implicit type narrowing in signal/slot connect() calls.
+    -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
 )
 
 if (YUZU_ENABLE_COMPATIBILITY_REPORTING)

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -165,6 +165,9 @@ target_compile_definitions(yuzu PRIVATE
 
     # Disable unsafe overloads of QProcess' start() function.
     -DQT_NO_PROCESS_COMBINED_ARGUMENT_START
+
+    # Disable implicit QString->QUrl conversions to enforce use of proper resolving functions.
+    -DQT_NO_URL_CAST_FROM_STRING
 )
 
 if (YUZU_ENABLE_COMPATIBILITY_REPORTING)

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -162,6 +162,9 @@ target_compile_definitions(yuzu PRIVATE
 
     # Disable implicit type narrowing in signal/slot connect() calls.
     -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
+
+    # Disable unsafe overloads of QProcess' start() function.
+    -DQT_NO_PROCESS_COMBINED_ARGUMENT_START
 )
 
 if (YUZU_ENABLE_COMPATIBILITY_REPORTING)


### PR DESCRIPTION
Passes three defines that Qt doesn't enable by default that make it harder to introduce bugs in Qt frontend code. Mainly makes it so written code is required to be more explicit in expressing its intent. e.g. if narrowing is desirable, it should be explicitly handled so it's made evident the writer intended that behavior to happen, etc.