### PR TITLE
nsp: Fix various errors with loading and processing of extracted NSPs 

### DIFF
--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -14,6 +14,7 @@
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/partition_filesystem.h"
+#include "core/file_sys/program_metadata.h"
 #include "core/file_sys/submission_package.h"
 #include "core/loader/loader.h"
 
@@ -78,6 +79,10 @@ Loader::ResultStatus NSP::GetStatus() const {
 }
 
 Loader::ResultStatus NSP::GetProgramStatus(u64 title_id) const {
+    if (IsExtractedType() && GetExeFS() != nullptr && FileSys::IsDirectoryExeFS(GetExeFS())) {
+        return Loader::ResultStatus::Success;
+    }
+
     const auto iter = program_status.find(title_id);
     if (iter == program_status.end())
         return Loader::ResultStatus::ErrorNSPMissingProgramNCA;

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -77,7 +77,7 @@ AppLoader_NSP::LoadResult AppLoader_NSP::Load(Kernel::Process& process) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
 
-    if (title_id == 0) {
+    if (!nsp->IsExtractedType() && title_id == 0) {
         return {ResultStatus::ErrorNSPMissingProgramNCA, {}};
     }
 

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -26,20 +26,18 @@ AppLoader_NSP::AppLoader_NSP(FileSys::VirtualFile file)
 
     if (nsp->GetStatus() != ResultStatus::Success)
         return;
-    if (nsp->IsExtractedType())
-        return;
-
-    const auto control_nca =
-        nsp->GetNCA(nsp->GetProgramTitleID(), FileSys::ContentRecordType::Control);
-    if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success)
-        return;
-
-    std::tie(nacp_file, icon_file) =
-        FileSys::PatchManager(nsp->GetProgramTitleID()).ParseControlNCA(*control_nca);
 
     if (nsp->IsExtractedType()) {
         secondary_loader = std::make_unique<AppLoader_DeconstructedRomDirectory>(nsp->GetExeFS());
     } else {
+        const auto control_nca =
+            nsp->GetNCA(nsp->GetProgramTitleID(), FileSys::ContentRecordType::Control);
+        if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success)
+            return;
+
+        std::tie(nacp_file, icon_file) =
+            FileSys::PatchManager(nsp->GetProgramTitleID()).ParseControlNCA(*control_nca);
+
         if (title_id == 0)
             return;
 
@@ -56,11 +54,11 @@ FileType AppLoader_NSP::IdentifyType(const FileSys::VirtualFile& file) {
     if (nsp.GetStatus() == ResultStatus::Success) {
         // Extracted Type case
         if (nsp.IsExtractedType() && nsp.GetExeFS() != nullptr &&
-            FileSys::IsDirectoryExeFS(nsp.GetExeFS()) && nsp.GetRomFS() != nullptr) {
+            FileSys::IsDirectoryExeFS(nsp.GetExeFS())) {
             return FileType::NSP;
         }
 
-        // Non-Ectracted Type case
+        // Non-Extracted Type case
         if (!nsp.IsExtractedType() &&
             nsp.GetNCA(nsp.GetFirstTitleID(), FileSys::ContentRecordType::Program) != nullptr &&
             AppLoader_NCA::IdentifyType(nsp.GetNCAFile(
@@ -91,7 +89,8 @@ AppLoader_NSP::LoadResult AppLoader_NSP::Load(Kernel::Process& process) {
         return {nsp_program_status, {}};
     }
 
-    if (nsp->GetNCA(title_id, FileSys::ContentRecordType::Program) == nullptr) {
+    if (!nsp->IsExtractedType() &&
+        nsp->GetNCA(title_id, FileSys::ContentRecordType::Program) == nullptr) {
         if (!Core::Crypto::KeyManager::KeyFileExists(false)) {
             return {ResultStatus::ErrorMissingProductionKeyFile, {}};
         }


### PR DESCRIPTION
Since NSPs actually comprise two formats, one of which contains NCAs and the other contains the raw game executable, the NSP processing code had to be updated as many assumptions were made that make extracted type NSPs have no title ID (even if they have one in main.npdm) and have a Missing NCA error, which is true they don't have NCAs.

It is now possible to properly load these types of NSPs.