### PR TITLE
file_sys/ips_layer: Remove unnecessary reserve() call

### DIFF
--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -287,7 +287,6 @@ void IPSwitchCompiler::Parse() {
                 } else {
                     // hex replacement
                     const auto value = patch_line.substr(9);
-                    replace.reserve(value.size() / 2);
                     replace = Common::HexStringToVector(value, is_little_endian);
                 }
 


### PR DESCRIPTION
'replace' is assigned to on the following line, this isn't necessary, given the underlying data is going to be overwritten entirely.