### PR TITLE
service/audio/audren_u: Correct event reset type for the system event

### DIFF
--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -47,7 +47,7 @@ public:
 
         auto& system = Core::System::GetInstance();
         system_event = Kernel::WritableEvent::CreateEventPair(
-            system.Kernel(), Kernel::ResetType::Manual, "IAudioRenderer:SystemEvent");
+            system.Kernel(), Kernel::ResetType::Automatic, "IAudioRenderer:SystemEvent");
         renderer = std::make_unique<AudioCore::AudioRenderer>(system.CoreTiming(), audren_params,
                                                               system_event.writable);
     }


### PR DESCRIPTION
This is actually an auto-reset event in the audio service itself, not a manual one.