### PR TITLE
gl_device: Fix TestVariableAoffi test

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -43,8 +43,9 @@ bool Device::TestVariableAoffi() {
 // This is a unit test, please ignore me on apitrace bug reports.
 uniform sampler2D tex;
 uniform ivec2 variable_offset;
+out vec4 output_attribute;
 void main() {
-    gl_Position = textureOffset(tex, vec2(0), variable_offset);
+    output_attribute = textureOffset(tex, vec2(0), variable_offset);
 }
 )";
     const GLuint shader{glCreateShaderProgramv(GL_VERTEX_SHADER, 1, &AOFFI_TEST)};


### PR DESCRIPTION
This test is intended to be invalid GLSL, but it was being invalid in
two points instead of one. The intention is to use a non-immediate
parameter in a textureOffset like function.

The problem is that this shader was being compiled as a separable
shader object and the text was writting to gl_Position without a
redeclaration, being invalid GLSL.

Address that issue by using a user-defined output attribute.