### PR TITLE
gl_rasterizer: Disable PolygonOffset until correctly implemented

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1113,9 +1113,10 @@ void RasterizerOpenGL::SyncPolygonOffset() {
     state.polygon_offset.fill_enable = regs.polygon_offset_fill_enable != 0;
     state.polygon_offset.line_enable = regs.polygon_offset_line_enable != 0;
     state.polygon_offset.point_enable = regs.polygon_offset_point_enable != 0;
-    state.polygon_offset.units = regs.polygon_offset_units;
-    state.polygon_offset.factor = regs.polygon_offset_factor;
-    state.polygon_offset.clamp = regs.polygon_offset_clamp;
+    // TODO(Blinkhawk): units factor and clamp need to be reversed accordingly
+    // state.polygon_offset.units = regs.polygon_offset_units;
+    // state.polygon_offset.factor = regs.polygon_offset_factor;
+    // state.polygon_offset.clamp = regs.polygon_offset_clamp;
 }
 
 void RasterizerOpenGL::SyncAlphaTest() {

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -544,7 +544,7 @@ void OpenGLState::Apply() const {
     ApplyLogicOp();
     ApplyTextures();
     ApplySamplers();
-    ApplyPolygonOffset();
+    //ApplyPolygonOffset();
     ApplyAlphaTest();
 }
 


### PR DESCRIPTION
The current implementation of PolygonOffset uses the wrong values for 
units factor and clamp, thus casuing severe errors and inaccuricies on 
certain games. Disabling it won't have any negative effects other than 
pixels may fight for position causing certain almost unnoticeable 
flickering.