### PR TITLE
file_sys: Ignore DeltaFragment NCAs during installation 

### DIFF
--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -37,7 +37,7 @@ enum class ContentRecordType : u8 {
     Control = 3,
     Manual = 4,
     Legal = 5,
-    Patch = 6,
+    DeltaFragment = 6,
 };
 
 struct ContentRecord {

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -415,6 +415,9 @@ InstallResult RegisteredCache::InstallEntry(const NSP& nsp, bool overwrite_if_ex
     const auto cnmt_file = section0->GetFiles()[0];
     const CNMT cnmt(cnmt_file);
     for (const auto& record : cnmt.GetContentRecords()) {
+        // Ignore DeltaFragments, they are not useful to us
+        if (record.type == ContentRecordType::DeltaFragment)
+            continue;
         const auto nca = GetNCAFromNSPForID(nsp, record.nca_id);
         if (nca == nullptr)
             return InstallResult::ErrorCopyFailed;

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -397,8 +397,8 @@ InstallResult RegisteredCache::InstallEntry(const NSP& nsp, bool overwrite_if_ex
     });
 
     if (meta_iter == ncas.end()) {
-        LOG_ERROR(Loader, "The XCI you are attempting to install does not have a metadata NCA and "
-                          "is therefore malformed. Double check your encryption keys.");
+        LOG_ERROR(Loader, "The file you are attempting to install does not have a metadata NCA and "
+                          "is therefore malformed. Check your encryption keys.");
         return InstallResult::ErrorMetaFailed;
     }
 

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -248,10 +248,13 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
                 auto next_file = pfs->GetFile(fmt::format("{}.nca", id_string));
 
                 if (next_file == nullptr) {
-                    LOG_WARNING(Service_FS,
-                                "NCA with ID {}.nca is listed in content metadata, but cannot "
-                                "be found in PFS. NSP appears to be corrupted.",
-                                id_string);
+                    if (rec.type != ContentRecordType::DeltaFragment) {
+                        LOG_WARNING(Service_FS,
+                                    "NCA with ID {}.nca is listed in content metadata, but cannot "
+                                    "be found in PFS. NSP appears to be corrupted.",
+                                    id_string);
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
Fixes the installation error and warnings when installing a patch NSP without DeltaFragments. Many patch NSPs do not include these even if they're listed in the CNMT, since they are not useful outside of Nintendo's official patch installation process on real consoles, and there is no need to install them when they're present.

Also, I only renamed `ContentRecordType::Patch` since it has the most potential to cause confusion, but it may be a good idea to rename the rest of the values to their more common names as well (Manual -> HtmlDocument, Legal -> LegalInformation). I'm not 100% sure but I believe these names are official.