### PR TITLE
hid:StartLrAssignmentMode, hid:StopLrAssignmentMode, hid:SwapNpadAssi…

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -291,6 +291,7 @@ add_library(core STATIC
     hle/service/hid/irs.h
     hle/service/hid/xcd.cpp
     hle/service/hid/xcd.h
+    hle/service/hid/errors.h
     hle/service/hid/controllers/controller_base.cpp
     hle/service/hid/controllers/controller_base.h
     hle/service/hid/controllers/debug_pad.cpp

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -548,6 +548,36 @@ void Controller_NPad::DisconnectNPad(u32 npad_id) {
     connected_controllers[NPadIdToIndex(npad_id)].is_connected = false;
 }
 
+void Controller_NPad::StartLRAssignmentMode() {
+    // Nothing internally is used for lr assignment mode. Since we have the ability to set the
+    // controller types from boot, it doesn't really matter about showing a selection screen
+    is_in_lr_assignment_mode = true;
+}
+
+void Controller_NPad::StopLRAssignmentMode() {
+    is_in_lr_assignment_mode = false;
+}
+
+bool Controller_NPad::SwapNpadAssignment(u32 npad_id_1, u32 npad_id_2) {
+    if (npad_id_1 == NPAD_HANDHELD || npad_id_2 == NPAD_HANDHELD || npad_id_1 == NPAD_UNKNOWN ||
+        npad_id_2 == NPAD_UNKNOWN) {
+        return true;
+    }
+
+    if (!IsControllerSupported(connected_controllers[NPadIdToIndex(npad_id_1)].type) ||
+        !IsControllerSupported(connected_controllers[NPadIdToIndex(npad_id_2)].type)) {
+        return false;
+    }
+
+    std::swap(connected_controllers[NPadIdToIndex(npad_id_1)].type,
+              connected_controllers[NPadIdToIndex(npad_id_2)].type);
+
+    InitNewlyAddedControler(NPadIdToIndex(npad_id_1));
+    InitNewlyAddedControler(NPadIdToIndex(npad_id_2));
+
+    return true;
+}
+
 bool Controller_NPad::IsControllerSupported(NPadControllerType controller) {
     if (controller == NPadControllerType::Handheld) {
         // Handheld is not even a supported type, lets stop here

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -124,6 +124,10 @@ public:
     void ConnectAllDisconnectedControllers();
     void ClearAllControllers();
 
+    void StartLRAssignmentMode();
+    void StopLRAssignmentMode();
+    bool SwapNpadAssignment(u32 npad_id_1, u32 npad_id_2);
+
     // Logical OR for all buttons presses on all controllers
     // Specifically for cheat engine and other features.
     u32 GetAndResetPressState();
@@ -321,5 +325,6 @@ private:
     void RequestPadStateUpdate(u32 npad_id);
     std::array<ControllerPad, 10> npad_pad_states{};
     bool IsControllerSupported(NPadControllerType controller);
+    bool is_in_lr_assignment_mode{false};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/errors.h
+++ b/src/core/hle/service/hid/errors.h
@@ -1,0 +1,13 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/result.h"
+
+namespace Service::HID {
+
+constexpr ResultCode ERR_NPAD_NOT_CONNECTED{ErrorModule::HID, 710};
+
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -119,6 +119,9 @@ private:
     void StopSixAxisSensor(Kernel::HLERequestContext& ctx);
     void SetIsPalmaAllConnectable(Kernel::HLERequestContext& ctx);
     void SetPalmaBoostMode(Kernel::HLERequestContext& ctx);
+    void StartLrAssignmentMode(Kernel::HLERequestContext& ctx);
+    void StopLrAssignmentMode(Kernel::HLERequestContext& ctx);
+    void SwapNpadAssignment(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<IAppletResource> applet_resource;
 };


### PR DESCRIPTION
…gnment

StartLrAssignmentMode and StopLrAssignmentMode don't require any implementation as it's just used for showing the screen of changing the controller orientation if the user wishes to do so.  Ever since  this has not been needed as users can specify the controller orientation from the config and swap at any time. We store a private member just in case this gets used for anything extra in the future