### PR TITLE
kernel/vm_manager: Handle stack/TLS IO region placement a little better 

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -98,9 +98,9 @@ ResultCode MapUnmapMemorySanityChecks(const VMManager& vm_manager, VAddr dst_add
         return ERR_INVALID_ADDRESS_STATE;
     }
 
-    if (!vm_manager.IsWithinNewMapRegion(dst_addr, size)) {
+    if (!vm_manager.IsWithinStackRegion(dst_addr, size)) {
         LOG_ERROR(Kernel_SVC,
-                  "Destination is not within the new map region, addr=0x{:016X}, size=0x{:016X}",
+                  "Destination is not within the stack region, addr=0x{:016X}, size=0x{:016X}",
                   dst_addr, size);
         return ERR_INVALID_MEMORY_RANGE;
     }
@@ -726,8 +726,8 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         // 2.0.0+
         ASLRRegionBaseAddr = 12,
         ASLRRegionSize = 13,
-        NewMapRegionBaseAddr = 14,
-        NewMapRegionSize = 15,
+        StackRegionBaseAddr = 14,
+        StackRegionSize = 15,
         // 3.0.0+
         IsVirtualAddressMemoryEnabled = 16,
         PersonalMmHeapUsage = 17,
@@ -752,8 +752,8 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
     case GetInfoType::HeapRegionSize:
     case GetInfoType::ASLRRegionBaseAddr:
     case GetInfoType::ASLRRegionSize:
-    case GetInfoType::NewMapRegionBaseAddr:
-    case GetInfoType::NewMapRegionSize:
+    case GetInfoType::StackRegionBaseAddr:
+    case GetInfoType::StackRegionSize:
     case GetInfoType::TotalPhysicalMemoryAvailable:
     case GetInfoType::TotalPhysicalMemoryUsed:
     case GetInfoType::IsVirtualAddressMemoryEnabled:
@@ -806,12 +806,12 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             *result = process->VMManager().GetASLRRegionSize();
             return RESULT_SUCCESS;
 
-        case GetInfoType::NewMapRegionBaseAddr:
-            *result = process->VMManager().GetNewMapRegionBaseAddress();
+        case GetInfoType::StackRegionBaseAddr:
+            *result = process->VMManager().GetStackRegionBaseAddress();
             return RESULT_SUCCESS;
 
-        case GetInfoType::NewMapRegionSize:
-            *result = process->VMManager().GetNewMapRegionSize();
+        case GetInfoType::StackRegionSize:
+            *result = process->VMManager().GetStackRegionSize();
             return RESULT_SUCCESS;
 
         case GetInfoType::TotalPhysicalMemoryAvailable:

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -625,7 +625,7 @@ void VMManager::UpdatePageTableForVMA(const VirtualMemoryArea& vma) {
 void VMManager::InitializeMemoryRegionRanges(FileSys::ProgramAddressSpaceType type) {
     u64 map_region_size = 0;
     u64 heap_region_size = 0;
-    u64 new_map_region_size = 0;
+    u64 stack_region_size = 0;
     u64 tls_io_region_size = 0;
 
     u64 stack_and_tls_io_end = 0;
@@ -665,7 +665,7 @@ void VMManager::InitializeMemoryRegionRanges(FileSys::ProgramAddressSpaceType ty
         aslr_region_end = aslr_region_base + 0x7FF8000000;
         map_region_size = 0x1000000000;
         heap_region_size = 0x180000000;
-        new_map_region_size = 0x80000000;
+        stack_region_size = 0x80000000;
         tls_io_region_size = 0x1000000000;
         break;
     default:
@@ -685,15 +685,15 @@ void VMManager::InitializeMemoryRegionRanges(FileSys::ProgramAddressSpaceType ty
     heap_region_end = heap_region_base + heap_region_size;
     heap_end = heap_region_base;
 
-    new_map_region_base = heap_region_end;
-    new_map_region_end = new_map_region_base + new_map_region_size;
+    stack_region_base = heap_region_end;
+    stack_region_end = stack_region_base + stack_region_size;
 
-    tls_io_region_base = new_map_region_end;
+    tls_io_region_base = stack_region_end;
     tls_io_region_end = tls_io_region_base + tls_io_region_size;
 
-    if (new_map_region_size == 0) {
-        new_map_region_base = stack_and_tls_io_begin;
-        new_map_region_end = stack_and_tls_io_end;
+    if (stack_region_size == 0) {
+        stack_region_base = stack_and_tls_io_begin;
+        stack_region_end = stack_and_tls_io_end;
     }
 
     if (tls_io_region_size == 0) {
@@ -890,21 +890,21 @@ bool VMManager::IsWithinMapRegion(VAddr address, u64 size) const {
     return IsInsideAddressRange(address, size, GetMapRegionBaseAddress(), GetMapRegionEndAddress());
 }
 
-VAddr VMManager::GetNewMapRegionBaseAddress() const {
-    return new_map_region_base;
+VAddr VMManager::GetStackRegionBaseAddress() const {
+    return stack_region_base;
 }
 
-VAddr VMManager::GetNewMapRegionEndAddress() const {
-    return new_map_region_end;
+VAddr VMManager::GetStackRegionEndAddress() const {
+    return stack_region_end;
 }
 
-u64 VMManager::GetNewMapRegionSize() const {
-    return new_map_region_end - new_map_region_base;
+u64 VMManager::GetStackRegionSize() const {
+    return stack_region_end - stack_region_base;
 }
 
-bool VMManager::IsWithinNewMapRegion(VAddr address, u64 size) const {
-    return IsInsideAddressRange(address, size, GetNewMapRegionBaseAddress(),
-                                GetNewMapRegionEndAddress());
+bool VMManager::IsWithinStackRegion(VAddr address, u64 size) const {
+    return IsInsideAddressRange(address, size, GetStackRegionBaseAddress(),
+                                GetStackRegionEndAddress());
 }
 
 VAddr VMManager::GetTLSIORegionBaseAddress() const {

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -596,17 +596,17 @@ public:
     /// Determines whether or not the specified range is within the map region.
     bool IsWithinMapRegion(VAddr address, u64 size) const;
 
-    /// Gets the base address of the new map region.
-    VAddr GetNewMapRegionBaseAddress() const;
+    /// Gets the base address of the stack region.
+    VAddr GetStackRegionBaseAddress() const;
 
-    /// Gets the end address of the new map region.
-    VAddr GetNewMapRegionEndAddress() const;
+    /// Gets the end address of the stack region.
+    VAddr GetStackRegionEndAddress() const;
 
-    /// Gets the total size of the new map region in bytes.
-    u64 GetNewMapRegionSize() const;
+    /// Gets the total size of the stack region in bytes.
+    u64 GetStackRegionSize() const;
 
-    /// Determines whether or not the given address range is within the new map region
-    bool IsWithinNewMapRegion(VAddr address, u64 size) const;
+    /// Determines whether or not the given address range is within the stack region
+    bool IsWithinStackRegion(VAddr address, u64 size) const;
 
     /// Gets the base address of the TLS IO region.
     VAddr GetTLSIORegionBaseAddress() const;
@@ -726,8 +726,8 @@ private:
     VAddr map_region_base = 0;
     VAddr map_region_end = 0;
 
-    VAddr new_map_region_base = 0;
-    VAddr new_map_region_end = 0;
+    VAddr stack_region_base = 0;
+    VAddr stack_region_end = 0;
 
     VAddr tls_io_region_base = 0;
     VAddr tls_io_region_end = 0;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -16,11 +16,9 @@
 #include "core/core.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/vm_manager.h"
-#include "core/hle/lock.h"
 #include "core/memory.h"
 #include "core/memory_setup.h"
 #include "video_core/gpu.h"
-#include "video_core/renderer_base.h"
 
 namespace Memory {
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -8,10 +8,6 @@
 #include <string>
 #include "common/common_types.h"
 
-namespace Common {
-struct PageTable;
-}
-
 namespace Kernel {
 class Process;
 }


### PR DESCRIPTION
Handles the placement of the stack a little nicer compared to the previous code. This resolves a few asserts that may have occurred for some games since 

The stack (new map) region, shouldn't be the width of the entire address space if the size of the region calculation ends up being zero. It should be placed at the same location as the TLS IO region and also have the same size.

In the event the TLS IO region contains a size of zero, we should also be doing the same thing. This fixes our memory layout a little bit and also resolves some cases where assertions can trigger due to the memory layout being incorrect.

While we're at it, this also renames usages of "new map" to "stack" to disambiguate between the already existing map region. This will also be followed up with subsequent changes.