### PR TITLE
kernel/process: Allocate the process' TLS region during initialization 

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -186,19 +186,9 @@ ResultCode Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
 }
 
 void Process::Run(s32 main_thread_priority, u64 stack_size) {
-    // The kernel always ensures that the given stack size is page aligned.
-    main_thread_stack_size = Common::AlignUp(stack_size, Memory::PAGE_SIZE);
-
-    // Allocate and map the main thread stack
-    // TODO(bunnei): This is heap area that should be allocated by the kernel and not mapped as part
-    // of the user address space.
-    const VAddr mapping_address = vm_manager.GetTLSIORegionEndAddress() - main_thread_stack_size;
-    vm_manager
-        .MapMemoryBlock(mapping_address, std::make_shared<std::vector<u8>>(main_thread_stack_size),
-                        0, main_thread_stack_size, MemoryState::Stack)
-        .Unwrap();
-
+    AllocateMainThreadStack(stack_size);
     vm_manager.LogLayout();
+
     ChangeStatus(ProcessStatus::Running);
 
     SetupMainThread(*this, kernel, main_thread_priority);
@@ -326,5 +316,18 @@ void Process::ChangeStatus(ProcessStatus new_status) {
     is_signaled = true;
     WakeupAllWaitingThreads();
 }
+
+void Process::AllocateMainThreadStack(u64 stack_size) {
+    // The kernel always ensures that the given stack size is page aligned.
+    main_thread_stack_size = Common::AlignUp(stack_size, Memory::PAGE_SIZE);
+
+    // Allocate and map the main thread stack
+    const VAddr mapping_address = vm_manager.GetTLSIORegionEndAddress() - main_thread_stack_size;
+    vm_manager
+        .MapMemoryBlock(mapping_address, std::make_shared<std::vector<u8>>(main_thread_stack_size),
+                        0, main_thread_stack_size, MemoryState::Stack)
+        .Unwrap();
+}
+
 
 } // namespace Kernel

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -187,6 +187,8 @@ ResultCode Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
 
 void Process::Run(s32 main_thread_priority, u64 stack_size) {
     AllocateMainThreadStack(stack_size);
+    tls_region_address = CreateTLSRegion();
+
     vm_manager.LogLayout();
 
     ChangeStatus(ProcessStatus::Running);
@@ -217,6 +219,9 @@ void Process::PrepareForTermination() {
     stop_threads(system.Scheduler(1).GetThreadList());
     stop_threads(system.Scheduler(2).GetThreadList());
     stop_threads(system.Scheduler(3).GetThreadList());
+
+    FreeTLSRegion(tls_region_address);
+    tls_region_address = 0;
 
     ChangeStatus(ProcessStatus::Exited);
 }

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -135,6 +135,11 @@ public:
         return mutex;
     }
 
+    /// Gets the address to the process' dedicated TLS region.
+    VAddr GetTLSRegionAddress() const {
+        return tls_region_address;
+    }
+
     /// Gets the current status of the process
     ProcessStatus GetStatus() const {
         return status;
@@ -340,6 +345,9 @@ private:
     /// forms of services, such as lock arbitration, and condition
     /// variable related facilities.
     Mutex mutex;
+
+    /// Address indicating the location of the process' dedicated TLS region.
+    VAddr tls_region_address = 0;
 
     /// Random values for svcGetInfo RandomEntropy
     std::array<u64, RANDOM_ENTROPY_SIZE> random_entropy{};

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -280,6 +280,9 @@ private:
     /// a process signal.
     void ChangeStatus(ProcessStatus new_status);
 
+    /// Allocates the main thread stack for the process, given the stack size in bytes.
+    void AllocateMainThreadStack(u64 stack_size);
+
     /// Memory manager for this process.
     Kernel::VMManager vm_manager;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -831,9 +831,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             return RESULT_SUCCESS;
 
         case GetInfoType::UserExceptionContextAddr:
-            LOG_WARNING(Kernel_SVC,
-                        "(STUBBED) Attempted to query user exception context address, returned 0");
-            *result = 0;
+            *result = process->GetTLSRegionAddress();
             return RESULT_SUCCESS;
 
         case GetInfoType::TotalPhysicalMemoryAvailableWithoutMmHeap:


### PR DESCRIPTION
Prior to execution within a process beginning, the process establishes its own TLS region for uses (as far as I can tell) related to exception handling.

Now that TLS creation was decoupled from threads themselves, we can add this behavior to our Process class. This is also good, as it allows us to remove a stub within svcGetInfo, namely querying the address of that region.