### PR TITLE
video_core: Add missing override specifiersvideo_core: Add missing override specifiers

### DIFF
--- a/src/video_core/renderer_opengl/gl_sampler_cache.h
+++ b/src/video_core/renderer_opengl/gl_sampler_cache.h
@@ -17,9 +17,9 @@ public:
     ~SamplerCacheOpenGL();
 
 protected:
-    OGLSampler CreateSampler(const Tegra::Texture::TSCEntry& tsc) const;
+    OGLSampler CreateSampler(const Tegra::Texture::TSCEntry& tsc) const override;
 
-    GLuint ToSamplerType(const OGLSampler& sampler) const;
+    GLuint ToSamplerType(const OGLSampler& sampler) const override;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.h
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.h
@@ -21,9 +21,9 @@ public:
     ~VKSamplerCache();
 
 protected:
-    UniqueSampler CreateSampler(const Tegra::Texture::TSCEntry& tsc) const;
+    UniqueSampler CreateSampler(const Tegra::Texture::TSCEntry& tsc) const override;
 
-    vk::Sampler ToSamplerType(const UniqueSampler& sampler) const;
+    vk::Sampler ToSamplerType(const UniqueSampler& sampler) const override;
 
 private:
     const VKDevice& device;

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.h
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.h
@@ -4,9 +4,6 @@
 
 #pragma once
 
-#include <unordered_map>
-
-#include "common/common_types.h"
 #include "video_core/renderer_vulkan/declarations.h"
 #include "video_core/sampler_cache.h"
 #include "video_core/textures/texture.h"


### PR DESCRIPTION
Given these functions are implementations of functions in the base class, they should be marked override.