### PR TITLE
Restore memory perms on svcUnmapMemory/UnloadNro 

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -318,7 +318,14 @@ static ResultCode UnmapMemory(Core::System& system, VAddr dst_addr, VAddr src_ad
         return result;
     }
 
-    return vm_manager.UnmapRange(dst_addr, size);
+    const auto unmap_res = vm_manager.UnmapRange(dst_addr, size);
+
+    // Reprotect the source mapping on success
+    if (unmap_res.IsSuccess()) {
+        ASSERT(vm_manager.ReprotectRange(src_addr, size, VMAPermission::ReadWrite).IsSuccess());
+    }
+
+    return unmap_res;
 }
 
 /// Connect to an OS service given the port name, returns the handle to the port to out


### PR DESCRIPTION
Prior to PR, Yuzu did not restore memory to RW- on unmap of mirrored memory or unloading of NRO.

(In fact, in the NRO case, the memory was unmapped instead of reprotected to --- on Load, so it was actually lost entirely...)

This PR addresses that, and restores memory to RW- as it should.

This fixes a crash in Super Smash Bros when creating a World of Light save for the first time, and possibly other games/circumstances.