### PR TITLE
core: Remove CurrentArmInterface() global accessor

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -327,10 +327,6 @@ private:
     static System s_instance;
 };
 
-inline ARM_Interface& CurrentArmInterface() {
-    return System::GetInstance().CurrentArmInterface();
-}
-
 inline Kernel::Process* CurrentProcess() {
     return System::GetInstance().CurrentProcess();
 }


### PR DESCRIPTION
Replaces the final usage of the global accessor function and removes it.
Removes one more enabler of global state.