### PR TITLE
gl_texture_cache: Implement asynchronous flushing 

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(video_core STATIC
     shader/shader_ir.cpp
     shader/shader_ir.h
     shader/track.cpp
+    staging_buffer_cache.h
     surface.cpp
     surface.h
     texture_cache/surface_base.cpp

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -62,6 +62,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_shader_manager.h
     renderer_opengl/gl_shader_util.cpp
     renderer_opengl/gl_shader_util.h
+    renderer_opengl/gl_staging_buffer.cpp
+    renderer_opengl/gl_staging_buffer.h
     renderer_opengl/gl_state.cpp
     renderer_opengl/gl_state.h
     renderer_opengl/gl_stream_buffer.cpp

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -4,6 +4,8 @@
 
 #include <array>
 #include <cstddef>
+#include <string_view>
+
 #include <glad/glad.h>
 
 #include "common/logging/log.h"
@@ -23,12 +25,16 @@ T GetInteger(GLenum pname) {
 } // Anonymous namespace
 
 Device::Device() {
+    const std::string_view vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    const bool intel_proprietary = vendor == "Intel";
+
     uniform_buffer_alignment = GetInteger<std::size_t>(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT);
     shader_storage_alignment = GetInteger<std::size_t>(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT);
     max_vertex_attributes = GetInteger<u32>(GL_MAX_VERTEX_ATTRIBS);
     max_varyings = GetInteger<u32>(GL_MAX_VARYING_VECTORS);
     has_variable_aoffi = TestVariableAoffi();
     has_component_indexing_bug = TestComponentIndexingBug();
+    has_broken_pbo_streaming = intel_proprietary;
 }
 
 Device::Device(std::nullptr_t) {
@@ -37,6 +43,7 @@ Device::Device(std::nullptr_t) {
     max_varyings = 15;
     has_variable_aoffi = true;
     has_component_indexing_bug = false;
+    has_broken_pbo_streaming = false;
 }
 
 bool Device::TestVariableAoffi() {
@@ -60,6 +67,7 @@ void main() {
 }
 
 bool Device::TestComponentIndexingBug() {
+    return false;
     constexpr char log_message[] = "Renderer_ComponentIndexingBug: {}";
     const GLchar* COMPONENT_TEST = R"(#version 430 core
 layout (std430, binding = 0) buffer OutputBuffer {

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -38,6 +38,10 @@ public:
         return has_component_indexing_bug;
     }
 
+    bool HasBrokenPBOStreaming() const {
+        return has_broken_pbo_streaming;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestComponentIndexingBug();
@@ -48,6 +52,7 @@ private:
     u32 max_varyings{};
     bool has_variable_aoffi{};
     bool has_component_indexing_bug{};
+    bool has_broken_pbo_streaming{};
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.cpp
@@ -11,6 +11,154 @@
 
 namespace OpenGL {
 
+class PersistentStagingBuffer final : public StagingBuffer {
+public:
+    explicit PersistentStagingBuffer(std::size_t size, bool is_read_buffer)
+        : is_read_buffer{is_read_buffer} {
+        constexpr GLenum storage_read = GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
+        constexpr GLenum storage_write = GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT;
+        constexpr GLenum map_read = GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
+        constexpr GLenum map_write = GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT |
+                                     GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_UNSYNCHRONIZED_BIT;
+        const GLenum storage = is_read_buffer ? storage_read : storage_write;
+        const GLenum map = is_read_buffer ? map_read : map_write;
+
+        buffer.Create();
+        glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr, storage);
+        pointer = reinterpret_cast<u8*>(
+            glMapNamedBufferRange(buffer.handle, 0, static_cast<GLsizeiptr>(size), map));
+    }
+
+    ~PersistentStagingBuffer() override {
+        if (sync) {
+            glDeleteSync(sync);
+        }
+    }
+
+    u8* GetOpenGLPointer() const override {
+        // Operations with a bound OpenGL buffer start with an offset of 0.
+        return nullptr;
+    }
+
+    u8* Map([[maybe_unused]] std::size_t size) const override {
+        return pointer;
+    }
+
+    void Unmap(std::size_t size) const override {
+        if (!is_read_buffer) {
+            // We flush the buffer on write operations
+            glFlushMappedNamedBufferRange(buffer.handle, 0, size);
+        }
+    }
+
+    void QueueFence(bool own) override {
+        DEBUG_ASSERT(!sync);
+        owned = own;
+        sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    }
+
+    void WaitFence() override {
+        DEBUG_ASSERT(sync);
+        switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
+        case GL_ALREADY_SIGNALED:
+        case GL_CONDITION_SATISFIED:
+            break;
+        case GL_TIMEOUT_EXPIRED:
+        case GL_WAIT_FAILED:
+            UNREACHABLE_MSG("Fence wait failed");
+            break;
+        }
+        Discard();
+    }
+
+    void Discard() override {
+        DEBUG_ASSERT(sync);
+        glDeleteSync(sync);
+        sync = nullptr;
+        owned = false;
+    }
+
+    bool IsAvailable() override {
+        if (owned) {
+            return false;
+        }
+        if (!sync) {
+            return true;
+        }
+        switch (glClientWaitSync(sync, 0, 0)) {
+        case GL_TIMEOUT_EXPIRED:
+            // The fence is unavailable
+            return false;
+        case GL_ALREADY_SIGNALED:
+        case GL_CONDITION_SATISFIED:
+            break;
+        case GL_WAIT_FAILED:
+            UNREACHABLE_MSG("Fence wait failed");
+            break;
+        default:
+            UNREACHABLE_MSG("Unknown glClientWaitSync result");
+            break;
+        }
+        // The fence has been signaled, we can destroy it
+        glDeleteSync(sync);
+        sync = nullptr;
+        return true;
+    }
+
+    void Bind(GLenum target) const override {
+        glBindBuffer(target, buffer.handle);
+    }
+
+private:
+    OGLBuffer buffer;
+    GLsync sync{};
+    u8* pointer{};
+    bool is_read_buffer{};
+    bool owned{};
+};
+
+class CpuStagingBuffer final : public StagingBuffer {
+public:
+    explicit CpuStagingBuffer(std::size_t size) : pointer{std::make_unique<u8[]>(size)} {}
+
+    ~CpuStagingBuffer() override = default;
+
+    u8* Map([[maybe_unused]] std::size_t size) const override {
+        return pointer.get();
+    }
+
+    u8* GetOpenGLPointer() const override {
+        return pointer.get();
+    }
+
+    void Unmap([[maybe_unused]] std::size_t size) const override {}
+
+    void QueueFence(bool own) override {
+        // We don't queue anything here
+    }
+
+    void WaitFence() override {
+        // CPU operations are immediate, we don't wait for anything
+    }
+
+    void Discard() override {
+        UNREACHABLE_MSG("CpuStagingBuffer doesn't support deferred operations");
+    }
+
+    bool IsAvailable() override {
+        // A CPU buffer is always available, operations are immediate
+        return true;
+    }
+
+    void Bind(GLenum target) const override {
+        // OpenGL operations that use CPU buffers need that the target is zero
+        glBindBuffer(target, 0);
+    }
+
+private:
+    std::unique_ptr<u8[]> pointer;
+};
+
 StagingBufferCache::StagingBufferCache(const Device& device)
     : VideoCommon::StagingBufferCache<StagingBuffer>{!device.HasBrokenPBOStreaming()},
       device{device} {}
@@ -19,130 +167,10 @@ StagingBufferCache::~StagingBufferCache() = default;
 
 std::unique_ptr<StagingBuffer> StagingBufferCache::CreateBuffer(std::size_t size, bool is_flush) {
     if (device.HasBrokenPBOStreaming()) {
-        return std::unique_ptr<StagingBuffer>(new CpuStagingBuffer(size, is_flush));
+        return std::unique_ptr<StagingBuffer>(new CpuStagingBuffer(size));
     } else {
         return std::unique_ptr<StagingBuffer>(new PersistentStagingBuffer(size, is_flush));
     }
-}
-
-PersistentStagingBuffer::PersistentStagingBuffer(std::size_t size, bool is_readable)
-    : is_readable{is_readable} {
-    buffer.Create();
-    glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr,
-                         GL_MAP_PERSISTENT_BIT |
-                             (is_readable ? GL_MAP_READ_BIT : GL_MAP_WRITE_BIT));
-    pointer = reinterpret_cast<u8*>(glMapNamedBufferRange(
-        buffer.handle, 0, static_cast<GLsizeiptr>(size),
-        GL_MAP_PERSISTENT_BIT | (is_readable ? GL_MAP_READ_BIT
-                                             : (GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
-                                                GL_MAP_UNSYNCHRONIZED_BIT))));
-}
-
-PersistentStagingBuffer::~PersistentStagingBuffer() {
-    if (sync) {
-        glDeleteSync(sync);
-    }
-}
-
-u8* PersistentStagingBuffer::GetOpenGLPointer() const {
-    return nullptr;
-}
-
-u8* PersistentStagingBuffer::Map([[maybe_unused]] std::size_t size) const {
-    return pointer;
-}
-
-void PersistentStagingBuffer::Unmap(std::size_t size) const {
-    if (!is_readable) {
-        glFlushMappedNamedBufferRange(buffer.handle, 0, size);
-    }
-}
-
-void PersistentStagingBuffer::QueueFence(bool own) {
-    DEBUG_ASSERT(!sync);
-    owned = own;
-    sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-}
-
-void PersistentStagingBuffer::WaitFence() {
-    DEBUG_ASSERT(sync);
-    switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
-    case GL_ALREADY_SIGNALED:
-    case GL_CONDITION_SATISFIED:
-        break;
-    case GL_TIMEOUT_EXPIRED:
-    case GL_WAIT_FAILED:
-        UNREACHABLE_MSG("Fence wait failed");
-        break;
-    }
-    Discard();
-}
-
-void PersistentStagingBuffer::Discard() {
-    DEBUG_ASSERT(sync);
-    glDeleteSync(sync);
-    sync = nullptr;
-    owned = false;
-}
-
-bool PersistentStagingBuffer::IsAvailable() {
-    if (owned) {
-        return false;
-    }
-    if (!sync) {
-        return true;
-    }
-    switch (glClientWaitSync(sync, 0, 0)) {
-    case GL_TIMEOUT_EXPIRED:
-        return false;
-    case GL_ALREADY_SIGNALED:
-    case GL_CONDITION_SATISFIED:
-        break;
-    case GL_WAIT_FAILED:
-        UNREACHABLE_MSG("Fence wait failed");
-        break;
-    default:
-        UNREACHABLE_MSG("Unknown glClientWaitSync result");
-        break;
-    }
-    glDeleteSync(sync);
-    sync = nullptr;
-    return true;
-}
-
-void PersistentStagingBuffer::Bind(GLenum target) const {
-    glBindBuffer(target, buffer.handle);
-}
-
-CpuStagingBuffer::CpuStagingBuffer(std::size_t size, bool is_readable)
-    : pointer{std::make_unique<u8[]>(size)} {}
-
-CpuStagingBuffer::~CpuStagingBuffer() = default;
-
-u8* CpuStagingBuffer::Map(std::size_t size) const {
-    return pointer.get();
-}
-
-u8* CpuStagingBuffer::GetOpenGLPointer() const {
-    return pointer.get();
-}
-
-void CpuStagingBuffer::Unmap(std::size_t size) const {}
-
-void CpuStagingBuffer::QueueFence(bool own) {}
-
-void CpuStagingBuffer::WaitFence() {}
-
-void CpuStagingBuffer::Discard() {
-    UNREACHABLE();
-}
-
-bool CpuStagingBuffer::IsAvailable() {
-    return true;
-}
-
-void CpuStagingBuffer::Bind(GLenum target) const {
-    glBindBuffer(target, 0);
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.cpp
@@ -1,0 +1,148 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include <glad/glad.h>
+#include "common/assert.h"
+#include "video_core/renderer_opengl/gl_device.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_staging_buffer.h"
+
+namespace OpenGL {
+
+StagingBufferCache::StagingBufferCache(const Device& device)
+    : VideoCommon::StagingBufferCache<StagingBuffer>{!device.HasBrokenPBOStreaming()},
+      device{device} {}
+
+StagingBufferCache::~StagingBufferCache() = default;
+
+std::unique_ptr<StagingBuffer> StagingBufferCache::CreateBuffer(std::size_t size, bool is_flush) {
+    if (device.HasBrokenPBOStreaming()) {
+        return std::unique_ptr<StagingBuffer>(new CpuStagingBuffer(size, is_flush));
+    } else {
+        return std::unique_ptr<StagingBuffer>(new PersistentStagingBuffer(size, is_flush));
+    }
+}
+
+PersistentStagingBuffer::PersistentStagingBuffer(std::size_t size, bool is_readable)
+    : is_readable{is_readable} {
+    buffer.Create();
+    glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr,
+                         GL_MAP_PERSISTENT_BIT |
+                             (is_readable ? GL_MAP_READ_BIT : GL_MAP_WRITE_BIT));
+    pointer = reinterpret_cast<u8*>(glMapNamedBufferRange(
+        buffer.handle, 0, static_cast<GLsizeiptr>(size),
+        GL_MAP_PERSISTENT_BIT | (is_readable ? GL_MAP_READ_BIT
+                                             : (GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
+                                                GL_MAP_UNSYNCHRONIZED_BIT))));
+}
+
+PersistentStagingBuffer::~PersistentStagingBuffer() {
+    if (sync) {
+        glDeleteSync(sync);
+    }
+}
+
+u8* PersistentStagingBuffer::GetOpenGLPointer() const {
+    return nullptr;
+}
+
+u8* PersistentStagingBuffer::Map([[maybe_unused]] std::size_t size) const {
+    return pointer;
+}
+
+void PersistentStagingBuffer::Unmap(std::size_t size) const {
+    if (!is_readable) {
+        glFlushMappedNamedBufferRange(buffer.handle, 0, size);
+    }
+}
+
+void PersistentStagingBuffer::QueueFence(bool own) {
+    DEBUG_ASSERT(!sync);
+    owned = own;
+    sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+}
+
+void PersistentStagingBuffer::WaitFence() {
+    DEBUG_ASSERT(sync);
+    switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
+    case GL_ALREADY_SIGNALED:
+    case GL_CONDITION_SATISFIED:
+        break;
+    case GL_TIMEOUT_EXPIRED:
+    case GL_WAIT_FAILED:
+        UNREACHABLE_MSG("Fence wait failed");
+        break;
+    }
+    Discard();
+}
+
+void PersistentStagingBuffer::Discard() {
+    DEBUG_ASSERT(sync);
+    glDeleteSync(sync);
+    sync = nullptr;
+    owned = false;
+}
+
+bool PersistentStagingBuffer::IsAvailable() {
+    if (owned) {
+        return false;
+    }
+    if (!sync) {
+        return true;
+    }
+    switch (glClientWaitSync(sync, 0, 0)) {
+    case GL_TIMEOUT_EXPIRED:
+        return false;
+    case GL_ALREADY_SIGNALED:
+    case GL_CONDITION_SATISFIED:
+        break;
+    case GL_WAIT_FAILED:
+        UNREACHABLE_MSG("Fence wait failed");
+        break;
+    default:
+        UNREACHABLE_MSG("Unknown glClientWaitSync result");
+        break;
+    }
+    glDeleteSync(sync);
+    sync = nullptr;
+    return true;
+}
+
+void PersistentStagingBuffer::Bind(GLenum target) const {
+    glBindBuffer(target, buffer.handle);
+}
+
+CpuStagingBuffer::CpuStagingBuffer(std::size_t size, bool is_readable)
+    : pointer{std::make_unique<u8[]>(size)} {}
+
+CpuStagingBuffer::~CpuStagingBuffer() = default;
+
+u8* CpuStagingBuffer::Map(std::size_t size) const {
+    return pointer.get();
+}
+
+u8* CpuStagingBuffer::GetOpenGLPointer() const {
+    return pointer.get();
+}
+
+void CpuStagingBuffer::Unmap(std::size_t size) const {}
+
+void CpuStagingBuffer::QueueFence(bool own) {}
+
+void CpuStagingBuffer::WaitFence() {}
+
+void CpuStagingBuffer::Discard() {
+    UNREACHABLE();
+}
+
+bool CpuStagingBuffer::IsAvailable() {
+    return true;
+}
+
+void CpuStagingBuffer::Bind(GLenum target) const {
+    glBindBuffer(target, 0);
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.h
@@ -31,75 +31,30 @@ class StagingBuffer : public NonCopyable {
 public:
     virtual ~StagingBuffer() = default;
 
+    /// Returns the base pointer passed to an OpenGL function.
     [[nodiscard]] virtual u8* GetOpenGLPointer() const = 0;
 
+    /// Maps the staging buffer.
     [[nodiscard]] virtual u8* Map(std::size_t size) const = 0;
 
+    /// Unmaps the staging buffer
     virtual void Unmap(std::size_t size) const = 0;
 
+    /// Inserts a fence in the OpenGL pipeline.
+    /// @param own Protects the fence from being used before it's waited, intended for flushes.
     virtual void QueueFence(bool own) = 0;
 
+    /// Waits for a fence and releases the ownership.
     virtual void WaitFence() = 0;
 
+    /// Discards the deferred operation and its bound fence. A fence must be queued.
     virtual void Discard() = 0;
 
+    /// Returns true when the fence is available.
     [[nodiscard]] virtual bool IsAvailable() = 0;
 
+    /// Binds the staging buffer handle to an OpenGL target.
     virtual void Bind(GLenum target) const = 0;
-};
-
-class PersistentStagingBuffer final : public StagingBuffer {
-public:
-    explicit PersistentStagingBuffer(std::size_t size, bool is_readable);
-    ~PersistentStagingBuffer() override;
-
-    u8* GetOpenGLPointer() const override;
-
-    u8* Map(std::size_t size) const override;
-
-    void Unmap(std::size_t size) const override;
-
-    void QueueFence(bool own) override;
-
-    void WaitFence() override;
-
-    void Discard() override;
-
-    bool IsAvailable() override;
-
-    void Bind(GLenum target) const override;
-
-private:
-    OGLBuffer buffer;
-    GLsync sync{};
-    u8* pointer{};
-    bool is_readable{};
-    bool owned{};
-};
-
-class CpuStagingBuffer final : public StagingBuffer {
-public:
-    explicit CpuStagingBuffer(std::size_t size, bool is_readable);
-    ~CpuStagingBuffer() override;
-
-    u8* GetOpenGLPointer() const override;
-
-    u8* Map(std::size_t size) const override;
-
-    void Unmap(std::size_t size) const override;
-
-    void QueueFence(bool own) override;
-
-    void WaitFence() override;
-
-    void Discard() override;
-
-    bool IsAvailable() override;
-
-    void Bind(GLenum target) const override;
-
-private:
-    std::unique_ptr<u8[]> pointer;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.h
@@ -1,0 +1,105 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <glad/glad.h>
+#include "common/common_types.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/staging_buffer_cache.h"
+
+namespace OpenGL {
+
+class Device;
+class StagingBuffer;
+
+class StagingBufferCache final : public VideoCommon::StagingBufferCache<StagingBuffer> {
+public:
+    explicit StagingBufferCache(const Device& device);
+    ~StagingBufferCache() override;
+
+protected:
+    std::unique_ptr<StagingBuffer> CreateBuffer(std::size_t size, bool is_flush) override;
+
+private:
+    const Device& device;
+};
+
+class StagingBuffer : public NonCopyable {
+public:
+    virtual ~StagingBuffer() = default;
+
+    [[nodiscard]] virtual u8* GetOpenGLPointer() const = 0;
+
+    [[nodiscard]] virtual u8* Map(std::size_t size) const = 0;
+
+    virtual void Unmap(std::size_t size) const = 0;
+
+    virtual void QueueFence(bool own) = 0;
+
+    virtual void WaitFence() = 0;
+
+    virtual void Discard() = 0;
+
+    [[nodiscard]] virtual bool IsAvailable() = 0;
+
+    virtual void Bind(GLenum target) const = 0;
+};
+
+class PersistentStagingBuffer final : public StagingBuffer {
+public:
+    explicit PersistentStagingBuffer(std::size_t size, bool is_readable);
+    ~PersistentStagingBuffer() override;
+
+    u8* GetOpenGLPointer() const override;
+
+    u8* Map(std::size_t size) const override;
+
+    void Unmap(std::size_t size) const override;
+
+    void QueueFence(bool own) override;
+
+    void WaitFence() override;
+
+    void Discard() override;
+
+    bool IsAvailable() override;
+
+    void Bind(GLenum target) const override;
+
+private:
+    OGLBuffer buffer;
+    GLsync sync{};
+    u8* pointer{};
+    bool is_readable{};
+    bool owned{};
+};
+
+class CpuStagingBuffer final : public StagingBuffer {
+public:
+    explicit CpuStagingBuffer(std::size_t size, bool is_readable);
+    ~CpuStagingBuffer() override;
+
+    u8* GetOpenGLPointer() const override;
+
+    u8* Map(std::size_t size) const override;
+
+    void Unmap(std::size_t size) const override;
+
+    void QueueFence(bool own) override;
+
+    void WaitFence() override;
+
+    void Discard() override;
+
+    bool IsAvailable() override;
+
+    void Bind(GLenum target) const override;
+
+private:
+    std::unique_ptr<u8[]> pointer;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -242,28 +242,61 @@ StagingBuffer::StagingBuffer(std::size_t size) {
         GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT));
 }
 
-StagingBuffer::~StagingBuffer() = default;
-
-void StagingBuffer::QueueFence() {
-    sync.Release();
-    sync.Create();
+StagingBuffer::~StagingBuffer() {
+    if (sync) {
+        glDeleteSync(sync);
+    }
 }
 
-bool StagingBuffer::IsAvailable() const {
-    if (!sync.handle) {
-        return true;
-    }
-    switch (glClientWaitSync(sync.handle, 0, 0)) {
+void StagingBuffer::QueueFence(bool own) {
+    DEBUG_ASSERT(!sync);
+    owned = own;
+    sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+}
+
+void StagingBuffer::WaitFence() {
+    ASSERT(sync);
+    switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
     case GL_ALREADY_SIGNALED:
     case GL_CONDITION_SATISFIED:
-        return true;
+        break;
     case GL_TIMEOUT_EXPIRED:
-        return false;
     case GL_WAIT_FAILED:
         UNREACHABLE_MSG("Fence wait failed");
+        break;
+    }
+    Discard();
+}
+
+void StagingBuffer::Discard() {
+    DEBUG_ASSERT(sync);
+    glDeleteSync(sync);
+    sync = nullptr;
+    owned = false;
+}
+
+bool StagingBuffer::IsAvailable() {
+    if (owned) {
+        return false;
+    }
+    if (!sync) {
         return true;
     }
-    UNREACHABLE();
+    switch (glClientWaitSync(sync, 0, 0)) {
+    case GL_TIMEOUT_EXPIRED:
+        return false;
+    case GL_ALREADY_SIGNALED:
+    case GL_CONDITION_SATISFIED:
+        break;
+    case GL_WAIT_FAILED:
+        UNREACHABLE_MSG("Fence wait failed");
+        break;
+    default:
+        UNREACHABLE_MSG("Unknown glClientWaitSync result");
+        break;
+    }
+    glDeleteSync(sync);
+    sync = nullptr;
     return true;
 }
 
@@ -305,7 +338,10 @@ void CachedSurface::DownloadTexture(StagingBuffer& buffer) {
                               static_cast<GLsizei>(params.GetHostMipmapSize(level)), mip_offset);
         }
     }
-    glFinish();
+    // According to Cemu glGetTextureImage and friends do not flush, resulting in a softlock if we
+    // wait for a fence. To fix this we have to explicitly flush and then queue a fence.
+    glFlush();
+    buffer.QueueFence(true);
 }
 
 void CachedSurface::UploadTexture(StagingBuffer& buffer) {
@@ -316,7 +352,7 @@ void CachedSurface::UploadTexture(StagingBuffer& buffer) {
     for (u32 level = 0; level < params.emulated_levels; ++level) {
         UploadTextureMipmap(level, buffer);
     }
-    buffer.QueueFence();
+    buffer.QueueFence(false);
 }
 
 void CachedSurface::UploadTextureMipmap(u32 level, const StagingBuffer& staging_buffer) {

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -10,6 +10,7 @@
 #include "core/core.h"
 #include "video_core/morton.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_staging_buffer.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_texture_cache.h"
 #include "video_core/renderer_opengl/utils.h"
@@ -232,74 +233,6 @@ OGLTexture CreateTexture(const SurfaceParams& params, GLenum target, GLenum inte
 
 } // Anonymous namespace
 
-StagingBuffer::StagingBuffer(std::size_t size) {
-    buffer.Create();
-    glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr,
-                         GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT |
-                             GL_CLIENT_STORAGE_BIT);
-    pointer = static_cast<u8*>(glMapNamedBufferRange(
-        buffer.handle, 0, static_cast<GLsizeiptr>(size),
-        GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT));
-}
-
-StagingBuffer::~StagingBuffer() {
-    if (sync) {
-        glDeleteSync(sync);
-    }
-}
-
-void StagingBuffer::QueueFence(bool own) {
-    DEBUG_ASSERT(!sync);
-    owned = own;
-    sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-}
-
-void StagingBuffer::WaitFence() {
-    ASSERT(sync);
-    switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
-    case GL_ALREADY_SIGNALED:
-    case GL_CONDITION_SATISFIED:
-        break;
-    case GL_TIMEOUT_EXPIRED:
-    case GL_WAIT_FAILED:
-        UNREACHABLE_MSG("Fence wait failed");
-        break;
-    }
-    Discard();
-}
-
-void StagingBuffer::Discard() {
-    DEBUG_ASSERT(sync);
-    glDeleteSync(sync);
-    sync = nullptr;
-    owned = false;
-}
-
-bool StagingBuffer::IsAvailable() {
-    if (owned) {
-        return false;
-    }
-    if (!sync) {
-        return true;
-    }
-    switch (glClientWaitSync(sync, 0, 0)) {
-    case GL_TIMEOUT_EXPIRED:
-        return false;
-    case GL_ALREADY_SIGNALED:
-    case GL_CONDITION_SATISFIED:
-        break;
-    case GL_WAIT_FAILED:
-        UNREACHABLE_MSG("Fence wait failed");
-        break;
-    default:
-        UNREACHABLE_MSG("Unknown glClientWaitSync result");
-        break;
-    }
-    glDeleteSync(sync);
-    sync = nullptr;
-    return true;
-}
-
 CachedSurface::CachedSurface(const GPUVAddr gpu_addr, const SurfaceParams& params,
                              std::vector<u8>& temporary_buffer)
     : VideoCommon::SurfaceBase<View, StagingBuffer>{gpu_addr, params, temporary_buffer} {
@@ -321,14 +254,12 @@ CachedSurface::~CachedSurface() = default;
 void CachedSurface::DownloadTexture(StagingBuffer& buffer) {
     MICROPROFILE_SCOPE(OpenGL_Texture_Download);
 
-    SCOPE_EXIT({ glPixelStorei(GL_PACK_ROW_LENGTH, 0); });
-
-    glBindBuffer(GL_PIXEL_PACK_BUFFER, buffer.GetHandle());
-
+    buffer.Bind(GL_PIXEL_PACK_BUFFER);
+    const auto pointer_base = buffer.GetOpenGLPointer();
     for (u32 level = 0; level < params.emulated_levels; ++level) {
         glPixelStorei(GL_PACK_ALIGNMENT, std::min(8U, params.GetRowAlignment(level)));
         glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(params.GetMipWidth(level)));
-        const auto mip_offset = reinterpret_cast<void*>(params.GetHostMipmapLevelOffset(level));
+        const auto mip_offset = pointer_base + params.GetHostMipmapLevelOffset(level);
         if (is_compressed) {
             glGetCompressedTextureImage(texture.handle, level,
                                         static_cast<GLsizei>(params.GetHostMipmapSize(level)),
@@ -338,6 +269,8 @@ void CachedSurface::DownloadTexture(StagingBuffer& buffer) {
                               static_cast<GLsizei>(params.GetHostMipmapSize(level)), mip_offset);
         }
     }
+    glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+
     // According to Cemu glGetTextureImage and friends do not flush, resulting in a softlock if we
     // wait for a fence. To fix this we have to explicitly flush and then queue a fence.
     glFlush();
@@ -346,41 +279,41 @@ void CachedSurface::DownloadTexture(StagingBuffer& buffer) {
 
 void CachedSurface::UploadTexture(StagingBuffer& buffer) {
     MICROPROFILE_SCOPE(OpenGL_Texture_Upload);
-    SCOPE_EXIT({ glPixelStorei(GL_UNPACK_ROW_LENGTH, 0); });
-    glFlushMappedNamedBufferRange(buffer.GetHandle(), 0,
-                                  static_cast<GLsizeiptr>(GetHostSizeInBytes()));
+
+    buffer.Bind(GL_PIXEL_UNPACK_BUFFER);
+    const auto pointer = buffer.GetOpenGLPointer();
     for (u32 level = 0; level < params.emulated_levels; ++level) {
-        UploadTextureMipmap(level, buffer);
+        UploadTextureMipmap(level, pointer);
     }
+    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
     buffer.QueueFence(false);
 }
 
-void CachedSurface::UploadTextureMipmap(u32 level, const StagingBuffer& staging_buffer) {
+void CachedSurface::UploadTextureMipmap(u32 level, const u8* opengl_pointer) {
     glPixelStorei(GL_UNPACK_ALIGNMENT, std::min(8U, params.GetRowAlignment(level)));
     glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(params.GetMipWidth(level)));
 
     const auto compression_type = params.GetCompressionType();
-    std::size_t mip_offset = compression_type == SurfaceCompression::Converted
-                                 ? params.GetConvertedMipmapOffset(level)
-                                 : params.GetHostMipmapLevelOffset(level);
-    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, staging_buffer.GetHandle());
+    const u8* mip_offset = opengl_pointer + (compression_type == SurfaceCompression::Converted
+                                                 ? params.GetConvertedMipmapOffset(level)
+                                                 : params.GetHostMipmapLevelOffset(level));
     if (is_compressed) {
         const auto image_size{static_cast<GLsizei>(params.GetHostMipmapSize(level))};
         switch (params.target) {
         case SurfaceTarget::Texture2D:
-            glCompressedTextureSubImage2D(
-                texture.handle, level, 0, 0, static_cast<GLsizei>(params.GetMipWidth(level)),
-                static_cast<GLsizei>(params.GetMipHeight(level)), internal_format, image_size,
-                reinterpret_cast<const void*>(mip_offset));
+            glCompressedTextureSubImage2D(texture.handle, level, 0, 0,
+                                          static_cast<GLsizei>(params.GetMipWidth(level)),
+                                          static_cast<GLsizei>(params.GetMipHeight(level)),
+                                          internal_format, image_size, mip_offset);
             break;
         case SurfaceTarget::Texture3D:
         case SurfaceTarget::Texture2DArray:
         case SurfaceTarget::TextureCubeArray:
-            glCompressedTextureSubImage3D(
-                texture.handle, level, 0, 0, 0, static_cast<GLsizei>(params.GetMipWidth(level)),
-                static_cast<GLsizei>(params.GetMipHeight(level)),
-                static_cast<GLsizei>(params.GetMipDepth(level)), internal_format, image_size,
-                reinterpret_cast<const void*>(mip_offset));
+            glCompressedTextureSubImage3D(texture.handle, level, 0, 0, 0,
+                                          static_cast<GLsizei>(params.GetMipWidth(level)),
+                                          static_cast<GLsizei>(params.GetMipHeight(level)),
+                                          static_cast<GLsizei>(params.GetMipDepth(level)),
+                                          internal_format, image_size, mip_offset);
             break;
         case SurfaceTarget::TextureCubemap: {
             const std::size_t layer_size{params.GetHostLayerSize(level)};
@@ -389,7 +322,7 @@ void CachedSurface::UploadTextureMipmap(u32 level, const StagingBuffer& staging_
                                               static_cast<GLsizei>(params.GetMipWidth(level)),
                                               static_cast<GLsizei>(params.GetMipHeight(level)), 1,
                                               internal_format, static_cast<GLsizei>(layer_size),
-                                              reinterpret_cast<const void*>(mip_offset));
+                                              mip_offset);
                 mip_offset += layer_size;
             }
             break;
@@ -401,36 +334,33 @@ void CachedSurface::UploadTextureMipmap(u32 level, const StagingBuffer& staging_
         switch (params.target) {
         case SurfaceTarget::Texture1D:
             glTextureSubImage1D(texture.handle, level, 0, params.GetMipWidth(level), format, type,
-                                reinterpret_cast<const void*>(mip_offset));
+                                mip_offset);
             break;
         case SurfaceTarget::TextureBuffer:
             ASSERT(level == 0);
             glNamedBufferSubData(texture_buffer.handle, 0,
-                                 params.GetMipWidth(level) * params.GetBytesPerPixel(),
-                                 reinterpret_cast<const void*>(mip_offset));
+                                 params.GetMipWidth(level) * params.GetBytesPerPixel(), mip_offset);
             break;
         case SurfaceTarget::Texture1DArray:
         case SurfaceTarget::Texture2D:
             glTextureSubImage2D(texture.handle, level, 0, 0, params.GetMipWidth(level),
-                                params.GetMipHeight(level), format, type,
-                                reinterpret_cast<const void*>(mip_offset));
+                                params.GetMipHeight(level), format, type, mip_offset);
             break;
         case SurfaceTarget::Texture3D:
         case SurfaceTarget::Texture2DArray:
         case SurfaceTarget::TextureCubeArray:
-            glTextureSubImage3D(texture.handle, level, 0, 0, 0,
-                                static_cast<GLsizei>(params.GetMipWidth(level)),
-                                static_cast<GLsizei>(params.GetMipHeight(level)),
-                                static_cast<GLsizei>(params.GetMipDepth(level)), format, type,
-                                reinterpret_cast<const void*>(mip_offset));
+            glTextureSubImage3D(
+                texture.handle, level, 0, 0, 0, static_cast<GLsizei>(params.GetMipWidth(level)),
+                static_cast<GLsizei>(params.GetMipHeight(level)),
+                static_cast<GLsizei>(params.GetMipDepth(level)), format, type, mip_offset);
             break;
         case SurfaceTarget::TextureCubemap: {
-            const std::size_t face_size = params.GetHostLayerSize(level);
+            const std::size_t layer_size = params.GetHostLayerSize(level);
             for (std::size_t face = 0; face < params.depth; ++face) {
                 glTextureSubImage3D(texture.handle, level, 0, 0, static_cast<GLint>(face),
                                     params.GetMipWidth(level), params.GetMipHeight(level), 1,
-                                    format, type, reinterpret_cast<const void*>(mip_offset));
-                mip_offset += face_size;
+                                    format, type, mip_offset);
+                mip_offset += layer_size;
             }
             break;
         }
@@ -531,7 +461,7 @@ OGLTextureView CachedSurfaceView::CreateTextureView() const {
 TextureCacheOpenGL::TextureCacheOpenGL(Core::System& system,
                                        VideoCore::RasterizerInterface& rasterizer,
                                        const Device& device)
-    : TextureCacheBase{system, rasterizer} {
+    : TextureCacheBase{system, rasterizer, std::make_unique<StagingBufferCache>(device)} {
     src_framebuffer.Create();
     dst_framebuffer.Create();
 }

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -13,6 +13,7 @@
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_texture_cache.h"
 #include "video_core/renderer_opengl/utils.h"
+#include "video_core/staging_buffer_cache.h"
 #include "video_core/texture_cache/surface_base.h"
 #include "video_core/texture_cache/texture_cache.h"
 #include "video_core/textures/convert.h"
@@ -231,8 +232,44 @@ OGLTexture CreateTexture(const SurfaceParams& params, GLenum target, GLenum inte
 
 } // Anonymous namespace
 
-CachedSurface::CachedSurface(const GPUVAddr gpu_addr, const SurfaceParams& params)
-    : VideoCommon::SurfaceBase<View>(gpu_addr, params) {
+StagingBuffer::StagingBuffer(std::size_t size) {
+    buffer.Create();
+    glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr,
+                         GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT |
+                             GL_CLIENT_STORAGE_BIT);
+    pointer = static_cast<u8*>(glMapNamedBufferRange(
+        buffer.handle, 0, static_cast<GLsizeiptr>(size),
+        GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT));
+}
+
+StagingBuffer::~StagingBuffer() = default;
+
+void StagingBuffer::QueueFence() {
+    sync.Release();
+    sync.Create();
+}
+
+bool StagingBuffer::IsAvailable() const {
+    if (!sync.handle) {
+        return true;
+    }
+    switch (glClientWaitSync(sync.handle, 0, 0)) {
+    case GL_ALREADY_SIGNALED:
+    case GL_CONDITION_SATISFIED:
+        return true;
+    case GL_TIMEOUT_EXPIRED:
+        return false;
+    case GL_WAIT_FAILED:
+        UNREACHABLE_MSG("Fence wait failed");
+        return true;
+    }
+    UNREACHABLE();
+    return true;
+}
+
+CachedSurface::CachedSurface(const GPUVAddr gpu_addr, const SurfaceParams& params,
+                             std::vector<u8>& temporary_buffer)
+    : VideoCommon::SurfaceBase<View, StagingBuffer>{gpu_addr, params, temporary_buffer} {
     const auto& tuple{GetFormatTuple(params.pixel_format, params.component_type)};
     internal_format = tuple.internal_format;
     format = tuple.format;
@@ -248,62 +285,66 @@ CachedSurface::CachedSurface(const GPUVAddr gpu_addr, const SurfaceParams& param
 
 CachedSurface::~CachedSurface() = default;
 
-void CachedSurface::DownloadTexture(std::vector<u8>& staging_buffer) {
+void CachedSurface::DownloadTexture(StagingBuffer& buffer) {
     MICROPROFILE_SCOPE(OpenGL_Texture_Download);
 
     SCOPE_EXIT({ glPixelStorei(GL_PACK_ROW_LENGTH, 0); });
 
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, buffer.GetHandle());
+
     for (u32 level = 0; level < params.emulated_levels; ++level) {
         glPixelStorei(GL_PACK_ALIGNMENT, std::min(8U, params.GetRowAlignment(level)));
         glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(params.GetMipWidth(level)));
-        const std::size_t mip_offset = params.GetHostMipmapLevelOffset(level);
+        const auto mip_offset = reinterpret_cast<void*>(params.GetHostMipmapLevelOffset(level));
         if (is_compressed) {
             glGetCompressedTextureImage(texture.handle, level,
                                         static_cast<GLsizei>(params.GetHostMipmapSize(level)),
-                                        staging_buffer.data() + mip_offset);
+                                        mip_offset);
         } else {
             glGetTextureImage(texture.handle, level, format, type,
-                              static_cast<GLsizei>(params.GetHostMipmapSize(level)),
-                              staging_buffer.data() + mip_offset);
+                              static_cast<GLsizei>(params.GetHostMipmapSize(level)), mip_offset);
         }
     }
+    glFinish();
 }
 
-void CachedSurface::UploadTexture(const std::vector<u8>& staging_buffer) {
+void CachedSurface::UploadTexture(StagingBuffer& buffer) {
     MICROPROFILE_SCOPE(OpenGL_Texture_Upload);
     SCOPE_EXIT({ glPixelStorei(GL_UNPACK_ROW_LENGTH, 0); });
+    glFlushMappedNamedBufferRange(buffer.GetHandle(), 0,
+                                  static_cast<GLsizeiptr>(GetHostSizeInBytes()));
     for (u32 level = 0; level < params.emulated_levels; ++level) {
-        UploadTextureMipmap(level, staging_buffer);
+        UploadTextureMipmap(level, buffer);
     }
+    buffer.QueueFence();
 }
 
-void CachedSurface::UploadTextureMipmap(u32 level, const std::vector<u8>& staging_buffer) {
+void CachedSurface::UploadTextureMipmap(u32 level, const StagingBuffer& staging_buffer) {
     glPixelStorei(GL_UNPACK_ALIGNMENT, std::min(8U, params.GetRowAlignment(level)));
     glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(params.GetMipWidth(level)));
 
-    auto compression_type = params.GetCompressionType();
-
-    const std::size_t mip_offset = compression_type == SurfaceCompression::Converted
-                                       ? params.GetConvertedMipmapOffset(level)
-                                       : params.GetHostMipmapLevelOffset(level);
-    const u8* buffer{staging_buffer.data() + mip_offset};
+    const auto compression_type = params.GetCompressionType();
+    std::size_t mip_offset = compression_type == SurfaceCompression::Converted
+                                 ? params.GetConvertedMipmapOffset(level)
+                                 : params.GetHostMipmapLevelOffset(level);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, staging_buffer.GetHandle());
     if (is_compressed) {
         const auto image_size{static_cast<GLsizei>(params.GetHostMipmapSize(level))};
         switch (params.target) {
         case SurfaceTarget::Texture2D:
-            glCompressedTextureSubImage2D(texture.handle, level, 0, 0,
-                                          static_cast<GLsizei>(params.GetMipWidth(level)),
-                                          static_cast<GLsizei>(params.GetMipHeight(level)),
-                                          internal_format, image_size, buffer);
+            glCompressedTextureSubImage2D(
+                texture.handle, level, 0, 0, static_cast<GLsizei>(params.GetMipWidth(level)),
+                static_cast<GLsizei>(params.GetMipHeight(level)), internal_format, image_size,
+                reinterpret_cast<const void*>(mip_offset));
             break;
         case SurfaceTarget::Texture3D:
         case SurfaceTarget::Texture2DArray:
         case SurfaceTarget::TextureCubeArray:
-            glCompressedTextureSubImage3D(texture.handle, level, 0, 0, 0,
-                                          static_cast<GLsizei>(params.GetMipWidth(level)),
-                                          static_cast<GLsizei>(params.GetMipHeight(level)),
-                                          static_cast<GLsizei>(params.GetMipDepth(level)),
-                                          internal_format, image_size, buffer);
+            glCompressedTextureSubImage3D(
+                texture.handle, level, 0, 0, 0, static_cast<GLsizei>(params.GetMipWidth(level)),
+                static_cast<GLsizei>(params.GetMipHeight(level)),
+                static_cast<GLsizei>(params.GetMipDepth(level)), internal_format, image_size,
+                reinterpret_cast<const void*>(mip_offset));
             break;
         case SurfaceTarget::TextureCubemap: {
             const std::size_t layer_size{params.GetHostLayerSize(level)};
@@ -312,8 +353,8 @@ void CachedSurface::UploadTextureMipmap(u32 level, const std::vector<u8>& stagin
                                               static_cast<GLsizei>(params.GetMipWidth(level)),
                                               static_cast<GLsizei>(params.GetMipHeight(level)), 1,
                                               internal_format, static_cast<GLsizei>(layer_size),
-                                              buffer);
-                buffer += layer_size;
+                                              reinterpret_cast<const void*>(mip_offset));
+                mip_offset += layer_size;
             }
             break;
         }
@@ -324,34 +365,39 @@ void CachedSurface::UploadTextureMipmap(u32 level, const std::vector<u8>& stagin
         switch (params.target) {
         case SurfaceTarget::Texture1D:
             glTextureSubImage1D(texture.handle, level, 0, params.GetMipWidth(level), format, type,
-                                buffer);
+                                reinterpret_cast<const void*>(mip_offset));
             break;
         case SurfaceTarget::TextureBuffer:
             ASSERT(level == 0);
             glNamedBufferSubData(texture_buffer.handle, 0,
-                                 params.GetMipWidth(level) * params.GetBytesPerPixel(), buffer);
+                                 params.GetMipWidth(level) * params.GetBytesPerPixel(),
+                                 reinterpret_cast<const void*>(mip_offset));
             break;
         case SurfaceTarget::Texture1DArray:
         case SurfaceTarget::Texture2D:
             glTextureSubImage2D(texture.handle, level, 0, 0, params.GetMipWidth(level),
-                                params.GetMipHeight(level), format, type, buffer);
+                                params.GetMipHeight(level), format, type,
+                                reinterpret_cast<const void*>(mip_offset));
             break;
         case SurfaceTarget::Texture3D:
         case SurfaceTarget::Texture2DArray:
         case SurfaceTarget::TextureCubeArray:
-            glTextureSubImage3D(
-                texture.handle, level, 0, 0, 0, static_cast<GLsizei>(params.GetMipWidth(level)),
-                static_cast<GLsizei>(params.GetMipHeight(level)),
-                static_cast<GLsizei>(params.GetMipDepth(level)), format, type, buffer);
+            glTextureSubImage3D(texture.handle, level, 0, 0, 0,
+                                static_cast<GLsizei>(params.GetMipWidth(level)),
+                                static_cast<GLsizei>(params.GetMipHeight(level)),
+                                static_cast<GLsizei>(params.GetMipDepth(level)), format, type,
+                                reinterpret_cast<const void*>(mip_offset));
             break;
-        case SurfaceTarget::TextureCubemap:
+        case SurfaceTarget::TextureCubemap: {
+            const std::size_t face_size = params.GetHostLayerSize(level);
             for (std::size_t face = 0; face < params.depth; ++face) {
                 glTextureSubImage3D(texture.handle, level, 0, 0, static_cast<GLint>(face),
                                     params.GetMipWidth(level), params.GetMipHeight(level), 1,
-                                    format, type, buffer);
-                buffer += params.GetHostLayerSize(level);
+                                    format, type, reinterpret_cast<const void*>(mip_offset));
+                mip_offset += face_size;
             }
             break;
+        }
         default:
             UNREACHABLE();
         }
@@ -457,7 +503,7 @@ TextureCacheOpenGL::TextureCacheOpenGL(Core::System& system,
 TextureCacheOpenGL::~TextureCacheOpenGL() = default;
 
 Surface TextureCacheOpenGL::CreateSurface(GPUVAddr gpu_addr, const SurfaceParams& params) {
-    return std::make_shared<CachedSurface>(gpu_addr, params);
+    return std::make_shared<CachedSurface>(gpu_addr, params, temporary_buffer);
 }
 
 void TextureCacheOpenGL::ImageCopy(Surface& src_surface, Surface& dst_surface,
@@ -561,7 +607,6 @@ void TextureCacheOpenGL::BufferCopy(Surface& src_surface, Surface& dst_surface) 
         glGetTextureImage(src_surface->GetTexture(), 0, source_format.format, source_format.type,
                           static_cast<GLsizei>(source_size), nullptr);
     }
-    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, copy_pbo_handle);
 
@@ -597,7 +642,6 @@ void TextureCacheOpenGL::BufferCopy(Surface& src_surface, Surface& dst_surface) 
             UNREACHABLE();
         }
     }
-    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
     glTextureBarrier();
 }

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -122,9 +122,13 @@ public:
     explicit StagingBuffer(std::size_t size);
     ~StagingBuffer();
 
-    void QueueFence();
+    void QueueFence(bool own);
 
-    [[nodiscard]] bool IsAvailable() const;
+    void WaitFence();
+
+    void Discard();
+
+    [[nodiscard]] bool IsAvailable();
 
     [[nodiscard]] GLuint GetHandle() const {
         return buffer.handle;
@@ -136,8 +140,9 @@ public:
 
 private:
     OGLBuffer buffer;
-    OGLSync sync;
+    GLsync sync{};
     u8* pointer{};
+    bool owned{};
 };
 
 class TextureCacheOpenGL final : public TextureCacheBase {

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -17,8 +17,8 @@
 #include "video_core/engines/shader_bytecode.h"
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
-#include "video_core/texture_cache/texture_cache.h"
 #include "video_core/renderer_opengl/gl_staging_buffer.h"
+#include "video_core/texture_cache/texture_cache.h"
 
 namespace OpenGL {
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -18,6 +18,7 @@
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/texture_cache/texture_cache.h"
+#include "video_core/renderer_opengl/gl_staging_buffer.h"
 
 namespace OpenGL {
 
@@ -59,7 +60,7 @@ protected:
     View CreateViewInner(const ViewParams& view_key, bool is_proxy);
 
 private:
-    void UploadTextureMipmap(u32 level, const StagingBuffer& staging_buffer);
+    void UploadTextureMipmap(u32 level, const u8* opengl_pointer);
 
     GLenum internal_format{};
     GLenum format{};
@@ -115,34 +116,6 @@ private:
     OGLTextureView texture_view;
     u32 swizzle;
     bool is_proxy;
-};
-
-class StagingBuffer final {
-public:
-    explicit StagingBuffer(std::size_t size);
-    ~StagingBuffer();
-
-    void QueueFence(bool own);
-
-    void WaitFence();
-
-    void Discard();
-
-    [[nodiscard]] bool IsAvailable();
-
-    [[nodiscard]] GLuint GetHandle() const {
-        return buffer.handle;
-    }
-
-    [[nodiscard]] u8* GetPointer() const {
-        return pointer;
-    }
-
-private:
-    OGLBuffer buffer;
-    GLsync sync{};
-    u8* pointer{};
-    bool owned{};
 };
 
 class TextureCacheOpenGL final : public TextureCacheBase {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -171,6 +171,7 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
                                        linear_bpp, Memory::GetPointer(framebuffer_addr),
                                        gl_framebuffer_data.data());
 
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
         glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(framebuffer.stride));
 
         // Update existing texture

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -17,24 +17,42 @@ namespace VideoCommon {
 
 template <typename StagingBufferType>
 class StagingBufferCache {
-public:
-    explicit StagingBufferCache() = default;
-    ~StagingBufferCache() = default;
+    using Cache = std::unordered_map<u32, std::vector<std::unique_ptr<StagingBufferType>>>;
 
-    StagingBufferType& GetBuffer(std::size_t size) {
+public:
+    explicit StagingBufferCache(bool can_flush_aot) : can_flush_aot{can_flush_aot} {}
+    virtual ~StagingBufferCache() = default;
+
+    [[nodiscard]] StagingBufferType& GetWriteBuffer(std::size_t size) {
+        return GetBuffer(size, false);
+    }
+
+    [[nodiscard]] StagingBufferType& GetReadBuffer(std::size_t size) {
+        return GetBuffer(size, true);
+    }
+
+    [[nodiscard]] bool CanFlushAheadOfTime() const {
+        return can_flush_aot;
+    }
+
+protected:
+    virtual std::unique_ptr<StagingBufferType> CreateBuffer(std::size_t size, bool is_flush) = 0;
+
+private:
+    StagingBufferType& GetBuffer(std::size_t size, bool is_flush) {
         const u32 ceil = Common::Log2Ceil64(size);
-        auto& buffers = cache[ceil];
+        auto& buffers = (is_flush ? flush_cache : upload_cache)[ceil];
         const auto it = std::find_if(buffers.begin(), buffers.end(),
                                      [](auto& buffer) { return buffer->IsAvailable(); });
         if (it != buffers.end()) {
             return **it;
         }
-        const std::size_t buf_size = 1ULL << ceil;
-        return *buffers.emplace_back(std::make_unique<StagingBufferType>(buf_size));
+        return *buffers.emplace_back(CreateBuffer(1ULL << ceil, is_flush));
     }
 
-private:
-    std::unordered_map<u32, std::vector<std::unique_ptr<StagingBufferType>>> cache;
+    bool can_flush_aot{};
+    Cache upload_cache;
+    Cache flush_cache;
 };
 
 } // namespace VideoCommon

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -25,7 +25,7 @@ public:
         const u32 ceil = Common::Log2Ceil64(size);
         auto& buffers = cache[ceil];
         const auto it = std::find_if(buffers.begin(), buffers.end(),
-                                     [](const auto& buffer) { return buffer->IsAvailable(); });
+                                     [](auto& buffer) { return buffer->IsAvailable(); });
         if (it != buffers.end()) {
             return **it;
         }

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -1,0 +1,40 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "common/bit_util.h"
+#include "common/common_types.h"
+
+namespace VideoCommon {
+
+template <typename StagingBufferType>
+class StagingBufferCache {
+public:
+    explicit StagingBufferCache() = default;
+    ~StagingBufferCache() = default;
+
+    StagingBufferType& GetBuffer(std::size_t size) {
+        const u32 ceil = Common::Log2Ceil64(size);
+        auto& buffers = cache[ceil];
+        const auto it = std::find_if(buffers.begin(), buffers.end(),
+                                     [](const auto& buffer) { return buffer->IsAvailable(); });
+        if (it != buffers.end()) {
+            return **it;
+        }
+        const std::size_t buf_size = 1ULL << ceil;
+        return *buffers.emplace_back(std::make_unique<StagingBufferType>(buf_size));
+    }
+
+private:
+    std::unordered_map<u32, std::vector<std::unique_ptr<StagingBufferType>>> cache;
+};
+
+} // namespace VideoCommon

--- a/src/video_core/texture_cache/surface_base.cpp
+++ b/src/video_core/texture_cache/surface_base.cpp
@@ -19,12 +19,9 @@ using Tegra::Texture::ConvertFromGuestToHost;
 using VideoCore::MortonSwizzleMode;
 using VideoCore::Surface::SurfaceCompression;
 
-StagingCache::StagingCache() = default;
-
-StagingCache::~StagingCache() = default;
-
-SurfaceBaseImpl::SurfaceBaseImpl(GPUVAddr gpu_addr, const SurfaceParams& params)
-    : params{params}, mipmap_sizes(params.num_levels),
+SurfaceBaseImpl::SurfaceBaseImpl(GPUVAddr gpu_addr, const SurfaceParams& params,
+                                 std::vector<u8>& temporary_buffer)
+    : params{params}, temporary_buffer{temporary_buffer}, mipmap_sizes(params.num_levels),
       mipmap_offsets(params.num_levels), gpu_addr{gpu_addr}, host_memory_size{
                                                                  params.GetHostSizeInBytes()} {
     std::size_t offset = 0;
@@ -45,6 +42,8 @@ SurfaceBaseImpl::SurfaceBaseImpl(GPUVAddr gpu_addr, const SurfaceParams& params)
         guest_memory_size = layer_size;
     }
 }
+
+SurfaceBaseImpl::~SurfaceBaseImpl() = default;
 
 MatchTopologyResult SurfaceBaseImpl::MatchesTopology(const SurfaceParams& rhs) const {
     const u32 src_bpp{params.GetBytesPerPixel()};
@@ -180,10 +179,8 @@ void SurfaceBaseImpl::SwizzleFunc(MortonSwizzleMode mode, u8* memory, const Surf
     }
 }
 
-void SurfaceBaseImpl::LoadBuffer(Tegra::MemoryManager& memory_manager,
-                                 StagingCache& staging_cache) {
+void SurfaceBaseImpl::LoadBuffer(Tegra::MemoryManager& memory_manager, u8* staging_buffer) {
     MICROPROFILE_SCOPE(GPU_Load_Texture);
-    auto& staging_buffer = staging_cache.GetBuffer(0);
     u8* host_ptr;
     is_continuous = memory_manager.IsBlockContinuous(gpu_addr, guest_memory_size);
 
@@ -196,9 +193,8 @@ void SurfaceBaseImpl::LoadBuffer(Tegra::MemoryManager& memory_manager,
         }
     } else {
         // Use an extra temporal buffer
-        auto& tmp_buffer = staging_cache.GetBuffer(1);
-        tmp_buffer.resize(guest_memory_size);
-        host_ptr = tmp_buffer.data();
+        temporary_buffer.resize(guest_memory_size);
+        host_ptr = temporary_buffer.data();
         memory_manager.ReadBlockUnsafe(gpu_addr, host_ptr, guest_memory_size);
     }
 
@@ -208,7 +204,7 @@ void SurfaceBaseImpl::LoadBuffer(Tegra::MemoryManager& memory_manager,
         for (u32 level = 0; level < params.num_levels; ++level) {
             const std::size_t host_offset{params.GetHostMipmapLevelOffset(level)};
             SwizzleFunc(MortonSwizzleMode::MortonToLinear, host_ptr, params,
-                        staging_buffer.data() + host_offset, level);
+                        staging_buffer + host_offset, level);
         }
     } else {
         ASSERT_MSG(params.num_levels == 1, "Linear mipmap loading is not implemented");
@@ -219,10 +215,10 @@ void SurfaceBaseImpl::LoadBuffer(Tegra::MemoryManager& memory_manager,
         const u32 height{(params.height + block_height - 1) / block_height};
         const u32 copy_size{width * bpp};
         if (params.pitch == copy_size) {
-            std::memcpy(staging_buffer.data(), host_ptr, params.GetHostSizeInBytes());
+            std::memcpy(staging_buffer, host_ptr, params.GetHostSizeInBytes());
         } else {
             const u8* start{host_ptr};
-            u8* write_to{staging_buffer.data()};
+            u8* write_to{staging_buffer};
             for (u32 h = height; h > 0; --h) {
                 std::memcpy(write_to, start, copy_size);
                 start += params.pitch;
@@ -242,18 +238,16 @@ void SurfaceBaseImpl::LoadBuffer(Tegra::MemoryManager& memory_manager,
         const std::size_t out_host_offset = compression_type == SurfaceCompression::Rearranged
                                                 ? in_host_offset
                                                 : params.GetConvertedMipmapOffset(level);
-        u8* in_buffer = staging_buffer.data() + in_host_offset;
-        u8* out_buffer = staging_buffer.data() + out_host_offset;
+        u8* in_buffer = staging_buffer + in_host_offset;
+        u8* out_buffer = staging_buffer + out_host_offset;
         ConvertFromGuestToHost(in_buffer, out_buffer, params.pixel_format,
                                params.GetMipWidth(level), params.GetMipHeight(level),
                                params.GetMipDepth(level), true, true);
     }
 }
 
-void SurfaceBaseImpl::FlushBuffer(Tegra::MemoryManager& memory_manager,
-                                  StagingCache& staging_cache) {
+void SurfaceBaseImpl::FlushBuffer(Tegra::MemoryManager& memory_manager, u8* staging_buffer) {
     MICROPROFILE_SCOPE(GPU_Flush_Texture);
-    auto& staging_buffer = staging_cache.GetBuffer(0);
     u8* host_ptr;
 
     // Handle continuouty
@@ -265,9 +259,8 @@ void SurfaceBaseImpl::FlushBuffer(Tegra::MemoryManager& memory_manager,
         }
     } else {
         // Use an extra temporal buffer
-        auto& tmp_buffer = staging_cache.GetBuffer(1);
-        tmp_buffer.resize(guest_memory_size);
-        host_ptr = tmp_buffer.data();
+        temporary_buffer.resize(guest_memory_size);
+        host_ptr = temporary_buffer.data();
     }
 
     if (params.is_tiled) {
@@ -275,7 +268,7 @@ void SurfaceBaseImpl::FlushBuffer(Tegra::MemoryManager& memory_manager,
         for (u32 level = 0; level < params.num_levels; ++level) {
             const std::size_t host_offset{params.GetHostMipmapLevelOffset(level)};
             SwizzleFunc(MortonSwizzleMode::LinearToMorton, host_ptr, params,
-                        staging_buffer.data() + host_offset, level);
+                        staging_buffer + host_offset, level);
         }
     } else {
         ASSERT(params.target == SurfaceTarget::Texture2D);
@@ -284,10 +277,10 @@ void SurfaceBaseImpl::FlushBuffer(Tegra::MemoryManager& memory_manager,
         const u32 bpp{params.GetBytesPerPixel()};
         const u32 copy_size{params.width * bpp};
         if (params.pitch == copy_size) {
-            std::memcpy(host_ptr, staging_buffer.data(), guest_memory_size);
+            std::memcpy(host_ptr, staging_buffer, guest_memory_size);
         } else {
             u8* start{host_ptr};
-            const u8* read_to{staging_buffer.data()};
+            const u8* read_to{staging_buffer};
             for (u32 h = params.height; h > 0; --h) {
                 std::memcpy(start, read_to, copy_size);
                 start += params.pitch;

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -197,13 +197,13 @@ public:
         }
     }
 
-    void MarkAsRenderTarget(const bool is_target, const u32 index) {
-        this->is_target = is_target;
-        this->index = index;
+    void MarkAsRenderTarget(const bool is_target_, const u32 index_) {
+        is_target = is_target_;
+        index = index_;
     }
 
-    void MarkAsPicked(const bool is_picked) {
-        this->is_picked = is_picked;
+    void MarkAsPicked(const bool is_picked_) {
+        is_picked = is_picked_;
     }
 
     bool IsModified() const {
@@ -211,7 +211,7 @@ public:
     }
 
     bool IsProtected() const {
-        // Only 3D Slices are to be protected
+        // Only 3D slices are to be protected
         return is_target && params.block_depth > 0;
     }
 

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -177,9 +177,24 @@ public:
 
     virtual void DownloadTexture(StagingBufferType& buffer) = 0;
 
+    void SetFlushBuffer(StagingBufferType* buffer) {
+        flush_buffer = buffer;
+    }
+
+    StagingBufferType* GetFlushBuffer() const {
+        return flush_buffer;
+    }
+
     void MarkAsModified(const bool is_modified_, const u64 tick) {
         is_modified = is_modified_ || is_target;
         modification_tick = tick;
+
+        if (is_modified && flush_buffer) {
+            // The buffer has been modified while we thought it was no longer being to be used and
+            // we queued a flush.
+            flush_buffer->Discard();
+            flush_buffer = nullptr;
+        }
     }
 
     void MarkAsRenderTarget(const bool is_target, const u32 index) {
@@ -303,6 +318,8 @@ private:
     bool is_picked{};
     u32 index{NO_RT};
     u64 modification_tick{};
+
+    StagingBufferType* flush_buffer{};
 };
 
 } // namespace VideoCommon

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -133,12 +133,18 @@ public:
             regs.zeta.memory_layout.block_width, regs.zeta.memory_layout.block_height,
             regs.zeta.memory_layout.block_depth, regs.zeta.memory_layout.type)};
         auto surface_view = GetSurface(gpu_addr, depth_params, preserve_contents, true);
-        if (depth_buffer.target)
+        if (auto& old_target = depth_buffer.target; old_target != surface_view.first) {
+            FlushAoT(old_target);
+        }
+
+        if (depth_buffer.target) {
             depth_buffer.target->MarkAsRenderTarget(false, NO_RT);
+        }
         depth_buffer.target = surface_view.first;
         depth_buffer.view = surface_view.second;
-        if (depth_buffer.target)
+        if (depth_buffer.target) {
             depth_buffer.target->MarkAsRenderTarget(true, DEPTH_RT);
+        }
         return surface_view.second;
     }
 
@@ -149,6 +155,7 @@ public:
         if (!maxwell3d.dirty_flags.color_buffer[index]) {
             return render_targets[index].view;
         }
+
         maxwell3d.dirty_flags.color_buffer.reset(index);
 
         const auto& regs{maxwell3d.regs};
@@ -167,12 +174,18 @@ public:
 
         auto surface_view = GetSurface(gpu_addr, SurfaceParams::CreateForFramebuffer(system, index),
                                        preserve_contents, true);
-        if (render_targets[index].target)
+        if (auto& old_target = render_targets[index].target; old_target != surface_view.first) {
+            FlushAoT(old_target);
+        }
+
+        if (render_targets[index].target) {
             render_targets[index].target->MarkAsRenderTarget(false, NO_RT);
+        }
         render_targets[index].target = surface_view.first;
         render_targets[index].view = surface_view.second;
-        if (render_targets[index].target)
+        if (render_targets[index].target) {
             render_targets[index].target->MarkAsRenderTarget(true, static_cast<u32>(index));
+        }
         return surface_view.second;
     }
 
@@ -189,19 +202,25 @@ public:
     }
 
     void SetEmptyDepthBuffer() {
-        if (depth_buffer.target == nullptr) {
+        auto& target = depth_buffer.target;
+        if (target == nullptr) {
             return;
         }
-        depth_buffer.target->MarkAsRenderTarget(false, NO_RT);
+        FlushAoT(target);
+        target->MarkAsRenderTarget(false, NO_RT);
+
         depth_buffer.target = nullptr;
         depth_buffer.view = nullptr;
     }
 
     void SetEmptyColorBuffer(std::size_t index) {
-        if (render_targets[index].target == nullptr) {
+        auto& target = render_targets[index].target;
+        if (target == nullptr) {
             return;
         }
-        render_targets[index].target->MarkAsRenderTarget(false, NO_RT);
+        FlushAoT(target);
+        target->MarkAsRenderTarget(false, NO_RT);
+
         render_targets[index].target = nullptr;
         render_targets[index].view = nullptr;
     }
@@ -698,9 +717,16 @@ private:
         if (!surface->IsModified()) {
             return;
         }
-        auto& buffer = staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
-        surface->DownloadTexture(buffer);
-        surface->FlushBuffer(system.GPU().MemoryManager(), buffer.GetPointer());
+
+        auto buffer = surface->GetFlushBuffer();
+        if (!buffer) {
+            buffer = &staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
+            surface->DownloadTexture(*buffer);
+        }
+        buffer->WaitFence();
+        surface->SetFlushBuffer(nullptr);
+
+        surface->FlushBuffer(system.GPU().MemoryManager(), buffer->GetPointer());
         surface->MarkAsModified(false, Tick());
     }
 
@@ -766,6 +792,15 @@ private:
             }
         }
         return {};
+    }
+
+    void FlushAoT(TSurface& surface) {
+        if (!surface || !surface->IsLinear() || surface->GetFlushBuffer()) {
+            return;
+        }
+        auto& buffer = staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
+        surface->DownloadTexture(buffer);
+        surface->SetFlushBuffer(&buffer);
     }
 
     constexpr PixelFormat GetSiblingFormat(PixelFormat format) const {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -27,6 +27,7 @@
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 #include "video_core/rasterizer_interface.h"
+#include "video_core/staging_buffer_cache.h"
 #include "video_core/surface.h"
 #include "video_core/texture_cache/copy_params.h"
 #include "video_core/texture_cache/surface_base.h"
@@ -48,7 +49,7 @@ using VideoCore::Surface::PixelFormat;
 using VideoCore::Surface::SurfaceTarget;
 using RenderTargetConfig = Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig;
 
-template <typename TSurface, typename TView>
+template <typename TSurface, typename TView, typename StagingBufferType>
 class TextureCache {
     using IntervalMap = boost::icl::interval_map<CacheAddr, std::set<TSurface>>;
     using IntervalType = typename IntervalMap::interval_type;
@@ -62,10 +63,10 @@ public:
         }
     }
 
-    /***
+    /**
      * `Guard` guarantees that rendertargets don't unregister themselves if the
      * collide. Protection is currently only done on 3D slices.
-     ***/
+     */
     void GuardRenderTargets(bool new_guard) {
         guard_render_targets = new_guard;
     }
@@ -242,7 +243,6 @@ protected:
         }
 
         SetEmptyDepthBuffer();
-        staging_cache.SetSize(2);
 
         const auto make_siblings = [this](PixelFormat a, PixelFormat b) {
             siblings_table[static_cast<std::size_t>(a)] = b;
@@ -688,9 +688,9 @@ private:
     }
 
     void LoadSurface(const TSurface& surface) {
-        staging_cache.GetBuffer(0).resize(surface->GetHostSizeInBytes());
-        surface->LoadBuffer(system.GPU().MemoryManager(), staging_cache);
-        surface->UploadTexture(staging_cache.GetBuffer(0));
+        auto& buffer = staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
+        surface->LoadBuffer(system.GPU().MemoryManager(), buffer.GetPointer());
+        surface->UploadTexture(buffer);
         surface->MarkAsModified(false, Tick());
     }
 
@@ -698,9 +698,9 @@ private:
         if (!surface->IsModified()) {
             return;
         }
-        staging_cache.GetBuffer(0).resize(surface->GetHostSizeInBytes());
-        surface->DownloadTexture(staging_cache.GetBuffer(0));
-        surface->FlushBuffer(system.GPU().MemoryManager(), staging_cache);
+        auto& buffer = staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
+        surface->DownloadTexture(buffer);
+        surface->FlushBuffer(system.GPU().MemoryManager(), buffer.GetPointer());
         surface->MarkAsModified(false, Tick());
     }
 
@@ -814,7 +814,7 @@ private:
 
     std::vector<TSurface> sampled_textures;
 
-    StagingCache staging_cache;
+    StagingBufferCache<StagingBufferType> staging_buffer_cache;
     std::recursive_mutex mutex;
 };
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -255,8 +255,10 @@ public:
     }
 
 protected:
-    TextureCache(Core::System& system, VideoCore::RasterizerInterface& rasterizer)
-        : system{system}, rasterizer{rasterizer} {
+    TextureCache(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
+                 std::unique_ptr<StagingBufferCache<StagingBufferType>> staging_buffer_cache)
+        : system{system}, rasterizer{rasterizer}, staging_buffer_cache{
+                                                      std::move(staging_buffer_cache)} {
         for (std::size_t i = 0; i < Tegra::Engines::Maxwell3D::Regs::NumRenderTargets; i++) {
             SetEmptyColorBuffer(i);
         }
@@ -707,8 +709,12 @@ private:
     }
 
     void LoadSurface(const TSurface& surface) {
-        auto& buffer = staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
-        surface->LoadBuffer(system.GPU().MemoryManager(), buffer.GetPointer());
+        const auto host_size = surface->GetHostSizeInBytes();
+        auto& buffer = staging_buffer_cache->GetWriteBuffer(host_size);
+
+        surface->LoadBuffer(system.GPU().MemoryManager(), buffer.Map(host_size));
+        buffer.Unmap(host_size);
+
         surface->UploadTexture(buffer);
         surface->MarkAsModified(false, Tick());
     }
@@ -718,15 +724,17 @@ private:
             return;
         }
 
+        const auto host_size = surface->GetHostSizeInBytes();
         auto buffer = surface->GetFlushBuffer();
         if (!buffer) {
-            buffer = &staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
+            buffer = &staging_buffer_cache->GetReadBuffer(host_size);
             surface->DownloadTexture(*buffer);
         }
         buffer->WaitFence();
         surface->SetFlushBuffer(nullptr);
 
-        surface->FlushBuffer(system.GPU().MemoryManager(), buffer->GetPointer());
+        surface->FlushBuffer(system.GPU().MemoryManager(), buffer->Map(host_size));
+        buffer->Unmap(host_size);
         surface->MarkAsModified(false, Tick());
     }
 
@@ -795,10 +803,11 @@ private:
     }
 
     void FlushAoT(TSurface& surface) {
-        if (!surface || !surface->IsLinear() || surface->GetFlushBuffer()) {
+        if (staging_buffer_cache->CanFlushAheadOfTime() || !surface || !surface->IsLinear() ||
+            surface->GetFlushBuffer()) {
             return;
         }
-        auto& buffer = staging_buffer_cache.GetBuffer(surface->GetHostSizeInBytes());
+        auto& buffer = staging_buffer_cache->GetReadBuffer(surface->GetHostSizeInBytes());
         surface->DownloadTexture(buffer);
         surface->SetFlushBuffer(&buffer);
     }
@@ -849,7 +858,7 @@ private:
 
     std::vector<TSurface> sampled_textures;
 
-    StagingBufferCache<StagingBufferType> staging_buffer_cache;
+    std::unique_ptr<StagingBufferCache<StagingBufferType>> staging_buffer_cache;
     std::recursive_mutex mutex;
 };
 


### PR DESCRIPTION
Instead of flushing textures when "the guest wants them" we flush ahead of time when a linear render target is detached. For most cases this means that when the guest requests for texture memory we wait for a fence and swizzle the texture instead of halting the whole OpenGL pipeline and waiting for the GPU to finish. This heuristic might harm performance on games that render to linear textures but never read them from the CPU, I haven't found a case where this is true.

This also moves texture uploads/downloads to OpenGL buffers potentially avoiding a memcpy in the driver.

The whole fast path is disabled on Intel's proprietary driver since it was throwing `GL_OUT_OF_MEMORY` errors with it. It falls back to classic client side buffers for uploads and downloads, with ahead of time flushing disabled. From my testing, it improves performance on Nvidia and AMD GPUs.

Thanks to exzap for explaining me why `glFlush` is required after `glGetTextureImage` calls, the explanation is in the code.




