### PR TITLE
system_archive: Add open-source reimplementation of MiiModel data

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -70,6 +70,8 @@ add_library(core STATIC
     file_sys/sdmc_factory.h
     file_sys/submission_package.cpp
     file_sys/submission_package.h
+    file_sys/system_archive/mii_model.cpp
+    file_sys/system_archive/mii_model.h
     file_sys/system_archive/ng_word.cpp
     file_sys/system_archive/ng_word.h
     file_sys/system_archive/system_archive.cpp

--- a/src/core/file_sys/system_archive/mii_model.cpp
+++ b/src/core/file_sys/system_archive/mii_model.cpp
@@ -1,0 +1,46 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/file_sys/system_archive/mii_model.h"
+#include "core/file_sys/vfs_vector.h"
+
+namespace FileSys::SystemArchive {
+
+namespace MiiModelData {
+
+constexpr std::array<u8, 0x10> NFTR_STANDARD{'N',  'F',  'T',  'R',  0x01, 0x00, 0x00, 0x00,
+                                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+constexpr std::array<u8, 0x10> NFSR_STANDARD{'N',  'F',  'S',  'R',  0x01, 0x00, 0x00, 0x00,
+                                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+constexpr auto TEXTURE_LOW_LINEAR = NFTR_STANDARD;
+constexpr auto TEXTURE_LOW_SRGB = NFTR_STANDARD;
+constexpr auto TEXTURE_MID_LINEAR = NFTR_STANDARD;
+constexpr auto TEXTURE_MID_SRGB = NFTR_STANDARD;
+constexpr auto SHAPE_HIGH = NFSR_STANDARD;
+constexpr auto SHAPE_MID = NFSR_STANDARD;
+
+} // namespace MiiModelData
+
+VirtualDir MiiModel() {
+    auto out = std::make_shared<VectorVfsDirectory>(std::vector<VirtualFile>{},
+                                                    std::vector<VirtualDir>{}, "data");
+
+    out->AddFile(std::make_shared<ArrayVfsFile<MiiModelData::TEXTURE_LOW_LINEAR.size()>>(
+        MiiModelData::TEXTURE_LOW_LINEAR, "NXTextureLowLinear.dat"));
+    out->AddFile(std::make_shared<ArrayVfsFile<MiiModelData::TEXTURE_LOW_SRGB.size()>>(
+        MiiModelData::TEXTURE_LOW_SRGB, "NXTextureLowSRGB.dat"));
+    out->AddFile(std::make_shared<ArrayVfsFile<MiiModelData::TEXTURE_MID_LINEAR.size()>>(
+        MiiModelData::TEXTURE_MID_LINEAR, "NXTextureMidLinear.dat"));
+    out->AddFile(std::make_shared<ArrayVfsFile<MiiModelData::TEXTURE_MID_SRGB.size()>>(
+        MiiModelData::TEXTURE_MID_SRGB, "NXTextureMidSRGB.dat"));
+    out->AddFile(std::make_shared<ArrayVfsFile<MiiModelData::SHAPE_HIGH.size()>>(
+        MiiModelData::SHAPE_HIGH, "ShapeHigh.dat"));
+    out->AddFile(std::make_shared<ArrayVfsFile<MiiModelData::SHAPE_MID.size()>>(
+        MiiModelData::SHAPE_MID, "ShapeMid.dat"));
+
+    return std::move(out);
+}
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/mii_model.h
+++ b/src/core/file_sys/system_archive/mii_model.h
@@ -1,0 +1,13 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/file_sys/vfs_types.h"
+
+namespace FileSys::SystemArchive {
+
+VirtualDir MiiModel();
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/system_archive.cpp
+++ b/src/core/file_sys/system_archive/system_archive.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logging/log.h"
 #include "core/file_sys/romfs.h"
+#include "core/file_sys/system_archive/mii_model.h"
 #include "core/file_sys/system_archive/ng_word.h"
 #include "core/file_sys/system_archive/system_archive.h"
 #include "core/file_sys/system_archive/system_version.h"
@@ -24,7 +25,7 @@ struct SystemArchiveDescriptor {
 constexpr std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHIVES{{
     {0x0100000000000800, "CertStore", nullptr},
     {0x0100000000000801, "ErrorMessage", nullptr},
-    {0x0100000000000802, "MiiModel", nullptr},
+    {0x0100000000000802, "MiiModel", &MiiModel},
     {0x0100000000000803, "BrowserDll", nullptr},
     {0x0100000000000804, "Help", nullptr},
     {0x0100000000000805, "SharedFont", nullptr},


### PR DESCRIPTION
This will cause Miis to render with the null texture and allows booting of SMM2 without a full NAND dump.