### PR TITLE
Implement Accelerate DMA for Texture Cache and correct some methods in DMA engine 

### DIFF
--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -37,11 +37,10 @@ void MaxwellDMA::CallMethod(const GPU::MethodCall& method_call) {
 #undef MAXWELLDMA_REG_INDEX
 }
 
-void MaxwellDMA::TiledLinearCopy(const std::size_t src_size, const std::size_t dst_size) {
+void MaxwellDMA::TiledLinearCopy(const std::size_t src_size, const std::size_t dst_size,
+                                 const std::size_t bytes_per_pixel) {
     const GPUVAddr source = regs.src_address.Address();
     const GPUVAddr dest = regs.dst_address.Address();
-
-    const u32 src_bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
 
     if (read_buffer.size() < src_size) {
         read_buffer.resize(src_size);
@@ -55,14 +54,15 @@ void MaxwellDMA::TiledLinearCopy(const std::size_t src_size, const std::size_t d
     memory_manager.ReadBlock(dest, write_buffer.data(), dst_size);
 
     Texture::UnswizzleSubrect(regs.x_count, regs.y_count, regs.dst_pitch, regs.src_params.size_x,
-                              src_bytes_per_pixel, read_buffer.data(), write_buffer.data(),
+                              bytes_per_pixel, read_buffer.data(), write_buffer.data(),
                               regs.src_params.BlockHeight(), regs.src_params.pos_x,
                               regs.src_params.pos_y);
 
     memory_manager.WriteBlock(dest, write_buffer.data(), dst_size);
 }
 
-void MaxwellDMA::LinearTiledCopy(const std::size_t src_size, const std::size_t dst_size) {
+void MaxwellDMA::LinearTiledCopy(const std::size_t src_size, const std::size_t dst_size,
+                                 const std::size_t bytes_per_pixel) {
     const GPUVAddr source = regs.src_address.Address();
     const GPUVAddr dest = regs.dst_address.Address();
 
@@ -85,7 +85,7 @@ void MaxwellDMA::LinearTiledCopy(const std::size_t src_size, const std::size_t d
 
     // If the input is linear and the output is tiled, swizzle the input and copy it over.
     Texture::SwizzleSubrect(regs.x_count, regs.y_count, regs.src_pitch, regs.dst_params.size_x,
-                            src_bytes_per_pixel,
+                            bytes_per_pixel,
                             write_buffer.data() + dst_layer_size * regs.dst_params.pos_z,
                             read_buffer.data(), regs.dst_params.BlockHeight());
 
@@ -93,19 +93,20 @@ void MaxwellDMA::LinearTiledCopy(const std::size_t src_size, const std::size_t d
 }
 
 void MaxwellDMA::TextureAccelerateDMA(const std::size_t src_size, const std::size_t dst_size,
-                                      bool src_hit, bool dst_hit) {
+                                      const bool src_hit, const bool dst_hit,
+                                      const std::size_t bytes_per_pixel) {
     // Configure Source
     SurfaceConfig src_config;
     src_config.in_cache = src_hit;
     src_config.gpu_addr = regs.src_address.Address();
+    src_config.size = src_size;
     src_config.is_linear = regs.exec.is_src_linear != 0;
+    src_config.bytes_per_pixel = bytes_per_pixel;
     if (src_config.is_linear) {
-        src_config.bytes_per_pixel = regs.src_pitch / regs.x_count;
         src_config.pitch = regs.src_pitch;
-        src_config.width = regs.x_count;
-        src_config.height = regs.y_count;
+        src_config.width = regs.x_count + regs.src_params.pos_x;
+        src_config.height = regs.y_count + regs.src_params.pos_y;
     } else {
-        src_config.bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
         src_config.tiled = regs.src_params;
     }
 
@@ -113,24 +114,15 @@ void MaxwellDMA::TextureAccelerateDMA(const std::size_t src_size, const std::siz
     SurfaceConfig dst_config;
     dst_config.in_cache = dst_hit;
     dst_config.gpu_addr = regs.dst_address.Address();
+    dst_config.size = dst_size;
     dst_config.is_linear = regs.exec.is_dst_linear != 0;
+    dst_config.bytes_per_pixel = bytes_per_pixel;
     if (dst_config.is_linear) {
-        dst_config.bytes_per_pixel = regs.dst_pitch / regs.x_count;
         dst_config.pitch = regs.dst_pitch;
-        dst_config.width = regs.x_count;
-        dst_config.height = regs.y_count;
+        dst_config.width = regs.x_count + regs.dst_params.pos_x;
+        dst_config.height = regs.y_count + regs.dst_params.pos_y;
     } else {
-        dst_config.bytes_per_pixel = regs.dst_pitch / regs.dst_params.size_x;
         dst_config.tiled = regs.dst_params;
-    }
-
-    if (dst_config.bytes_per_pixel != src_config.bytes_per_pixel) {
-        if (src_config.is_linear) {
-            LinearTiledCopy(src_size, dst_size);
-        } else {
-            TiledLinearCopy(src_size, dst_size);
-        }
-        return;
     }
 
     CopyConfig copy_config;
@@ -140,8 +132,10 @@ void MaxwellDMA::TextureAccelerateDMA(const std::size_t src_size, const std::siz
     copy_config.dst_pos_x = regs.dst_params.pos_x;
     copy_config.dst_pos_y = regs.dst_params.pos_y;
     copy_config.dst_pos_z = regs.dst_params.pos_z;
+    copy_config.width = regs.x_count;
+    copy_config.height = regs.y_count;
 
-    // rasterizer.AccelerateDMATexture(src_config, dst_config, copy_config);
+    rasterizer.AccelerateDMATexture(src_config, dst_config, copy_config);
 }
 
 void MaxwellDMA::HandleCopy() {
@@ -193,9 +187,9 @@ void MaxwellDMA::HandleCopy() {
     if (regs.exec.is_dst_linear && !regs.exec.is_src_linear) {
         ASSERT(regs.src_params.size_z == 1);
         // If the input is tiled and the output is linear, deswizzle the input and copy it over.
-        const u32 src_bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
+        const u32 bytes_per_pixel = regs.dst_pitch / regs.x_count;
         const std::size_t src_size = Texture::CalculateSize(
-            true, src_bytes_per_pixel, regs.src_params.size_x, regs.src_params.size_y,
+            true, bytes_per_pixel, regs.src_params.size_x, regs.src_params.size_y,
             regs.src_params.size_z, regs.src_params.BlockHeight(), regs.src_params.BlockDepth());
 
         const std::size_t dst_size = regs.dst_pitch * regs.y_count;
@@ -206,17 +200,17 @@ void MaxwellDMA::HandleCopy() {
         const bool dst_hit = dst_flags == VideoCore::Caches::TextureCache;
 
         if (src_hit || dst_hit) {
-            TextureAccelerateDMA(src_size, dst_size, src_hit, dst_hit);
+            TextureAccelerateDMA(src_size, dst_size, src_hit, dst_hit, bytes_per_pixel);
         } else {
-            TiledLinearCopy(src_size, dst_size);
+            TiledLinearCopy(src_size, dst_size, bytes_per_pixel);
         }
     } else {
         ASSERT(regs.dst_params.BlockDepth() == 0);
 
-        const u32 src_bytes_per_pixel = regs.src_pitch / regs.x_count;
+        const u32 bytes_per_pixel = regs.src_pitch / regs.x_count;
 
         const std::size_t dst_size = Texture::CalculateSize(
-            true, src_bytes_per_pixel, regs.dst_params.size_x, regs.dst_params.size_y,
+            true, bytes_per_pixel, regs.dst_params.size_x, regs.dst_params.size_y,
             regs.dst_params.size_z, regs.dst_params.BlockHeight(), regs.dst_params.BlockDepth());
 
         const std::size_t src_size = regs.src_pitch * regs.y_count;
@@ -227,9 +221,9 @@ void MaxwellDMA::HandleCopy() {
         const bool dst_hit = dst_flags == VideoCore::Caches::TextureCache;
 
         if (src_hit || dst_hit) {
-            TextureAccelerateDMA(src_size, dst_size, src_hit, dst_hit);
+            TextureAccelerateDMA(src_size, dst_size, src_hit, dst_hit, bytes_per_pixel);
         } else {
-            LinearTiledCopy(src_size, dst_size);
+            LinearTiledCopy(src_size, dst_size, bytes_per_pixel);
         }
     }
 }

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -177,6 +177,30 @@ public:
         };
     } regs{};
 
+    struct SurfaceConfig {
+        bool in_cache;
+        u32 bytes_per_pixel;
+        GPUVAddr gpu_addr;
+        bool is_linear;
+        union {
+            struct {
+                u32 pitch;
+                u32 width;
+                u32 height;
+            };
+            Regs::Parameters tiled;
+        };
+    };
+
+    struct CopyConfig {
+        u32 src_pos_x;
+        u32 src_pos_y;
+        u32 src_pos_z;
+        u32 dst_pos_x;
+        u32 dst_pos_y;
+        u32 dst_pos_z;
+    };
+
 private:
     Core::System& system;
 
@@ -186,6 +210,11 @@ private:
 
     std::vector<u8> read_buffer;
     std::vector<u8> write_buffer;
+
+    void TiledLinearCopy(const std::size_t src_size, const std::size_t dst_size);
+    void LinearTiledCopy(const std::size_t src_size, const std::size_t dst_size);
+    void TextureAccelerateDMA(const std::size_t src_size, const std::size_t dst_size, bool src_hit,
+                              bool dst_hit);
 
     /// Performs the copy from the source buffer to the destination buffer as configured in the
     /// registers.

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -58,6 +58,10 @@ public:
                 BitField<16, 16, u32> pos_y;
             };
 
+            u32 BlockWidth() const {
+                return block_width.Value();
+            }
+
             u32 BlockHeight() const {
                 return block_height.Value();
             }
@@ -181,6 +185,7 @@ public:
         bool in_cache;
         u32 bytes_per_pixel;
         GPUVAddr gpu_addr;
+        std::size_t size;
         bool is_linear;
         union {
             struct {
@@ -199,6 +204,8 @@ public:
         u32 dst_pos_x;
         u32 dst_pos_y;
         u32 dst_pos_z;
+        u32 width;
+        u32 height;
     };
 
 private:
@@ -211,10 +218,10 @@ private:
     std::vector<u8> read_buffer;
     std::vector<u8> write_buffer;
 
-    void TiledLinearCopy(const std::size_t src_size, const std::size_t dst_size);
-    void LinearTiledCopy(const std::size_t src_size, const std::size_t dst_size);
-    void TextureAccelerateDMA(const std::size_t src_size, const std::size_t dst_size, bool src_hit,
-                              bool dst_hit);
+    void TiledLinearCopy(std::size_t src_size, std::size_t dst_size, std::size_t bytes_per_pixel);
+    void LinearTiledCopy(std::size_t src_size, std::size_t dst_size, std::size_t bytes_per_pixel);
+    void TextureAccelerateDMA(std::size_t src_size, std::size_t dst_size, bool src_hit,
+                              bool dst_hit, std::size_t bytes_per_pixel);
 
     /// Performs the copy from the source buffer to the destination buffer as configured in the
     /// registers.

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include "common/common_types.h"
 #include "video_core/engines/fermi_2d.h"
+#include "video_core/engines/maxwell_dma.h"
 #include "video_core/gpu.h"
 
 namespace Tegra {
@@ -68,6 +69,10 @@ public:
                                        const Tegra::Engines::Fermi2D::Config& copy_config) {
         return false;
     }
+
+    virtual void AccelerateDMATexture(const Tegra::Engines::MaxwellDMA::SurfaceConfig& src_config,
+                                      const Tegra::Engines::MaxwellDMA::SurfaceConfig& dst_config,
+                                      const Tegra::Engines::MaxwellDMA::CopyConfig& copy_config) {}
 
     /// Attempt to use a faster method to display the framebuffer to screen
     virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -22,6 +22,13 @@ enum class LoadCallbackStage {
     Build,
     Complete,
 };
+
+enum Caches : u32 {
+    TextureCache = 1,
+    BufferCache = 2,
+    ShaderCache = 4,
+};
+
 using DiskResourceLoadCallback = std::function<void(LoadCallbackStage, std::size_t, std::size_t)>;
 
 class RasterizerInterface {
@@ -46,6 +53,11 @@ public:
     /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory
     /// and invalidated
     virtual void FlushAndInvalidateRegion(CacheAddr addr, u64 size) = 0;
+
+    /// Checks if the memory adress and size is within any of caches of the gpu.
+    /// The result will be a flag variable based on VideoCore::Caches, turning on
+    /// corresponding bits for caches that were hit.
+    virtual u32 IsCacheHit(GPUVAddr gpu_addr, std::size_t size) = 0;
 
     /// Notify rasterizer that a frame is about to finish
     virtual void TickFrame() = 0;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -811,6 +811,14 @@ void RasterizerOpenGL::FlushAndInvalidateRegion(CacheAddr addr, u64 size) {
     InvalidateRegion(addr, size);
 }
 
+u32 RasterizerOpenGL::IsCacheHit(const GPUVAddr gpu_addr, const std::size_t size) {
+    u32 flags = 0;
+    if (texture_cache.IsHit(gpu_addr, size)) {
+        flags |= VideoCore::Caches::TextureCache;
+    }
+    return flags;
+}
+
 void RasterizerOpenGL::TickFrame() {
     buffer_cache.TickFrame();
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -831,6 +831,13 @@ bool RasterizerOpenGL::AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Regs
     return true;
 }
 
+void RasterizerOpenGL::AccelerateDMATexture(
+    const Tegra::Engines::MaxwellDMA::SurfaceConfig& src_config,
+    const Tegra::Engines::MaxwellDMA::SurfaceConfig& dst_config,
+    const Tegra::Engines::MaxwellDMA::CopyConfig& copy_config) {
+    texture_cache.AccelerateDMA(src_config, dst_config, copy_config);
+}
+
 bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& config,
                                          VAddr framebuffer_addr, u32 pixel_stride) {
     if (!framebuffer_addr) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -62,6 +62,7 @@ public:
     void FlushRegion(CacheAddr addr, u64 size) override;
     void InvalidateRegion(CacheAddr addr, u64 size) override;
     void FlushAndInvalidateRegion(CacheAddr addr, u64 size) override;
+    u32 IsCacheHit(GPUVAddr gpu_addr, std::size_t size) override;
     void TickFrame() override;
     bool AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Regs::Surface& src,
                                const Tegra::Engines::Fermi2D::Regs::Surface& dst,

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -67,6 +67,9 @@ public:
     bool AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Regs::Surface& src,
                                const Tegra::Engines::Fermi2D::Regs::Surface& dst,
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
+    void AccelerateDMATexture(const Tegra::Engines::MaxwellDMA::SurfaceConfig& src_config,
+                              const Tegra::Engines::MaxwellDMA::SurfaceConfig& dst_config,
+                              const Tegra::Engines::MaxwellDMA::CopyConfig& copy_config) override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     bool AccelerateDrawBatch(bool is_indexed) override;

--- a/src/video_core/texture_cache/copy_params.h
+++ b/src/video_core/texture_cache/copy_params.h
@@ -9,6 +9,7 @@
 namespace VideoCommon {
 
 struct CopyParams {
+    constexpr CopyParams() = default;
     constexpr CopyParams(u32 source_x, u32 source_y, u32 source_z, u32 dest_x, u32 dest_y,
                          u32 dest_z, u32 source_level, u32 dest_level, u32 width, u32 height,
                          u32 depth)

--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -202,6 +202,39 @@ SurfaceParams SurfaceParams::CreateForFermiCopySurface(
     return params;
 }
 
+SurfaceParams SurfaceParams::CreateForDMASurface(
+    const Tegra::Engines::MaxwellDMA::SurfaceConfig& config,
+    const VideoCore::Surface::ComponentType component_type,
+    const VideoCore::Surface::PixelFormat pixel_format,
+    const VideoCore::Surface::SurfaceTarget target) {
+    SurfaceParams params{};
+    params.is_tiled = !config.is_linear;
+    params.srgb_conversion = false;
+    params.block_width = params.is_tiled ? std::min(config.tiled.BlockWidth(), 5U) : 0,
+    params.block_height = params.is_tiled ? std::min(config.tiled.BlockHeight(), 5U) : 0,
+    params.block_depth = params.is_tiled ? std::min(config.tiled.BlockDepth(), 5U) : 0,
+    params.tile_width_spacing = 1;
+    params.pixel_format = pixel_format;
+    params.component_type = component_type;
+    params.type = GetFormatType(pixel_format);
+    params.target = target;
+    if (params.is_tiled) {
+        params.depth = config.tiled.size_z;
+        params.width = config.tiled.size_x;
+        params.height = config.tiled.size_y;
+        params.pitch = params.width * config.bytes_per_pixel;
+    } else {
+        params.depth = 1;
+        params.width = config.width;
+        params.height = config.height;
+        params.pitch = config.pitch;
+    }
+    params.num_levels = 1;
+    params.emulated_levels = 1;
+    params.is_layered = params.IsLayered();
+    return params;
+}
+
 bool SurfaceParams::IsLayered() const {
     switch (target) {
     case SurfaceTarget::Texture1DArray:

--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -12,6 +12,7 @@
 #include "common/common_types.h"
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/maxwell_dma.h"
 #include "video_core/shader/shader_ir.h"
 #include "video_core/surface.h"
 #include "video_core/textures/decoders.h"
@@ -39,6 +40,12 @@ public:
     /// Creates SurfaceCachedParams from a Fermi2D surface configuration.
     static SurfaceParams CreateForFermiCopySurface(
         const Tegra::Engines::Fermi2D::Regs::Surface& config);
+
+    /// Creates SurfaceCachedParams from a MaxwellDMA surface configuration.
+    static SurfaceParams CreateForDMASurface(
+        const Tegra::Engines::MaxwellDMA::SurfaceConfig& config,
+        VideoCore::Surface::ComponentType component_type,
+        VideoCore::Surface::PixelFormat pixel_format, VideoCore::Surface::SurfaceTarget target);
 
     std::size_t Hash() const {
         return static_cast<std::size_t>(

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -234,6 +234,26 @@ public:
         return ++ticks;
     }
 
+    bool IsHit(const GPUVAddr gpu_addr, const std::size_t size) {
+        std::lock_guard lock{mutex};
+        const auto host_ptr{system.GPU().MemoryManager().GetPointer(gpu_addr)};
+        const auto cache_addr{ToCacheAddr(host_ptr)};
+
+        if (!cache_addr) {
+            return false;
+        }
+
+        if (l1_cache.count(cache_addr) > 0) {
+            return true;
+        }
+
+        auto overlaps{GetSurfacesInRegion(cache_addr, size)};
+        if (overlaps.empty()) {
+            return false;
+        }
+        return true;
+    }
+
 protected:
     TextureCache(Core::System& system, VideoCore::RasterizerInterface& rasterizer)
         : system{system}, rasterizer{rasterizer} {

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -256,20 +256,23 @@ std::vector<u8> UnswizzleTexture(u8* address, u32 tile_size_x, u32 tile_size_y, 
 }
 
 void SwizzleSubrect(u32 subrect_width, u32 subrect_height, u32 source_pitch, u32 swizzled_width,
-                    u32 bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data,
-                    u32 block_height_bit) {
+                    u32 dst_x, u32 dst_y, u32 bytes_per_pixel, u8* swizzled_data,
+                    u8* unswizzled_data, u32 block_height_bit) {
     const u32 block_height = 1U << block_height_bit;
     const u32 image_width_in_gobs{(swizzled_width * bytes_per_pixel + (gob_size_x - 1)) /
                                   gob_size_x};
     for (u32 line = 0; line < subrect_height; ++line) {
+        const u32 dst_line = line + dst_y;
         const u32 gob_address_y =
-            (line / (gob_size_y * block_height)) * gob_size * block_height * image_width_in_gobs +
-            ((line % (gob_size_y * block_height)) / gob_size_y) * gob_size;
+            (dst_line / (gob_size_y * block_height)) * gob_size * block_height *
+                image_width_in_gobs +
+            ((dst_line % (gob_size_y * block_height)) / gob_size_y) * gob_size;
         const auto& table = legacy_swizzle_table[line % gob_size_y];
         for (u32 x = 0; x < subrect_width; ++x) {
+            const u32 x2 = x + dst_x;
             const u32 gob_address =
-                gob_address_y + (x * bytes_per_pixel / gob_size_x) * gob_size * block_height;
-            const u32 swizzled_offset = gob_address + table[(x * bytes_per_pixel) % gob_size_x];
+                gob_address_y + (x2 * bytes_per_pixel / gob_size_x) * gob_size * block_height;
+            const u32 swizzled_offset = gob_address + table[(x2 * bytes_per_pixel) % gob_size_x];
             u8* source_line = unswizzled_data + line * source_pitch + x * bytes_per_pixel;
             u8* dest_addr = swizzled_data + swizzled_offset;
 

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -44,7 +44,8 @@ std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height
 
 /// Copies an untiled subrectangle into a tiled surface.
 void SwizzleSubrect(u32 subrect_width, u32 subrect_height, u32 source_pitch, u32 swizzled_width,
-                    u32 bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data, u32 block_height);
+                    u32 dst_x, u32 dst_y, u32 bytes_per_pixel, u8* swizzled_data,
+                    u8* unswizzled_data, u32 block_height);
 
 /// Copies a tiled subrectangle into a linear surface.
 void UnswizzleSubrect(u32 subrect_width, u32 subrect_height, u32 dest_pitch, u32 swizzled_width,


### PR DESCRIPTION
This PR takes care of providing a safe conduct to do DMAs on the GPU if any of the textures is within the Texture Cache. It also corrects some missing things in Linear->Tile Copies and Tiled->Linear Copies as a result DKCTP now displays text and icons correctly.