### PR TITLE
shader/image: Implement SUATOM and fix SUST

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -538,6 +538,28 @@ enum class PhysicalAttributeDirection : u64 {
     Output = 1,
 };
 
+enum class ImageAtomicSize : u64 {
+    U32 = 0,
+    S32 = 1,
+    U64 = 2,
+    F32 = 3,
+    S64 = 5,
+    SD32 = 6,
+    SD64 = 7,
+};
+
+enum class ImageAtomicOperation : u64 {
+    Add = 0,
+    Min = 1,
+    Max = 2,
+    Inc = 3,
+    Dec = 4,
+    And = 5,
+    Or = 6,
+    Xor = 7,
+    Exch = 8,
+};
+
 union Instruction {
     Instruction& operator=(const Instruction& instr) {
         value = instr.value;
@@ -1365,6 +1387,14 @@ union Instruction {
     } sust;
 
     union {
+        BitField<28, 1, u64> is_ba;
+        BitField<51, 3, ImageAtomicSize> size;
+        BitField<33, 3, ImageType> image_type;
+        BitField<29, 4, ImageAtomicOperation> operation;
+        BitField<49, 2, OutOfBoundsStore> out_of_bounds_store;
+    } suatom_d;
+
+    union {
         BitField<20, 24, u64> target;
         BitField<5, 1, u64> constant_buffer;
 
@@ -1515,6 +1545,7 @@ public:
         TMML_B, // Texture Mip Map Level
         TMML,   // Texture Mip Map Level
         SUST,   // Surface Store
+        SUATOM, // Surface Atomic Operation
         EXIT,
         IPA,
         OUT_R, // Emit vertex/primitive
@@ -1795,6 +1826,7 @@ private:
             INST("110111110110----", Id::TMML_B, Type::Texture, "TMML_B"),
             INST("1101111101011---", Id::TMML, Type::Texture, "TMML"),
             INST("11101011001-----", Id::SUST, Type::Image, "SUST"),
+            INST("1110101000------", Id::SUATOM, Type::Image, "SUATOM_D"),
             INST("11100000--------", Id::IPA, Type::Trivial, "IPA"),
             INST("1111101111100---", Id::OUT_R, Type::Trivial, "OUT_R"),
             INST("1110111111010---", Id::ISBERD, Type::Trivial, "ISBERD"),

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -929,6 +929,11 @@ private:
         return {};
     }
 
+    Id ImageAtomicOperation(Operation operation) {
+        UNIMPLEMENTED();
+        return {};
+    }
+
     Id Branch(Operation operation) {
         const auto target = std::get_if<ImmediateNode>(&*operation[0]);
         UNIMPLEMENTED_IF(!target);
@@ -1328,6 +1333,13 @@ private:
         &SPIRVDecompiler::TexelFetch,
 
         &SPIRVDecompiler::ImageStore,
+        &SPIRVDecompiler::ImageAtomicOperation, // Add
+        &SPIRVDecompiler::ImageAtomicOperation, // Min
+        &SPIRVDecompiler::ImageAtomicOperation, // Max
+        &SPIRVDecompiler::ImageAtomicOperation, // And
+        &SPIRVDecompiler::ImageAtomicOperation, // Or
+        &SPIRVDecompiler::ImageAtomicOperation, // Xor
+        &SPIRVDecompiler::ImageAtomicOperation, // Exchange
 
         &SPIRVDecompiler::Branch,
         &SPIRVDecompiler::BranchIndirect,

--- a/src/video_core/shader/decode/image.cpp
+++ b/src/video_core/shader/decode/image.cpp
@@ -44,7 +44,6 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
     switch (opcode->get().GetId()) {
     case OpCode::Id::SUST: {
         UNIMPLEMENTED_IF(instr.sust.mode != Tegra::Shader::SurfaceDataMode::P);
-        UNIMPLEMENTED_IF(instr.sust.image_type == Tegra::Shader::ImageType::TextureBuffer);
         UNIMPLEMENTED_IF(instr.sust.out_of_bounds_store != Tegra::Shader::OutOfBoundsStore::Ignore);
         UNIMPLEMENTED_IF(instr.sust.component_mask_selector != 0xf); // Ensure we have an RGBA store
 
@@ -64,8 +63,46 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
         const auto& image{instr.sust.is_immediate ? GetImage(instr.image, type)
                                                   : GetBindlessImage(instr.gpr39, type)};
         MetaImage meta{image, values};
-        const Node store{Operation(OperationCode::ImageStore, meta, std::move(coords))};
-        bb.push_back(store);
+        bb.push_back(Operation(OperationCode::ImageStore, meta, std::move(coords)));
+        break;
+    }
+    case OpCode::Id::SUATOM: {
+        UNIMPLEMENTED_IF(instr.suatom_d.is_ba != 0);
+
+        Node value = GetRegister(instr.gpr0);
+
+        std::vector<Node> coords;
+        const std::size_t num_coords{GetImageTypeNumCoordinates(instr.sust.image_type)};
+        for (std::size_t i = 0; i < num_coords; ++i) {
+            coords.push_back(GetRegister(instr.gpr8.Value() + i));
+        }
+
+        const OperationCode operation_code = [instr] {
+            switch (instr.suatom_d.operation) {
+            case Tegra::Shader::ImageAtomicOperation::Add:
+                return OperationCode::AtomicImageAdd;
+            case Tegra::Shader::ImageAtomicOperation::Min:
+                return OperationCode::AtomicImageMin;
+            case Tegra::Shader::ImageAtomicOperation::Max:
+                return OperationCode::AtomicImageMax;
+            case Tegra::Shader::ImageAtomicOperation::And:
+                return OperationCode::AtomicImageAnd;
+            case Tegra::Shader::ImageAtomicOperation::Or:
+                return OperationCode::AtomicImageOr;
+            case Tegra::Shader::ImageAtomicOperation::Xor:
+                return OperationCode::AtomicImageXor;
+            case Tegra::Shader::ImageAtomicOperation::Exch:
+                return OperationCode::AtomicImageExchange;
+            default:
+                UNIMPLEMENTED_MSG("Unimplemented operation={}",
+                                  static_cast<u32>(instr.suatom_d.operation.Value()));
+                return OperationCode::AtomicImageAdd;
+            }
+        }();
+
+        const auto& image{GetImage(instr.image, instr.suatom_d.image_type, instr.suatom_d.size)};
+        MetaImage meta{image, {std::move(value)}};
+        SetRegister(bb, instr.gpr0, Operation(operation_code, meta, std::move(coords)));
         break;
     }
     default:
@@ -75,42 +112,51 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
     return pc;
 }
 
-const Image& ShaderIR::GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type) {
+const Image& ShaderIR::GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type,
+                                std::optional<Tegra::Shader::ImageAtomicSize> size) {
     const auto offset{static_cast<std::size_t>(image.index.Value())};
-
-    // If this image has already been used, return the existing mapping.
-    const auto itr{std::find_if(used_images.begin(), used_images.end(),
-                                [=](const Image& entry) { return entry.GetOffset() == offset; })};
-    if (itr != used_images.end()) {
-        ASSERT(itr->GetType() == type);
-        return *itr;
+    if (const auto image = TryUseExistingImage(offset, type, size)) {
+        return *image;
     }
 
-    // Otherwise create a new mapping for this image.
     const std::size_t next_index{used_images.size()};
-    const Image entry{offset, next_index, type};
-    return *used_images.emplace(entry).first;
+    return used_images.emplace(offset, Image{offset, next_index, type, size}).first->second;
 }
 
-const Image& ShaderIR::GetBindlessImage(Tegra::Shader::Register reg,
-                                        Tegra::Shader::ImageType type) {
+const Image& ShaderIR::GetBindlessImage(Tegra::Shader::Register reg, Tegra::Shader::ImageType type,
+                                        std::optional<Tegra::Shader::ImageAtomicSize> size) {
     const Node image_register{GetRegister(reg)};
     const auto [base_image, cbuf_index, cbuf_offset]{
         TrackCbuf(image_register, global_code, static_cast<s64>(global_code.size()))};
     const auto cbuf_key{(static_cast<u64>(cbuf_index) << 32) | static_cast<u64>(cbuf_offset)};
 
-    // If this image has already been used, return the existing mapping.
-    const auto itr{std::find_if(used_images.begin(), used_images.end(),
-                                [=](const Image& entry) { return entry.GetOffset() == cbuf_key; })};
-    if (itr != used_images.end()) {
-        ASSERT(itr->GetType() == type);
-        return *itr;
+    if (const auto image = TryUseExistingImage(cbuf_key, type, size)) {
+        return *image;
     }
 
-    // Otherwise create a new mapping for this image.
     const std::size_t next_index{used_images.size()};
-    const Image entry{cbuf_index, cbuf_offset, next_index, type};
-    return *used_images.emplace(entry).first;
+    return used_images.emplace(cbuf_key, Image{cbuf_index, cbuf_offset, next_index, type, size})
+        .first->second;
+}
+
+const Image* ShaderIR::TryUseExistingImage(u64 offset, Tegra::Shader::ImageType type,
+                                           std::optional<Tegra::Shader::ImageAtomicSize> size) {
+    auto it = used_images.find(offset);
+    if (it == used_images.end()) {
+        return nullptr;
+    }
+    auto& image = it->second;
+    ASSERT(image.GetType() == type);
+
+    if (size) {
+        // We know the size, if it's known it has to be the same as before, otherwise we can set it.
+        if (image.IsSizeKnown()) {
+            ASSERT(image.GetSize() == size);
+        } else {
+            image.SetSize(*size);
+        }
+    }
+    return &image;
 }
 
 } // namespace VideoCommon::Shader

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -145,7 +146,14 @@ enum class OperationCode {
     TextureQueryLod,        /// (MetaTexture, float[N] coords) -> float4
     TexelFetch,             /// (MetaTexture, int[N], int) -> float4
 
-    ImageStore, /// (MetaImage, float[N] coords) -> void
+    ImageStore,          /// (MetaImage, int[N] values) -> void
+    AtomicImageAdd,      /// (MetaImage, int[N] coords) -> void
+    AtomicImageMin,      /// (MetaImage, int[N] coords) -> void
+    AtomicImageMax,      /// (MetaImage, int[N] coords) -> void
+    AtomicImageAnd,      /// (MetaImage, int[N] coords) -> void
+    AtomicImageOr,       /// (MetaImage, int[N] coords) -> void
+    AtomicImageXor,      /// (MetaImage, int[N] coords) -> void
+    AtomicImageExchange, /// (MetaImage, int[N] coords) -> void
 
     Branch,         /// (uint branch_target) -> void
     BranchIndirect, /// (uint branch_target) -> void
@@ -267,17 +275,19 @@ private:
 
 class Image {
 public:
-    explicit Image(std::size_t offset, std::size_t index, Tegra::Shader::ImageType type)
-        : offset{offset}, index{index}, type{type}, is_bindless{false} {}
+    explicit Image(std::size_t offset, std::size_t index, Tegra::Shader::ImageType type,
+                   std::optional<Tegra::Shader::ImageAtomicSize> size)
+        : offset{offset}, index{index}, type{type}, size{size}, is_bindless{false} {}
 
     explicit Image(u32 cbuf_index, u32 cbuf_offset, std::size_t index,
-                   Tegra::Shader::ImageType type)
+                   Tegra::Shader::ImageType type,
+                   std::optional<Tegra::Shader::ImageAtomicSize> size)
         : offset{(static_cast<u64>(cbuf_index) << 32) | cbuf_offset}, index{index}, type{type},
-          is_bindless{true} {}
+          size{size}, is_bindless{true} {}
 
     explicit Image(std::size_t offset, std::size_t index, Tegra::Shader::ImageType type,
-                   bool is_bindless)
-        : offset{offset}, index{index}, type{type}, is_bindless{is_bindless} {}
+                   std::optional<Tegra::Shader::ImageAtomicSize> size, bool is_bindless)
+        : offset{offset}, index{index}, type{type}, size{size}, is_bindless{is_bindless} {}
 
     std::size_t GetOffset() const {
         return offset;
@@ -291,19 +301,32 @@ public:
         return type;
     }
 
+    bool IsSizeKnown() const {
+        return size.has_value();
+    }
+
+    Tegra::Shader::ImageAtomicSize GetSize() const {
+        return size.value();
+    }
+
+    void SetSize(Tegra::Shader::ImageAtomicSize size_) {
+        size = size_;
+    }
+
     bool IsBindless() const {
         return is_bindless;
     }
 
     bool operator<(const Image& rhs) const {
-        return std::tie(offset, index, type, is_bindless) <
-               std::tie(rhs.offset, rhs.index, rhs.type, rhs.is_bindless);
+        return std::tie(offset, index, type, size, is_bindless) <
+               std::tie(rhs.offset, rhs.index, rhs.type, rhs.size, rhs.is_bindless);
     }
 
 private:
     std::size_t offset{};
     std::size_t index{};
     Tegra::Shader::ImageType type{};
+    std::optional<Tegra::Shader::ImageAtomicSize> size{};
     bool is_bindless{};
 };
 

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -95,7 +95,7 @@ public:
         return used_samplers;
     }
 
-    const std::set<Image>& GetImages() const {
+    const std::map<u64, Image>& GetImages() const {
         return used_images;
     }
 
@@ -271,10 +271,16 @@ private:
                                       bool is_shadow);
 
     /// Accesses an image.
-    const Image& GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type);
+    const Image& GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type,
+                          std::optional<Tegra::Shader::ImageAtomicSize> size = {});
 
     /// Access a bindless image sampler.
-    const Image& GetBindlessImage(Tegra::Shader::Register reg, Tegra::Shader::ImageType type);
+    const Image& GetBindlessImage(Tegra::Shader::Register reg, Tegra::Shader::ImageType type,
+                                  std::optional<Tegra::Shader::ImageAtomicSize> size = {});
+
+    /// Tries to access an existing image, updating it's state as needed
+    const Image* TryUseExistingImage(u64 offset, Tegra::Shader::ImageType type,
+                                     std::optional<Tegra::Shader::ImageAtomicSize> size);
 
     /// Extracts a sequence of bits from a node
     Node BitfieldExtract(Node value, u32 offset, u32 bits);
@@ -352,7 +358,7 @@ private:
     std::set<Tegra::Shader::Attribute::Index> used_output_attributes;
     std::map<u32, ConstBuffer> used_cbufs;
     std::set<Sampler> used_samplers;
-    std::set<Image> used_images;
+    std::map<u64, Image> used_images;
     std::array<bool, Tegra::Engines::Maxwell3D::Regs::NumClipDistances> used_clip_distances{};
     std::map<GlobalMemoryBase, GlobalMemoryUsage> used_global_memory;
     bool uses_layer{};


### PR DESCRIPTION
`SUATOM` is the instruction used for atomic image operations. This implements it and fixes some issues related to image operations in general.