### PR TITLE
gl_texture_cache: Miscellaneous texture buffer fixes

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -218,17 +218,21 @@ CachedProgram SpecializeShader(const std::string& code, const GLShader::ShaderEn
         if (!texture_buffer_usage.test(i)) {
             continue;
         }
-        source += fmt::format("#define SAMPLER_{}_IS_BUFFER", i);
+        source += fmt::format("#define SAMPLER_{}_IS_BUFFER\n", i);
+    }
+    if (texture_buffer_usage.any()) {
+        source += '\n';
     }
 
     if (program_type == Maxwell::ShaderProgram::Geometry) {
         const auto [glsl_topology, debug_name, max_vertices] =
             GetPrimitiveDescription(primitive_mode);
 
-        source += "layout (" + std::string(glsl_topology) + ") in;\n";
+        source += "layout (" + std::string(glsl_topology) + ") in;\n\n";
         source += "#define MAX_VERTEX_INPUT " + std::to_string(max_vertices) + '\n';
     }
 
+    source += '\n';
     source += code;
 
     OGLShader shader;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -561,7 +561,7 @@ private:
                 case Tegra::Shader::ImageType::Texture1D:
                     return "image1D";
                 case Tegra::Shader::ImageType::TextureBuffer:
-                    return "bufferImage";
+                    return "imageBuffer";
                 case Tegra::Shader::ImageType::Texture1DArray:
                     return "image1DArray";
                 case Tegra::Shader::ImageType::Texture2D:

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -185,6 +185,9 @@ GLint GetSwizzleSource(SwizzleSource source) {
 }
 
 void ApplyTextureDefaults(const SurfaceParams& params, GLuint texture) {
+    if (params.IsBuffer()) {
+        return;
+    }
     glTextureParameteri(texture, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTextureParameteri(texture, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTextureParameteri(texture, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -209,6 +209,7 @@ OGLTexture CreateTexture(const SurfaceParams& params, GLenum target, GLenum inte
         glNamedBufferStorage(texture_buffer.handle, params.width * params.GetBytesPerPixel(),
                              nullptr, GL_DYNAMIC_STORAGE_BIT);
         glTextureBuffer(texture.handle, internal_format, texture_buffer.handle);
+        break;
     case SurfaceTarget::Texture2D:
     case SurfaceTarget::TextureCubemap:
         glTextureStorage2D(texture.handle, params.emulated_levels, internal_format, params.width,

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -213,7 +213,7 @@ struct TICEntry {
         if (header_version != TICHeaderVersion::OneDBuffer) {
             return width_minus_1 + 1;
         }
-        return (buffer_high_width_minus_one << 16) | buffer_low_width_minus_one;
+        return ((buffer_high_width_minus_one << 16) | buffer_low_width_minus_one) + 1;
     }
 
     u32 Height() const {


### PR DESCRIPTION
There were some bugs in texture buffers management, these didn't deserve individual PRs so I packed them into one. The explanation is in the individual commits.