### PR TITLE
GPU: Flush commands on every dma pusher step.

### DIFF
--- a/src/video_core/dma_pusher.cpp
+++ b/src/video_core/dma_pusher.cpp
@@ -31,6 +31,7 @@ void DmaPusher::DispatchCalls() {
             break;
         }
     }
+    gpu.FlushCommands();
 }
 
 bool DmaPusher::Step() {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -120,6 +120,10 @@ bool GPU::CancelSyncptInterrupt(const u32 syncpoint_id, const u32 value) {
     return true;
 }
 
+void GPU::FlushCommands() {
+    renderer.Rasterizer().FlushCommands();
+}
+
 u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
     ASSERT(format != RenderTargetFormat::NONE);
 

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -153,6 +153,8 @@ public:
     /// Calls a GPU method.
     void CallMethod(const MethodCall& method_call);
 
+    void FlushCommands();
+
     /// Returns a reference to the Maxwell3D GPU engine.
     Engines::Maxwell3D& Maxwell3D();
 

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -50,6 +50,9 @@ public:
     /// and invalidated
     virtual void FlushAndInvalidateRegion(CacheAddr addr, u64 size) = 0;
 
+    // Notify the rasterizer to send all written commands to the host GPU.
+    virtual void FlushCommands() = 0;
+
     /// Notify rasterizer that a frame is about to finish
     virtual void TickFrame() = 0;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -863,6 +863,10 @@ void RasterizerOpenGL::FlushAndInvalidateRegion(CacheAddr addr, u64 size) {
     InvalidateRegion(addr, size);
 }
 
+void RasterizerOpenGL::FlushCommands() {
+    glFlush();
+}
+
 void RasterizerOpenGL::TickFrame() {
     buffer_cache.TickFrame();
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -63,6 +63,7 @@ public:
     void FlushRegion(CacheAddr addr, u64 size) override;
     void InvalidateRegion(CacheAddr addr, u64 size) override;
     void FlushAndInvalidateRegion(CacheAddr addr, u64 size) override;
+    void FlushCommands() override;
     void TickFrame() override;
     bool AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Regs::Surface& src,
                                const Tegra::Engines::Fermi2D::Regs::Surface& dst,


### PR DESCRIPTION
This commit ensures that the host gpu is constantly fed with commands to
work with, while the guest gpu keeps producing the rest of the commands.
This reduces syncing time between host and guest gpu.