### PR TITLE
gl_rasterizer: Bind images and samplers to compute

### DIFF
--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -12,6 +12,7 @@
 #include "common/common_types.h"
 #include "video_core/engines/engine_upload.h"
 #include "video_core/gpu.h"
+#include "video_core/textures/texture.h"
 
 namespace Core {
 class System;
@@ -111,7 +112,7 @@ public:
 
                 INSERT_PADDING_WORDS(0x3FE);
 
-                u32 texture_const_buffer_index;
+                u32 tex_cb_index;
 
                 INSERT_PADDING_WORDS(0x374);
             };
@@ -149,7 +150,7 @@ public:
         union {
             BitField<0, 8, u32> const_buffer_enable_mask;
             BitField<29, 2, u32> cache_layout;
-        } memory_config;
+        };
 
         INSERT_PADDING_WORDS(0x8);
 
@@ -194,6 +195,14 @@ public:
     /// Write the value to the register identified by method.
     void CallMethod(const GPU::MethodCall& method_call);
 
+    Tegra::Texture::FullTextureInfo GetTexture(std::size_t offset) const;
+
+    /// Given a Texture Handle, returns the TSC and TIC entries.
+    Texture::FullTextureInfo GetTextureInfo(const Texture::TextureHandle tex_handle,
+                                            std::size_t offset) const;
+
+    u32 AccessConstBuffer32(u64 const_buffer, u64 offset) const;
+
 private:
     Core::System& system;
     VideoCore::RasterizerInterface& rasterizer;
@@ -201,6 +210,12 @@ private:
     Upload::State upload_state;
 
     void ProcessLaunch();
+
+    /// Retrieves information about a specific TIC entry from the TIC buffer.
+    Texture::TICEntry GetTICEntry(u32 tic_index) const;
+
+    /// Retrieves information about a specific TSC entry from the TSC buffer.
+    Texture::TSCEntry GetTSCEntry(u32 tsc_index) const;
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \
@@ -218,12 +233,12 @@ ASSERT_REG_POSITION(launch, 0xAF);
 ASSERT_REG_POSITION(tsc, 0x557);
 ASSERT_REG_POSITION(tic, 0x55D);
 ASSERT_REG_POSITION(code_loc, 0x582);
-ASSERT_REG_POSITION(texture_const_buffer_index, 0x982);
+ASSERT_REG_POSITION(tex_cb_index, 0x982);
 ASSERT_LAUNCH_PARAM_POSITION(program_start, 0x8);
 ASSERT_LAUNCH_PARAM_POSITION(grid_dim_x, 0xC);
 ASSERT_LAUNCH_PARAM_POSITION(shared_alloc, 0x11);
 ASSERT_LAUNCH_PARAM_POSITION(block_dim_x, 0x12);
-ASSERT_LAUNCH_PARAM_POSITION(memory_config, 0x14);
+ASSERT_LAUNCH_PARAM_POSITION(const_buffer_enable_mask, 0x14);
 ASSERT_LAUNCH_PARAM_POSITION(const_buffer_config, 0x1D);
 
 #undef ASSERT_REG_POSITION

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -62,6 +62,7 @@ public:
         static constexpr std::size_t NumVertexAttributes = 32;
         static constexpr std::size_t NumVaryings = 31;
         static constexpr std::size_t NumTextureSamplers = 32;
+        static constexpr std::size_t NumImages = 8; // TODO(Rodrigo): Investigate this number
         static constexpr std::size_t NumClipDistances = 8;
         static constexpr std::size_t MaxShaderProgram = 6;
         static constexpr std::size_t MaxShaderStage = 5;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1021,7 +1021,7 @@ bool RasterizerOpenGL::SetupTexture(const Shader& shader, u32 binding,
     auto& unit{state.texture_units[binding]};
     unit.sampler = sampler_cache.GetSampler(texture.tsc);
 
-    const auto view = texture_cache.GetImageSurface(texture.tic, entry);
+    const auto view = texture_cache.GetTextureSurface(texture.tic, entry);
     if (!view) {
         // Can occur when texture addr is null or its memory is unmapped/invalid
         unit.texture = 0;
@@ -1053,7 +1053,12 @@ void RasterizerOpenGL::SetupComputeImages(const Shader& shader) {
             tex_handle.raw = compute.AccessConstBuffer32(cbuf.first, cbuf.second);
             return compute.GetTextureInfo(tex_handle, entry.GetOffset());
         }();
-        UNIMPLEMENTED();
+        const auto view = texture_cache.GetImageSurface(texture.tic, entry);
+        if (!view) {
+            state.images[bindpoint] = 0;
+            continue;
+        }
+        state.images[bindpoint] = view->GetTexture();
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -804,6 +804,8 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     }
 
     auto kernel = shader_cache.GetComputeKernel(code_addr);
+    SetupComputeImages(kernel);
+
     const auto [program, next_bindings] = kernel->GetProgramHandle({});
     state.draw.shader_program = program;
     state.draw.program_pipeline = 0;
@@ -921,7 +923,7 @@ void RasterizerOpenGL::SetupComputeConstBuffers(const Shader& kernel) {
     const auto& launch_desc = system.GPU().KeplerCompute().launch_description;
     for (const auto& entry : kernel->GetShaderEntries().const_buffers) {
         const auto& config = launch_desc.const_buffer_config[entry.GetIndex()];
-        const std::bitset<8> mask = launch_desc.memory_config.const_buffer_enable_mask.Value();
+        const std::bitset<8> mask = launch_desc.const_buffer_enable_mask.Value();
         Tegra::Engines::ConstBufferInfo buffer;
         buffer.address = config.Address();
         buffer.size = config.size;
@@ -1035,6 +1037,24 @@ bool RasterizerOpenGL::SetupTexture(const Shader& shader, u32 binding,
     view->ApplySwizzle(texture.tic.x_source, texture.tic.y_source, texture.tic.z_source,
                        texture.tic.w_source);
     return false;
+}
+
+void RasterizerOpenGL::SetupComputeImages(const Shader& shader) {
+    const auto& compute = system.GPU().KeplerCompute();
+    const auto& entries = shader->GetShaderEntries().images;
+    for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
+        const auto& entry = entries[bindpoint];
+        const auto texture = [&]() {
+            if (!entry.IsBindless()) {
+                return compute.GetTexture(entry.GetOffset());
+            }
+            const auto cbuf = entry.GetBindlessCBuf();
+            Tegra::Texture::TextureHandle tex_handle;
+            tex_handle.raw = compute.AccessConstBuffer32(cbuf.first, cbuf.second);
+            return compute.GetTextureInfo(tex_handle, entry.GetOffset());
+        }();
+        UNIMPLEMENTED();
+    }
 }
 
 void RasterizerOpenGL::SyncViewport(OpenGLState& current_state) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -331,7 +331,7 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         const auto stage_enum = static_cast<Maxwell::ShaderStage>(stage);
         SetupDrawConstBuffers(stage_enum, shader);
         SetupDrawGlobalMemory(stage_enum, shader);
-        const auto texture_buffer_usage{SetupTextures(stage_enum, shader, base_bindings)};
+        const auto texture_buffer_usage{SetupDrawTextures(stage_enum, shader, base_bindings)};
 
         const ProgramVariant variant{base_bindings, primitive_mode, texture_buffer_usage};
         const auto [program_handle, next_bindings] = shader->GetProgramHandle(variant);
@@ -980,8 +980,9 @@ void RasterizerOpenGL::SetupGlobalMemory(const GLShader::GlobalMemoryEntry& entr
     bind_ssbo_pushbuffer.Push(ssbo, buffer_offset, static_cast<GLsizeiptr>(size));
 }
 
-TextureBufferUsage RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, const Shader& shader,
-                                                   BaseBindings base_bindings) {
+TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stage,
+                                                       const Shader& shader,
+                                                       BaseBindings base_bindings) {
     MICROPROFILE_SCOPE(OpenGL_Texture);
     const auto& gpu = system.GPU();
     const auto& maxwell3d = gpu.Maxwell3D();
@@ -1003,28 +1004,37 @@ TextureBufferUsage RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, c
         } else {
             texture = maxwell3d.GetStageTexture(stage, entry.GetOffset());
         }
-        const u32 current_bindpoint = base_bindings.sampler + bindpoint;
 
-        auto& unit{state.texture_units[current_bindpoint]};
-        unit.sampler = sampler_cache.GetSampler(texture.tsc);
-
-        if (const auto view{texture_cache.GetTextureSurface(texture, entry)}; view) {
-            if (view->GetSurfaceParams().IsBuffer()) {
-                // Record that this texture is a texture buffer.
-                texture_buffer_usage.set(bindpoint);
-            } else {
-                // Apply swizzle to textures that are not buffers.
-                view->ApplySwizzle(texture.tic.x_source, texture.tic.y_source, texture.tic.z_source,
-                                   texture.tic.w_source);
-            }
-            state.texture_units[current_bindpoint].texture = view->GetTexture();
-        } else {
-            // Can occur when texture addr is null or its memory is unmapped/invalid
-            unit.texture = 0;
+        if (SetupTexture(shader, base_bindings.sampler + bindpoint, texture, entry)) {
+            texture_buffer_usage.set(bindpoint);
         }
     }
 
     return texture_buffer_usage;
+}
+
+bool RasterizerOpenGL::SetupTexture(const Shader& shader, u32 binding,
+                                    const Tegra::Texture::FullTextureInfo& texture,
+                                    const GLShader::SamplerEntry& entry) {
+    auto& unit{state.texture_units[binding]};
+    unit.sampler = sampler_cache.GetSampler(texture.tsc);
+
+    const auto view = texture_cache.GetTextureSurface(texture, entry);
+    if (!view) {
+        // Can occur when texture addr is null or its memory is unmapped/invalid
+        unit.texture = 0;
+        return false;
+    }
+    unit.texture = view->GetTexture();
+
+    if (view->GetSurfaceParams().IsBuffer()) {
+        return true;
+    }
+
+    // Apply swizzle to textures that are not buffers.
+    view->ApplySwizzle(texture.tic.x_source, texture.tic.y_source, texture.tic.z_source,
+                       texture.tic.w_source);
+    return false;
 }
 
 void RasterizerOpenGL::SyncViewport(OpenGLState& current_state) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -804,9 +804,11 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     }
 
     auto kernel = shader_cache.GetComputeKernel(code_addr);
+    ProgramVariant variant;
+    variant.texture_buffer_usage = SetupComputeTextures(kernel);
     SetupComputeImages(kernel);
 
-    const auto [program, next_bindings] = kernel->GetProgramHandle({});
+    const auto [program, next_bindings] = kernel->GetProgramHandle(variant);
     state.draw.shader_program = program;
     state.draw.program_pipeline = 0;
 
@@ -820,8 +822,6 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
 
     SetupComputeConstBuffers(kernel);
     SetupComputeGlobalMemory(kernel);
-
-    // TODO(Rodrigo): Bind images and samplers
 
     buffer_cache.Unmap();
 
@@ -1008,6 +1008,36 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
         }();
 
         if (SetupTexture(base_bindings.sampler + bindpoint, texture, entry)) {
+            texture_buffer_usage.set(bindpoint);
+        }
+    }
+
+    return texture_buffer_usage;
+}
+
+TextureBufferUsage RasterizerOpenGL::SetupComputeTextures(const Shader& kernel) {
+    MICROPROFILE_SCOPE(OpenGL_Texture);
+    const auto& compute = system.GPU().KeplerCompute();
+    const auto& entries = kernel->GetShaderEntries().samplers;
+
+    ASSERT_MSG(entries.size() <= std::size(state.textures),
+               "Exceeded the number of active textures.");
+
+    TextureBufferUsage texture_buffer_usage{0};
+
+    for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
+        const auto& entry = entries[bindpoint];
+        const auto texture = [&]() {
+            if (!entry.IsBindless()) {
+                return compute.GetTexture(entry.GetOffset());
+            }
+            const auto cbuf = entry.GetBindlessCBuf();
+            Tegra::Texture::TextureHandle tex_handle;
+            tex_handle.raw = compute.AccessConstBuffer32(cbuf.first, cbuf.second);
+            return compute.GetTextureInfo(tex_handle, entry.GetOffset());
+        }();
+
+        if (SetupTexture(bindpoint, texture, entry)) {
             texture_buffer_usage.set(bindpoint);
         }
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -828,6 +828,8 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     bind_ubo_pushbuffer.Bind();
     bind_ssbo_pushbuffer.Bind();
 
+    state.ApplyTextures();
+    state.ApplyImages();
     state.ApplyShaderProgram();
     state.ApplyProgramPipeline();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -997,17 +997,17 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
 
     for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
         const auto& entry = entries[bindpoint];
-        Tegra::Texture::FullTextureInfo texture;
-        if (entry.IsBindless()) {
+        const auto texture = [&]() {
+            if (!entry.IsBindless()) {
+                return maxwell3d.GetStageTexture(stage, entry.GetOffset());
+            }
             const auto cbuf = entry.GetBindlessCBuf();
             Tegra::Texture::TextureHandle tex_handle;
             tex_handle.raw = maxwell3d.AccessConstBuffer32(stage, cbuf.first, cbuf.second);
-            texture = maxwell3d.GetTextureInfo(tex_handle, entry.GetOffset());
-        } else {
-            texture = maxwell3d.GetStageTexture(stage, entry.GetOffset());
-        }
+            return maxwell3d.GetTextureInfo(tex_handle, entry.GetOffset());
+        }();
 
-        if (SetupTexture(shader, base_bindings.sampler + bindpoint, texture, entry)) {
+        if (SetupTexture(base_bindings.sampler + bindpoint, texture, entry)) {
             texture_buffer_usage.set(bindpoint);
         }
     }
@@ -1015,8 +1015,7 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
     return texture_buffer_usage;
 }
 
-bool RasterizerOpenGL::SetupTexture(const Shader& shader, u32 binding,
-                                    const Tegra::Texture::FullTextureInfo& texture,
+bool RasterizerOpenGL::SetupTexture(u32 binding, const Tegra::Texture::FullTextureInfo& texture,
                                     const GLShader::SamplerEntry& entry) {
     state.samplers[binding] = sampler_cache.GetSampler(texture.tsc);
 
@@ -1043,22 +1042,30 @@ void RasterizerOpenGL::SetupComputeImages(const Shader& shader) {
     const auto& entries = shader->GetShaderEntries().images;
     for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
         const auto& entry = entries[bindpoint];
-        const auto texture = [&]() {
+        const auto tic = [&]() {
             if (!entry.IsBindless()) {
-                return compute.GetTexture(entry.GetOffset());
+                return compute.GetTexture(entry.GetOffset()).tic;
             }
             const auto cbuf = entry.GetBindlessCBuf();
             Tegra::Texture::TextureHandle tex_handle;
             tex_handle.raw = compute.AccessConstBuffer32(cbuf.first, cbuf.second);
-            return compute.GetTextureInfo(tex_handle, entry.GetOffset());
+            return compute.GetTextureInfo(tex_handle, entry.GetOffset()).tic;
         }();
-        const auto view = texture_cache.GetImageSurface(texture.tic, entry);
-        if (!view) {
-            state.images[bindpoint] = 0;
-            continue;
-        }
-        state.images[bindpoint] = view->GetTexture();
+        SetupImage(bindpoint, tic, entry);
     }
+}
+
+void RasterizerOpenGL::SetupImage(u32 binding, const Tegra::Texture::TICEntry& tic,
+                                  const GLShader::ImageEntry& entry) {
+    const auto view = texture_cache.GetImageSurface(tic, entry);
+    if (!view) {
+        state.images[binding] = 0;
+        return;
+    }
+    if (!tic.IsBuffer()) {
+        view->ApplySwizzle(tic.x_source, tic.y_source, tic.z_source, tic.w_source);
+    }
+    state.images[binding] = view->GetTexture();
 }
 
 void RasterizerOpenGL::SyncViewport(OpenGLState& current_state) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -990,7 +990,7 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
     const auto& maxwell3d = gpu.Maxwell3D();
     const auto& entries = shader->GetShaderEntries().samplers;
 
-    ASSERT_MSG(base_bindings.sampler + entries.size() <= std::size(state.texture_units),
+    ASSERT_MSG(base_bindings.sampler + entries.size() <= std::size(state.textures),
                "Exceeded the number of active textures.");
 
     TextureBufferUsage texture_buffer_usage{0};
@@ -1018,16 +1018,15 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
 bool RasterizerOpenGL::SetupTexture(const Shader& shader, u32 binding,
                                     const Tegra::Texture::FullTextureInfo& texture,
                                     const GLShader::SamplerEntry& entry) {
-    auto& unit{state.texture_units[binding]};
-    unit.sampler = sampler_cache.GetSampler(texture.tsc);
+    state.samplers[binding] = sampler_cache.GetSampler(texture.tsc);
 
     const auto view = texture_cache.GetTextureSurface(texture.tic, entry);
     if (!view) {
         // Can occur when texture addr is null or its memory is unmapped/invalid
-        unit.texture = 0;
+        state.textures[binding] = 0;
         return false;
     }
-    unit.texture = view->GetTexture();
+    state.textures[binding] = view->GetTexture();
 
     if (view->GetSurfaceParams().IsBuffer()) {
         return true;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1021,7 +1021,7 @@ bool RasterizerOpenGL::SetupTexture(const Shader& shader, u32 binding,
     auto& unit{state.texture_units[binding]};
     unit.sampler = sampler_cache.GetSampler(texture.tsc);
 
-    const auto view = texture_cache.GetTextureSurface(texture, entry);
+    const auto view = texture_cache.GetImageSurface(texture.tic, entry);
     if (!view) {
         // Can occur when texture addr is null or its memory is unmapped/invalid
         unit.texture = 0;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -32,6 +32,7 @@
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_texture_cache.h"
 #include "video_core/renderer_opengl/utils.h"
+#include "video_core/textures/texture.h"
 
 namespace Core {
 class System;
@@ -136,8 +137,13 @@ private:
 
     /// Configures the current textures to use for the draw command. Returns shaders texture buffer
     /// usage.
-    TextureBufferUsage SetupTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
-                                     const Shader& shader, BaseBindings base_bindings);
+    TextureBufferUsage SetupDrawTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
+                                         const Shader& shader, BaseBindings base_bindings);
+
+    /// Configures a texture. Returns true when the texture is a texture buffer.
+    bool SetupTexture(const Shader& shader, u32 binding,
+                      const Tegra::Texture::FullTextureInfo& texture,
+                      const GLShader::SamplerEntry& entry);
 
     /// Syncs the viewport and depth range to match the guest state
     void SyncViewport(OpenGLState& current_state);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -145,6 +145,8 @@ private:
                       const Tegra::Texture::FullTextureInfo& texture,
                       const GLShader::SamplerEntry& entry);
 
+    void SetupComputeImages(const Shader& shader);
+
     /// Syncs the viewport and depth range to match the guest state
     void SyncViewport(OpenGLState& current_state);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -140,6 +140,9 @@ private:
     TextureBufferUsage SetupDrawTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
                                          const Shader& shader, BaseBindings base_bindings);
 
+    /// Configures the textures used in a compute shader. Returns texture buffer usage.
+    TextureBufferUsage SetupComputeTextures(const Shader& kernel);
+
     /// Configures a texture. Returns true when the texture is a texture buffer.
     bool SetupTexture(u32 binding, const Tegra::Texture::FullTextureInfo& texture,
                       const GLShader::SamplerEntry& entry);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -141,11 +141,15 @@ private:
                                          const Shader& shader, BaseBindings base_bindings);
 
     /// Configures a texture. Returns true when the texture is a texture buffer.
-    bool SetupTexture(const Shader& shader, u32 binding,
-                      const Tegra::Texture::FullTextureInfo& texture,
+    bool SetupTexture(u32 binding, const Tegra::Texture::FullTextureInfo& texture,
                       const GLShader::SamplerEntry& entry);
 
+    /// Configures images in a compute shader.
     void SetupComputeImages(const Shader& shader);
+
+    /// Configures an image.
+    void SetupImage(u32 binding, const Tegra::Texture::TICEntry& tic,
+                    const GLShader::ImageEntry& entry);
 
     /// Syncs the viewport and depth range to match the guest state
     void SyncViewport(OpenGLState& current_state);

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -545,6 +545,26 @@ void OpenGLState::ApplySamplers() const {
     }
 }
 
+void OpenGLState::ApplyImages() const {
+    bool has_delta{};
+    std::size_t first{};
+    std::size_t last{};
+    for (std::size_t i = 0; i < std::size(images); ++i) {
+        if (!UpdateValue(cur_state.images[i], images[i])) {
+            continue;
+        }
+        if (!has_delta) {
+            first = i;
+            has_delta = true;
+        }
+        last = i;
+    }
+    if (has_delta) {
+        glBindImageTextures(static_cast<GLuint>(first), static_cast<GLsizei>(last - first + 1),
+                            images.data() + first);
+    }
+}
+
 void OpenGLState::Apply() {
     MICROPROFILE_SCOPE(OpenGL_State);
     ApplyFramebufferState();
@@ -576,6 +596,7 @@ void OpenGLState::Apply() {
     ApplyLogicOp();
     ApplyTextures();
     ApplySamplers();
+    ApplyImages();
     if (dirty.polygon_offset) {
         ApplyPolygonOffset();
         dirty.polygon_offset = false;

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -34,6 +34,25 @@ bool UpdateTie(T1 current_value, const T2 new_value) {
     return changed;
 }
 
+template <typename T>
+std::optional<std::pair<GLuint, GLsizei>> UpdateArray(T& current_values, const T& new_values) {
+    std::optional<std::size_t> first;
+    std::size_t last;
+    for (std::size_t i = 0; i < std::size(current_values); ++i) {
+        if (!UpdateValue(current_values[i], new_values[i])) {
+            continue;
+        }
+        if (!first) {
+            first = i;
+        }
+        last = i;
+    }
+    if (!first) {
+        return std::nullopt;
+    }
+    return std::make_pair(static_cast<GLuint>(*first), static_cast<GLsizei>(last - *first + 1));
+}
+
 void Enable(GLenum cap, bool enable) {
     if (enable) {
         glEnable(cap);
@@ -133,10 +152,6 @@ OpenGLState::OpenGLState() {
 
     logic_op.enabled = false;
     logic_op.operation = GL_COPY;
-
-    for (auto& texture_unit : texture_units) {
-        texture_unit.Reset();
-    }
 
     draw.read_framebuffer = 0;
     draw.draw_framebuffer = 0;
@@ -496,72 +511,20 @@ void OpenGLState::ApplyAlphaTest() const {
 }
 
 void OpenGLState::ApplyTextures() const {
-    bool has_delta{};
-    std::size_t first{};
-    std::size_t last{};
-    std::array<GLuint, Maxwell::NumTextureSamplers> textures;
-
-    for (std::size_t i = 0; i < std::size(texture_units); ++i) {
-        const auto& texture_unit = texture_units[i];
-        auto& cur_state_texture_unit = cur_state.texture_units[i];
-        textures[i] = texture_unit.texture;
-        if (cur_state_texture_unit.texture == textures[i]) {
-            continue;
-        }
-        cur_state_texture_unit.texture = textures[i];
-        if (!has_delta) {
-            first = i;
-            has_delta = true;
-        }
-        last = i;
-    }
-    if (has_delta) {
-        glBindTextures(static_cast<GLuint>(first), static_cast<GLsizei>(last - first + 1),
-                       textures.data() + first);
+    if (const auto update = UpdateArray(cur_state.textures, textures)) {
+        glBindTextures(update->first, update->second, textures.data() + update->first);
     }
 }
 
 void OpenGLState::ApplySamplers() const {
-    bool has_delta{};
-    std::size_t first{};
-    std::size_t last{};
-    std::array<GLuint, Maxwell::NumTextureSamplers> samplers;
-
-    for (std::size_t i = 0; i < std::size(samplers); ++i) {
-        samplers[i] = texture_units[i].sampler;
-        if (cur_state.texture_units[i].sampler == texture_units[i].sampler) {
-            continue;
-        }
-        cur_state.texture_units[i].sampler = texture_units[i].sampler;
-        if (!has_delta) {
-            first = i;
-            has_delta = true;
-        }
-        last = i;
-    }
-    if (has_delta) {
-        glBindSamplers(static_cast<GLuint>(first), static_cast<GLsizei>(last - first + 1),
-                       samplers.data() + first);
+    if (const auto update = UpdateArray(cur_state.samplers, samplers)) {
+        glBindSamplers(update->first, update->second, samplers.data() + update->first);
     }
 }
 
 void OpenGLState::ApplyImages() const {
-    bool has_delta{};
-    std::size_t first{};
-    std::size_t last{};
-    for (std::size_t i = 0; i < std::size(images); ++i) {
-        if (!UpdateValue(cur_state.images[i], images[i])) {
-            continue;
-        }
-        if (!has_delta) {
-            first = i;
-            has_delta = true;
-        }
-        last = i;
-    }
-    if (has_delta) {
-        glBindImageTextures(static_cast<GLuint>(first), static_cast<GLsizei>(last - first + 1),
-                            images.data() + first);
+    if (const auto update = UpdateArray(cur_state.images, images)) {
+        glBindImageTextures(update->first, update->second, images.data() + update->first);
     }
 }
 
@@ -627,18 +590,18 @@ void OpenGLState::EmulateViewportWithScissor() {
 }
 
 OpenGLState& OpenGLState::UnbindTexture(GLuint handle) {
-    for (auto& unit : texture_units) {
-        if (unit.texture == handle) {
-            unit.Unbind();
+    for (auto& texture : textures) {
+        if (texture == handle) {
+            texture = 0;
         }
     }
     return *this;
 }
 
 OpenGLState& OpenGLState::ResetSampler(GLuint handle) {
-    for (auto& unit : texture_units) {
-        if (unit.sampler == handle) {
-            unit.sampler = 0;
+    for (auto& sampler : samplers) {
+        if (sampler == handle) {
+            sampler = 0;
         }
     }
     return *this;

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -118,22 +118,8 @@ public:
         GLenum operation;
     } logic_op;
 
-    // 3 texture units - one for each that is used in PICA fragment shader emulation
-    struct TextureUnit {
-        GLuint texture; // GL_TEXTURE_BINDING_2D
-        GLuint sampler; // GL_SAMPLER_BINDING
-
-        void Unbind() {
-            texture = 0;
-        }
-
-        void Reset() {
-            Unbind();
-            sampler = 0;
-        }
-    };
-    std::array<TextureUnit, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> texture_units;
-
+    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> textures{};
+    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> samplers{};
     std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumImages> images{};
 
     struct {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -134,6 +134,8 @@ public:
     };
     std::array<TextureUnit, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> texture_units;
 
+    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumImages> images{};
+
     struct {
         GLuint read_framebuffer; // GL_READ_FRAMEBUFFER_BINDING
         GLuint draw_framebuffer; // GL_DRAW_FRAMEBUFFER_BINDING
@@ -220,6 +222,7 @@ public:
     void ApplyLogicOp() const;
     void ApplyTextures() const;
     void ApplySamplers() const;
+    void ApplyImages() const;
     void ApplyDepthClamp() const;
     void ApplyPolygonOffset() const;
     void ApplyAlphaTest() const;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -337,7 +337,7 @@ void RendererOpenGL::DrawScreenTriangles(const ScreenInfo& screen_info, float x,
         ScreenRectVertex(x + w, y + h, texcoords.bottom * scale_u, right * scale_v),
     }};
 
-    state.texture_units[0].texture = screen_info.display_texture;
+    state.textures[0] = screen_info.display_texture;
     // Workaround brigthness problems in SMO by enabling sRGB in the final output
     // if it has been used in the frame. Needed because of this bug in QT: QTBUG-50987
     state.framebuffer_srgb.enabled = OpenGLState::GetsRGBUsed();
@@ -347,7 +347,7 @@ void RendererOpenGL::DrawScreenTriangles(const ScreenInfo& screen_info, float x,
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     // Restore default state
     state.framebuffer_srgb.enabled = false;
-    state.texture_units[0].texture = 0;
+    state.textures[0] = 0;
     state.AllDirty();
     state.Apply();
     // Clear sRGB state for the next frame

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -295,6 +295,10 @@ public:
         return is_bindless;
     }
 
+    std::pair<u32, u32> GetBindlessCBuf() const {
+        return {static_cast<u32>(offset >> 32), static_cast<u32>(offset)};
+    }
+
     bool operator<(const Image& rhs) const {
         return std::tie(offset, index, type, is_bindless) <
                std::tie(rhs.offset, rhs.index, rhs.type, rhs.is_bindless);

--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -24,45 +24,53 @@ using VideoCore::Surface::SurfaceTarget;
 using VideoCore::Surface::SurfaceTargetFromTextureType;
 using VideoCore::Surface::SurfaceType;
 
-SurfaceTarget TextureType2SurfaceTarget(Tegra::Shader::TextureType type, bool is_array) {
+namespace {
+
+SurfaceTarget TextureTypeToSurfaceTarget(Tegra::Shader::TextureType type, bool is_array) {
     switch (type) {
-    case Tegra::Shader::TextureType::Texture1D: {
-        if (is_array)
-            return SurfaceTarget::Texture1DArray;
-        else
-            return SurfaceTarget::Texture1D;
-    }
-    case Tegra::Shader::TextureType::Texture2D: {
-        if (is_array)
-            return SurfaceTarget::Texture2DArray;
-        else
-            return SurfaceTarget::Texture2D;
-    }
-    case Tegra::Shader::TextureType::Texture3D: {
+    case Tegra::Shader::TextureType::Texture1D:
+        return is_array ? SurfaceTarget::Texture1DArray : SurfaceTarget::Texture1D;
+    case Tegra::Shader::TextureType::Texture2D:
+        return is_array ? SurfaceTarget::Texture2DArray : SurfaceTarget::Texture2D;
+    case Tegra::Shader::TextureType::Texture3D:
         ASSERT(!is_array);
         return SurfaceTarget::Texture3D;
-    }
-    case Tegra::Shader::TextureType::TextureCube: {
-        if (is_array)
-            return SurfaceTarget::TextureCubeArray;
-        else
-            return SurfaceTarget::TextureCubemap;
-    }
-    default: {
+    case Tegra::Shader::TextureType::TextureCube:
+        return is_array ? SurfaceTarget::TextureCubeArray : SurfaceTarget::TextureCubemap;
+    default:
         UNREACHABLE();
         return SurfaceTarget::Texture2D;
     }
+}
+
+SurfaceTarget ImageTypeToSurfaceTarget(Tegra::Shader::ImageType type) {
+    switch (type) {
+    case Tegra::Shader::ImageType::Texture1D:
+        return SurfaceTarget::Texture1D;
+    case Tegra::Shader::ImageType::TextureBuffer:
+        return SurfaceTarget::TextureBuffer;
+    case Tegra::Shader::ImageType::Texture1DArray:
+        return SurfaceTarget::Texture1DArray;
+    case Tegra::Shader::ImageType::Texture2D:
+        return SurfaceTarget::Texture2D;
+    case Tegra::Shader::ImageType::Texture2DArray:
+        return SurfaceTarget::Texture2DArray;
+    case Tegra::Shader::ImageType::Texture3D:
+        return SurfaceTarget::Texture3D;
+    default:
+        UNREACHABLE();
+        return SurfaceTarget::Texture2D;
     }
 }
 
-namespace {
 constexpr u32 GetMipmapSize(bool uncompressed, u32 mip_size, u32 tile) {
     return uncompressed ? mip_size : std::max(1U, (mip_size + tile - 1) / tile);
 }
+
 } // Anonymous namespace
 
-SurfaceParams SurfaceParams::CreateForImage(const Tegra::Texture::TICEntry& tic,
-                                            const VideoCommon::Shader::Sampler& entry) {
+SurfaceParams SurfaceParams::CreateForTexture(const Tegra::Texture::TICEntry& tic,
+                                              const VideoCommon::Shader::Sampler& entry) {
     SurfaceParams params;
     params.is_tiled = tic.IsTiled();
     params.srgb_conversion = tic.IsSrgbConversionEnabled();
@@ -94,8 +102,17 @@ SurfaceParams SurfaceParams::CreateForImage(const Tegra::Texture::TICEntry& tic,
     params.component_type = ComponentTypeFromTexture(tic.r_type.Value());
     params.type = GetFormatType(params.pixel_format);
     // TODO: on 1DBuffer we should use the tic info.
-    if (!tic.IsBuffer()) {
-        params.target = TextureType2SurfaceTarget(entry.GetType(), entry.IsArray());
+    if (tic.IsBuffer()) {
+        params.target = SurfaceTarget::TextureBuffer;
+        params.width = tic.Width();
+        params.pitch = params.width * params.GetBytesPerPixel();
+        params.height = 1;
+        params.depth = 1;
+        params.num_levels = 1;
+        params.emulated_levels = 1;
+        params.is_layered = false;
+    } else {
+        params.target = TextureTypeToSurfaceTarget(entry.GetType(), entry.IsArray());
         params.width = tic.Width();
         params.height = tic.Height();
         params.depth = tic.Depth();
@@ -107,7 +124,27 @@ SurfaceParams SurfaceParams::CreateForImage(const Tegra::Texture::TICEntry& tic,
         params.num_levels = tic.max_mip_level + 1;
         params.emulated_levels = std::min(params.num_levels, params.MaxPossibleMipmap());
         params.is_layered = params.IsLayered();
-    } else {
+    }
+    return params;
+}
+
+SurfaceParams SurfaceParams::CreateForImage(const Tegra::Texture::TICEntry& tic,
+                                            const VideoCommon::Shader::Image& entry) {
+    SurfaceParams params;
+    params.is_tiled = tic.IsTiled();
+    params.srgb_conversion = tic.IsSrgbConversionEnabled();
+    params.block_width = params.is_tiled ? tic.BlockWidth() : 0,
+    params.block_height = params.is_tiled ? tic.BlockHeight() : 0,
+    params.block_depth = params.is_tiled ? tic.BlockDepth() : 0,
+    params.tile_width_spacing = params.is_tiled ? (1 << tic.tile_width_spacing.Value()) : 1;
+    params.pixel_format =
+        PixelFormatFromTextureFormat(tic.format, tic.r_type.Value(), params.srgb_conversion);
+    params.type = GetFormatType(params.pixel_format);
+    params.component_type = ComponentTypeFromTexture(tic.r_type.Value());
+    params.type = GetFormatType(params.pixel_format);
+    params.target = ImageTypeToSurfaceTarget(entry.GetType());
+    // TODO: on 1DBuffer we should use the tic info.
+    if (tic.IsBuffer()) {
         params.target = SurfaceTarget::TextureBuffer;
         params.width = tic.Width();
         params.pitch = params.width * params.GetBytesPerPixel();
@@ -116,6 +153,18 @@ SurfaceParams SurfaceParams::CreateForImage(const Tegra::Texture::TICEntry& tic,
         params.num_levels = 1;
         params.emulated_levels = 1;
         params.is_layered = false;
+    } else {
+        params.width = tic.Width();
+        params.height = tic.Height();
+        params.depth = tic.Depth();
+        params.pitch = params.is_tiled ? 0 : tic.Pitch();
+        if (params.target == SurfaceTarget::TextureCubemap ||
+            params.target == SurfaceTarget::TextureCubeArray) {
+            params.depth *= 6;
+        }
+        params.num_levels = tic.max_mip_level + 1;
+        params.emulated_levels = std::min(params.num_levels, params.MaxPossibleMipmap());
+        params.is_layered = params.IsLayered();
     }
     return params;
 }

--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -23,9 +23,8 @@ using VideoCore::Surface::SurfaceCompression;
 class SurfaceParams {
 public:
     /// Creates SurfaceCachedParams from a texture configuration.
-    static SurfaceParams CreateForTexture(Core::System& system,
-                                          const Tegra::Texture::FullTextureInfo& config,
-                                          const VideoCommon::Shader::Sampler& entry);
+    static SurfaceParams CreateForImage(const Tegra::Texture::TICEntry& tic,
+                                        const VideoCommon::Shader::Sampler& entry);
 
     /// Creates SurfaceCachedParams for a depth buffer configuration.
     static SurfaceParams CreateForDepthBuffer(

--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -23,8 +23,12 @@ using VideoCore::Surface::SurfaceCompression;
 class SurfaceParams {
 public:
     /// Creates SurfaceCachedParams from a texture configuration.
+    static SurfaceParams CreateForTexture(const Tegra::Texture::TICEntry& tic,
+                                          const VideoCommon::Shader::Sampler& entry);
+
+    /// Creates SurfaceCachedParams from an image configuration.
     static SurfaceParams CreateForImage(const Tegra::Texture::TICEntry& tic,
-                                        const VideoCommon::Shader::Sampler& entry);
+                                        const VideoCommon::Shader::Image& entry);
 
     /// Creates SurfaceCachedParams for a depth buffer configuration.
     static SurfaceParams CreateForDepthBuffer(

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -89,8 +89,23 @@ public:
         }
     }
 
+    TView GetTextureSurface(const Tegra::Texture::TICEntry& tic,
+                            const VideoCommon::Shader::Sampler& entry) {
+        std::lock_guard lock{mutex};
+        const auto gpu_addr{tic.Address()};
+        if (!gpu_addr) {
+            return {};
+        }
+        const auto params{SurfaceParams::CreateForTexture(tic, entry)};
+        const auto [surface, view] = GetSurface(gpu_addr, params, true, false);
+        if (guard_samplers) {
+            sampled_textures.push_back(surface);
+        }
+        return view;
+    }
+
     TView GetImageSurface(const Tegra::Texture::TICEntry& tic,
-                          const VideoCommon::Shader::Sampler& entry) {
+                          const VideoCommon::Shader::Image& entry) {
         std::lock_guard lock{mutex};
         const auto gpu_addr{tic.Address()};
         if (!gpu_addr) {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -89,14 +89,14 @@ public:
         }
     }
 
-    TView GetTextureSurface(const Tegra::Texture::FullTextureInfo& config,
-                            const VideoCommon::Shader::Sampler& entry) {
+    TView GetImageSurface(const Tegra::Texture::TICEntry& tic,
+                          const VideoCommon::Shader::Sampler& entry) {
         std::lock_guard lock{mutex};
-        const auto gpu_addr{config.tic.Address()};
+        const auto gpu_addr{tic.Address()};
         if (!gpu_addr) {
             return {};
         }
-        const auto params{SurfaceParams::CreateForTexture(system, config, entry)};
+        const auto params{SurfaceParams::CreateForImage(tic, entry)};
         const auto [surface, view] = GetSurface(gpu_addr, params, true, false);
         if (guard_samplers) {
             sampled_textures.push_back(surface);


### PR DESCRIPTION
Implements sampler and image bindings to compute invocations. Images are used in instructions like `SUST,` `SULD` and `SUATOM.` There is some code repetition between `maxwell_3d` and `kepler_compute` that I'd like to address afterwards.

While adding an extra entry to OpenGLState, this splits texture and samplers binding to pass them to OpenGL as they are instead of generating a temporary buffer in the stack and abstracts the algorithm into a separate function.