### PR TITLE
shader_ir: Implement shared memory

### DIFF
--- a/src/video_core/buffer_cache.h
+++ b/src/video_core/buffer_cache.h
@@ -187,7 +187,9 @@ private:
                                   std::size_t alignment) {
         AlignBuffer(alignment);
         const std::size_t uploaded_offset = buffer_offset;
-        std::memcpy(buffer_ptr, raw_pointer, size);
+        if (raw_pointer != nullptr) {
+            std::memcpy(buffer_ptr, raw_pointer, size);
+        }
 
         buffer_ptr += size;
         buffer_offset += size;

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -23,9 +23,6 @@ namespace OpenGL {
 
 using VideoCommon::Shader::ProgramCode;
 
-// One UBO is always reserved for emulation values on staged shaders
-constexpr u32 STAGE_RESERVED_UBOS = 1;
-
 struct UnspecializedShader {
     std::string code;
     GLShader::ShaderEntries entries;
@@ -364,9 +361,12 @@ std::tuple<GLuint, BaseBindings> CachedShader::GetProgramHandle(const ProgramVar
     auto base_bindings = variant.base_bindings;
     base_bindings.cbuf += static_cast<u32>(entries.const_buffers.size());
     if (program_type != ProgramType::Compute) {
-        base_bindings.cbuf += STAGE_RESERVED_UBOS;
+        base_bindings.cbuf += GLShader::NUM_STAGE_RESERVED_UBOS;
     }
     base_bindings.gmem += static_cast<u32>(entries.global_memory_entries.size());
+    if (program_type == ProgramType::Compute) {
+        base_bindings.gmem += GLShader::NUM_KERNEL_RESERVED_SSBOS;
+    }
     base_bindings.sampler += static_cast<u32>(entries.samplers.size());
 
     return {handle, base_bindings};

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -177,6 +177,7 @@ public:
         DeclareRegisters();
         DeclarePredicates();
         DeclareLocalMemory();
+        DeclareSharedMemory();
         DeclareInternalFlags();
         DeclareInputAttributes();
         DeclareOutputAttributes();
@@ -350,6 +351,24 @@ private:
         const auto element_count = Common::AlignUp(local_memory_size, 4) / 4;
         code.AddLine("float {}[{}];", GetLocalMemory(), element_count);
         code.AddNewLine();
+    }
+
+    void DeclareSharedMemory() {
+        if (stage != ProgramType::Compute) {
+            return;
+        }
+        code.AddLine("layout (location = {}) uniform uint smem_size;", SMEM_SIZE_LOCATION);
+        code.AddLine("layout (std430, binding = {}) buffer FloatSharedMemory {{ float {}[]; }};",
+                     SMEM_BINDING, GetSharedMemory());
+        code.AddLine("layout (std430, binding = {}) buffer SignedSharedMemory {{ int {}[]; }};",
+                     SMEM_BINDING, GetSignedSharedMemory());
+        code.AddLine("layout (std430, binding = {}) buffer UnsignedSharedMemory {{ uint {}[]; }};",
+                     SMEM_BINDING, GetUnsignedSharedMemory());
+
+        code.AddLine("\nconst uint WORKGROUP_INDEX =\n"
+                     "    gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y +\n"
+                     "    gl_WorkGroupID.y * gl_NumWorkGroups.x +\n"
+                     "    gl_WorkGroupID.x;\n");
     }
 
     void DeclareInternalFlags() {
@@ -705,6 +724,11 @@ private:
                 LOG_WARNING(Render_OpenGL, "Local memory is stubbed on compute shaders");
             }
             return fmt::format("{}[ftou({}) / 4]", GetLocalMemory(), Visit(lmem->GetAddress()));
+        }
+
+        if (const auto smem = std::get_if<SmemNode>(&*node)) {
+            return fmt::format("{}[(WORKGROUP_INDEX * smem_size + ftou({})) / 4]",
+                               GetSharedMemory(), Visit(smem->GetAddress()));
         }
 
         if (const auto internal_flag = std::get_if<InternalFlagNode>(&*node)) {
@@ -1084,6 +1108,10 @@ private:
                 LOG_WARNING(Render_OpenGL, "Local memory is stubbed on compute shaders");
             }
             target = fmt::format("{}[ftou({}) / 4]", GetLocalMemory(), Visit(lmem->GetAddress()));
+        } else if (const auto smem = std::get_if<SmemNode>(&*dest)) {
+            ASSERT(stage == ProgramType::Compute);
+            target = fmt::format("{}[(WORKGROUP_INDEX * smem_size + ftou({})) / 4]",
+                                 GetSharedMemory(), Visit(smem->GetAddress()));
         } else if (const auto gmem = std::get_if<GmemNode>(&*dest)) {
             const std::string real = Visit(gmem->GetRealAddress());
             const std::string base = Visit(gmem->GetBaseAddress());
@@ -1905,6 +1933,18 @@ private:
 
     std::string GetLocalMemory() const {
         return "lmem_" + suffix;
+    }
+
+    std::string GetSharedMemory() const {
+        return fmt::format("smem_{}", suffix);
+    }
+
+    std::string GetUnsignedSharedMemory() const {
+        return fmt::format("uint_smem_{}", suffix);
+    }
+
+    std::string GetSignedSharedMemory() const {
+        return fmt::format("sint_smem_{}", suffix);
     }
 
     std::string GetInternalFlag(InternalFlag flag) const {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -41,6 +41,12 @@ using ProgramResult = std::pair<std::string, ShaderEntries>;
 using SamplerEntry = VideoCommon::Shader::Sampler;
 using ImageEntry = VideoCommon::Shader::Image;
 
+constexpr u32 SMEM_BINDING = 0;
+constexpr u32 SMEM_SIZE_LOCATION = 0;
+
+constexpr u32 NUM_STAGE_RESERVED_UBOS = 1;
+constexpr u32 NUM_KERNEL_RESERVED_SSBOS = 1;
+
 class ConstBufferEntry : public VideoCommon::Shader::ConstBuffer {
 public:
     explicit ConstBufferEntry(u32 max_offset, bool is_indirect, u32 index)

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -35,7 +35,7 @@ u32 GetUniformTypeElementsCount(Tegra::Shader::UniformType uniform_type) {
         return 1;
     }
 }
-} // namespace
+} // Anonymous namespace
 
 u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
@@ -209,27 +209,34 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
 
         break;
     }
-    case OpCode::Id::ST_L: {
+    case OpCode::Id::ST_L:
         LOG_DEBUG(HW_GPU, "ST_L cache management mode: {}",
                   static_cast<u64>(instr.st_l.cache_management.Value()));
-
-        const auto GetLmemAddr = [&](s32 offset) {
+        [[fallthrough]];
+    case OpCode::Id::ST_S: {
+        const auto GetAddress = [&](s32 offset) {
             ASSERT(offset % 4 == 0);
             const Node immediate = Immediate(static_cast<s32>(instr.smem_imm) + offset);
             return Operation(OperationCode::IAdd, NO_PRECISE, GetRegister(instr.gpr8), immediate);
         };
 
+        const auto set_memory = opcode->get().GetId() == OpCode::Id::ST_L
+                                    ? &ShaderIR::SetLocalMemory
+                                    : &ShaderIR::SetSharedMemory;
+
         switch (instr.ldst_sl.type.Value()) {
         case Tegra::Shader::StoreType::Bits128:
-            SetLocalMemory(bb, GetLmemAddr(12), GetRegister(instr.gpr0.Value() + 3));
-            SetLocalMemory(bb, GetLmemAddr(8), GetRegister(instr.gpr0.Value() + 2));
+            (this->*set_memory)(bb, GetAddress(12), GetRegister(instr.gpr0.Value() + 3));
+            (this->*set_memory)(bb, GetAddress(8), GetRegister(instr.gpr0.Value() + 2));
+            [[fallthrough]];
         case Tegra::Shader::StoreType::Bits64:
-            SetLocalMemory(bb, GetLmemAddr(4), GetRegister(instr.gpr0.Value() + 1));
+            (this->*set_memory)(bb, GetAddress(4), GetRegister(instr.gpr0.Value() + 1));
+            [[fallthrough]];
         case Tegra::Shader::StoreType::Bits32:
-            SetLocalMemory(bb, GetLmemAddr(0), GetRegister(instr.gpr0));
+            (this->*set_memory)(bb, GetAddress(0), GetRegister(instr.gpr0));
             break;
         default:
-            UNIMPLEMENTED_MSG("ST_L Unhandled type: {}",
+            UNIMPLEMENTED_MSG("{} unhandled type: {}", opcode->get().GetName(),
                               static_cast<u32>(instr.ldst_sl.type.Value()));
         }
         break;

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -190,12 +190,13 @@ class PredicateNode;
 class AbufNode;
 class CbufNode;
 class LmemNode;
+class SmemNode;
 class GmemNode;
 class CommentNode;
 
 using NodeData =
     std::variant<OperationNode, ConditionalNode, GprNode, ImmediateNode, InternalFlagNode,
-                 PredicateNode, AbufNode, CbufNode, LmemNode, GmemNode, CommentNode>;
+                 PredicateNode, AbufNode, CbufNode, LmemNode, SmemNode, GmemNode, CommentNode>;
 using Node = std::shared_ptr<NodeData>;
 using Node4 = std::array<Node, 4>;
 using NodeBlock = std::vector<Node>;
@@ -519,6 +520,19 @@ private:
 class LmemNode final {
 public:
     explicit LmemNode(Node address) : address{std::move(address)} {}
+
+    const Node& GetAddress() const {
+        return address;
+    }
+
+private:
+    Node address;
+};
+
+/// Shared memory node
+class SmemNode final {
+public:
+    explicit SmemNode(Node address) : address{std::move(address)} {}
 
     const Node& GetAddress() const {
         return address;

--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -137,6 +137,10 @@ Node ShaderIR::GetLocalMemory(Node address) {
     return MakeNode<LmemNode>(std::move(address));
 }
 
+Node ShaderIR::GetSharedMemory(Node address) {
+    return MakeNode<SmemNode>(std::move(address));
+}
+
 Node ShaderIR::GetTemporary(u32 id) {
     return GetRegister(Register::ZeroIndex + 1 + id);
 }
@@ -376,6 +380,11 @@ void ShaderIR::SetInternalFlag(NodeBlock& bb, InternalFlag flag, Node value) {
 void ShaderIR::SetLocalMemory(NodeBlock& bb, Node address, Node value) {
     bb.push_back(
         Operation(OperationCode::Assign, GetLocalMemory(std::move(address)), std::move(value)));
+}
+
+void ShaderIR::SetSharedMemory(NodeBlock& bb, Node address, Node value) {
+    bb.push_back(
+        Operation(OperationCode::Assign, GetSharedMemory(std::move(address)), std::move(value)));
 }
 
 void ShaderIR::SetTemporary(NodeBlock& bb, u32 id, Node value) {

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -207,6 +207,8 @@ private:
     Node GetInternalFlag(InternalFlag flag, bool negated = false);
     /// Generates a node representing a local memory address
     Node GetLocalMemory(Node address);
+    /// Generates a node representing a shared memory address
+    Node GetSharedMemory(Node address);
     /// Generates a temporary, internally it uses a post-RZ register
     Node GetTemporary(u32 id);
 
@@ -216,8 +218,10 @@ private:
     void SetPredicate(NodeBlock& bb, u64 dest, Node src);
     /// Sets an internal flag. src value must be a bool-evaluated node
     void SetInternalFlag(NodeBlock& bb, InternalFlag flag, Node value);
-    /// Sets a local memory address. address and value must be a number-evaluated node
+    /// Sets a local memory address with a value.
     void SetLocalMemory(NodeBlock& bb, Node address, Node value);
+    /// Sets a shared memory address with a value.
+    void SetSharedMemory(NodeBlock& bb, Node address, Node value);
     /// Sets a temporary. Internally it uses a post-RZ register
     void SetTemporary(NodeBlock& bb, u32 id, Node value);
 


### PR DESCRIPTION
Implement shared memory using SSBOs. Instead of using host shared memory for this, I opted for SSBOs because it let's us alias memory in GLSL to choose between signed and unsigned overloads sets (required for ATOMS).

As a side effect of this approach, we can avoid issues of different hardware having different shared memory size limitations. SSBOs have a much higher size limit compared to shared memory.