### PR TITLE
Add FPS to SDL title bar

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -4,6 +4,8 @@
 
 #include <SDL.h>
 #include "common/logging/log.h"
+#include "common/scm_rev.h"
+#include "core/core.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
 #include "input_common/motion_emu.h"
@@ -169,6 +171,16 @@ void EmuWindow_SDL2::PollEvents() {
         default:
             break;
         }
+    }
+
+    const u32 current_time = SDL_GetTicks();
+    if (current_time > last_time + 2000) {
+        const auto results = Core::System::GetInstance().GetAndResetPerfStats();
+        const auto title = fmt::format(
+            "yuzu {} | {}-{} | FPS: {:.0f} ({:.0%})", Common::g_build_fullname,
+            Common::g_scm_branch, Common::g_scm_desc, results.game_fps, results.emulation_speed);
+        SDL_SetWindowTitle(render_window, title.c_str());
+        last_time = current_time;
     }
 }
 

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -60,4 +60,7 @@ protected:
 
     /// Internal SDL2 render window
     SDL_Window* render_window;
+
+    /// Keeps track of how often to update the title bar during gameplay
+    u32 last_time = 0;
 };

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -186,8 +186,6 @@ int main(int argc, char** argv) {
     system.SetFilesystem(std::make_shared<FileSys::RealVfsFilesystem>());
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem());
 
-    SCOPE_EXIT({ system.Shutdown(); });
-
     const Core::System::ResultStatus load_result{system.Load(*emu_window, filepath)};
 
     switch (load_result) {
@@ -226,6 +224,8 @@ int main(int argc, char** argv) {
     while (emu_window->IsOpen()) {
         system.RunLoop();
     }
+
+    system.Shutdown();
 
     detached_tasks.WaitForAllTasks();
     return 0;


### PR DESCRIPTION
Also fix a small issue with incorrect shutdown ordering in SDL.
Previously the system would still be running so the telemetry task
didn't launch and detached_tasks would assert(count == 0)