### PR TITLE
qt_themes: add two colorful themes

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -341,15 +341,24 @@ Public License instead of this License.
 
 The icons used in this project have the following licenses:
 
-Icon Name                          | License       | Origin/Author
----                                | ---           | ---
-checked.png                        | Free for non-commercial use
-failed.png                         | Free for non-commercial use
-lock.png                           | CC BY-ND 3.0  | https://icons8.com
-plus_folder.png                    | CC BY-ND 3.0  | https://icons8.com
-bad_folder.png                     | CC BY-ND 3.0  | https://icons8.com
-chip.png                           | CC BY-ND 3.0  | https://icons8.com
-folder.png                         | CC BY-ND 3.0  | https://icons8.com
-plus.png (Default, Dark)           | CC0 1.0       | Designed by BreadFish64 from the Citra team
-plus.png (Colorful, Colorful Dark) | CC BY-ND 3.0  | https://icons8.com
-sd_card.png | CC BY-ND 3.0 | https://icons8.com
+Icon Name                                   | License       | Origin/Author
+---                                         | ---           | ---
+checked.png                                 | Free for non-commercial use
+failed.png                                  | Free for non-commercial use
+lock.png                                    | CC BY-ND 3.0  | https://icons8.com
+plus_folder.png (Default, Dark)             | CC BY-ND 3.0  | https://icons8.com
+bad_folder.png (Default, Dark)              | CC BY-ND 3.0  | https://icons8.com
+chip.png (Default, Dark)                    | CC BY-ND 3.0  | https://icons8.com
+folder.png (Default, Dark)                  | CC BY-ND 3.0  | https://icons8.com
+plus.png (Default, Dark)                    | CC0 1.0       | Designed by BreadFish64 from the Citra team
+sd_card.png (Default, Dark)                 | CC BY-ND 3.0  | https://icons8.com
+plus_folder.png (Colorful, Colorful Dark)   | CC BY-ND 3.0  | https://icons8.com
+bad_folder.png (Colorful, Colorful Dark)    | CC BY-ND 3.0  | https://icons8.com
+chip.png (Colorful, Colorful Dark)          | CC BY-ND 3.0  | https://icons8.com
+folder.png (Colorful, Colorful Dark)        | CC BY-ND 3.0  | https://icons8.com
+plus.png (Colorful, Colorful Dark)          | CC BY-ND 3.0  | https://icons8.com
+sd_card.png (Colorful, Colorful Dark)       | CC BY-ND 3.0  | https://icons8.com
+
+Note:
+Some icons are different in different themes, and they are separately listed
+only when they have different licenses/origins.

--- a/src/yuzu/uisettings.cpp
+++ b/src/yuzu/uisettings.cpp
@@ -9,6 +9,8 @@ namespace UISettings {
 const Themes themes{{
     {"Default", "default"},
     {"Dark", "qdarkstyle"},
+    {"Colorful", "colorful"},
+    {"Colorful Dark", "colorful_dark"},
 }};
 
 Values values = {};

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -24,7 +24,7 @@ struct Shortcut {
     ContextualShortcut shortcut;
 };
 
-using Themes = std::array<std::pair<const char*, const char*>, 2>;
+using Themes = std::array<std::pair<const char*, const char*>, 4>;
 extern const Themes themes;
 
 struct GameDir {


### PR DESCRIPTION
These two colorful themes are based on the Default and Dark themes, and contain icons that are colored rather than black and white. These icons come from icons8.com and they have been slightly revised by me. I'm pretty sure I was licensed to use them for Citra.

Co-Authored-By: Pengfei Zhu <zhupengfei321@sina.cn>