### PR TITLE
ci: Split mainline pipeline and add support for GitHub releases 

### DIFF
--- a/.ci/templates/build-mock.yml
+++ b/.ci/templates/build-mock.yml
@@ -1,0 +1,5 @@
+steps:
+  - script: mkdir artifacts || echo 'X' > artifacts/T1.txt
+  - publish: artifacts
+    artifact: 'yuzu-$(BuildName)-$(BuildSuffix)'
+    displayName: 'Upload Artifacts'

--- a/.ci/templates/build-single.yml
+++ b/.ci/templates/build-single.yml
@@ -7,13 +7,12 @@ steps:
   displayName: 'Prepare Environment'
   inputs:
     dockerVersion: '17.09.0-ce'
-- ${{ if eq(parameters.cache, 'true') }}:
-  - task: CacheBeta@0
-    displayName: 'Cache Build System'
-    inputs:
-      key: yuzu-v1-$(BuildName)-$(BuildSuffix)-$(CacheSuffix)
-      path: $(System.DefaultWorkingDirectory)/ccache
-      cacheHitVar: CACHE_RESTORED
+- task: CacheBeta@0
+  displayName: 'Cache Build System'
+  inputs:
+    key: yuzu-v1-$(BuildName)-$(BuildSuffix)-$(CacheSuffix)
+    path: $(System.DefaultWorkingDirectory)/ccache
+    cacheHitVar: CACHE_RESTORED
 - script: chmod a+x ./.ci/scripts/$(ScriptFolder)/exec.sh && ./.ci/scripts/$(ScriptFolder)/exec.sh
   displayName: 'Build'
 - script: chmod a+x ./.ci/scripts/$(ScriptFolder)/upload.sh && RELEASE_NAME=$(BuildName) ./.ci/scripts/$(ScriptFolder)/upload.sh

--- a/.ci/templates/release-download.yml
+++ b/.ci/templates/release-download.yml
@@ -1,0 +1,13 @@
+steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download Windows Release'
+    inputs:
+      artifactName: 'yuzu-$(BuildName)-windows-mingw'
+      buildType: 'current'
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download Linux Release'
+    inputs:
+      artifactName: 'yuzu-$(BuildName)-linux'
+      buildType: 'current'
+      targetPath: '$(Build.ArtifactStagingDirectory)'

--- a/.ci/templates/release-github.yml
+++ b/.ci/templates/release-github.yml
@@ -1,0 +1,11 @@
+steps:
+  - template: ./release-download.yml
+  - task: GitHubRelease@0
+    inputs:
+      action: 'create'
+      title: 'yuzu $(BuildName) #$(Build.BuildId)'
+      assets: '$(Build.ArtifactStagingDirectory)/*'
+      gitHubConnection: $(GitHubReleaseConnectionName)
+      repositoryName: '$(Build.Repository.Name)'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'auto'

--- a/.ci/templates/release-universal.yml
+++ b/.ci/templates/release-universal.yml
@@ -1,0 +1,10 @@
+steps:
+  - template: ./release-download.yml
+  - task: UniversalPackages@0
+    displayName: Publish Artifacts
+    inputs:
+      command: publish
+      publishDirectory: '$(Build.ArtifactStagingDirectory)'
+      vstsFeedPublish: 'yuzu-$(BuildName)'
+      vstsFeedPackagePublish: 'main'
+      packagePublishDescription: 'Yuzu Windows and Linux Executable Packages'

--- a/.ci/yuzu-mainline-step1.yml
+++ b/.ci/yuzu-mainline-step1.yml
@@ -1,0 +1,8 @@
+trigger:
+- master
+
+stages:
+- stage: merge
+  displayName: 'merge'
+  jobs:
+  - template: ./templates/merge.yml

--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -2,12 +2,7 @@ trigger:
 - master
 
 stages:
-- stage: merge
-  displayName: 'merge'
-  jobs:
-  - template: ./templates/merge.yml
 - stage: format
-  dependsOn: merge
   displayName: 'format'
   jobs:
   - job: format
@@ -17,9 +12,17 @@ stages:
     steps:
     - template: ./templates/format-check.yml
 - stage: build
-  displayName: 'build'
   dependsOn: format
+  displayName: 'build'
   jobs:
   - template: ./templates/build-standard.yml
     parameters:
       cache: 'true'
+- stage: release
+  displayName: 'Release'
+  dependsOn: build
+  jobs:
+  - job: github
+    displayName: 'GitHub Release'
+    steps:
+    - template: ./templates/release-github.yml


### PR DESCRIPTION
Adds:

 *   Caching for all builds
 *   Mock build for faster testing
 *   Templates for universal and github releases
 *   Split mainline pipeline to two parts, one for main and sub repos
