### PR TITLE
bcat: Silence various warnings 

### DIFF
--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -96,7 +96,7 @@ Backend::Backend(DirectoryGetter getter) : dir_getter(std::move(getter)) {}
 
 Backend::~Backend() = default;
 
-NullBackend::NullBackend(const DirectoryGetter& getter) : Backend(std::move(getter)) {}
+NullBackend::NullBackend(DirectoryGetter getter) : Backend(std::move(getter)) {}
 
 NullBackend::~NullBackend() = default;
 

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -10,10 +10,11 @@
 
 namespace Service::BCAT {
 
-ProgressServiceBackend::ProgressServiceBackend(std::string event_name) : impl{} {
+ProgressServiceBackend::ProgressServiceBackend(std::string_view event_name) : impl{} {
     auto& kernel{Core::System::GetInstance().Kernel()};
     event = Kernel::WritableEvent::CreateEventPair(
-        kernel, Kernel::ResetType::Automatic, "ProgressServiceBackend:UpdateEvent:" + event_name);
+        kernel, Kernel::ResetType::Automatic,
+        std::string("ProgressServiceBackend:UpdateEvent:").append(event_name));
 }
 
 Kernel::SharedPtr<Kernel::ReadableEvent> ProgressServiceBackend::GetEvent() const {

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -10,7 +10,7 @@
 
 namespace Service::BCAT {
 
-ProgressServiceBackend::ProgressServiceBackend(std::string_view event_name) : impl{} {
+ProgressServiceBackend::ProgressServiceBackend(std::string_view event_name) {
     auto& kernel{Core::System::GetInstance().Kernel()};
     event = Kernel::WritableEvent::CreateEventPair(
         kernel, Kernel::ResetType::Automatic,

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -131,7 +131,7 @@ protected:
 // A backend of BCAT that provides no operation.
 class NullBackend : public Backend {
 public:
-    explicit NullBackend(const DirectoryGetter& getter);
+    explicit NullBackend(DirectoryGetter getter);
     ~NullBackend() override;
 
     bool Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) override;

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -6,6 +6,9 @@
 
 #include <functional>
 #include <optional>
+#include <string>
+#include <string_view>
+
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
 #include "core/hle/kernel/readable_event.h"
@@ -85,7 +88,7 @@ public:
     void FinishDownload(ResultCode result);
 
 private:
-    explicit ProgressServiceBackend(std::string event_name);
+    explicit ProgressServiceBackend(std::string_view event_name);
 
     Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent() const;
     DeliveryCacheProgressImpl& GetImpl();

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -95,7 +95,7 @@ private:
 
     void SignalUpdate() const;
 
-    DeliveryCacheProgressImpl impl;
+    DeliveryCacheProgressImpl impl{};
     Kernel::EventPair event;
     bool need_hle_lock = false;
 };

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -451,7 +451,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(write_size * sizeof(DeliveryCacheDirectoryEntry));
+        rb.Push(static_cast<u32>(write_size * sizeof(DeliveryCacheDirectoryEntry)));
     }
 
     void GetCount(Kernel::HLERequestContext& ctx) {
@@ -468,7 +468,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(files.size());
+        rb.Push(static_cast<u32>(files.size()));
     }
 
     FileSys::VirtualDir root;
@@ -525,7 +525,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(size);
+        rb.Push(static_cast<u32>(size));
     }
 
     FileSys::VirtualDir root;


### PR DESCRIPTION
Silences unused variable warnings and type truncation warnings. While we're in the same area, we can also make minor improvements to the interfaces.