### PR TITLE
yuzu/configure_input_player: Fix input handling for ZL and ZR from controllers with analog triggers 

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -245,25 +245,24 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
 
         button->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(button, &QPushButton::clicked, [=] {
-            HandleClick(
-                button_map[button_id],
-                [=](Common::ParamPackage params) {
-                    // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
-                    // Analog triggers (from controllers like the XBOX controller) would not work
-                    // due to a different range of their signals (from 0 to 255 on analog triggers
-                    // instead of -32768 to 32768 on analog joysticks). The SDL driver misinterprets
-                    // analog triggers as analog joysticks.
-                    // TODO: reinterpret the signal range for analog triggers to map the values
-                    // correctly. This is required for the correct emulation of the analog triggers
-                    // of the GameCube controller.
-                    if (button_id == Settings::NativeButton::ZL ||
-                        button_id == Settings::NativeButton::ZR) {
-                        params.Set("direction", "+");
-                        params.Set("threshold", "0.5");
-                    }
-                    buttons_param[button_id] = params;
-                },
-                InputCommon::Polling::DeviceType::Button);
+            HandleClick(button_map[button_id],
+                        [=](Common::ParamPackage params) {
+                            // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
+                            // Analog triggers (from controllers like the XBOX controller) would not
+                            // work due to a different range of their signals (from 0 to 255 on
+                            // analog triggers instead of -32768 to 32768 on analog joysticks). The
+                            // SDL driver misinterprets analog triggers as analog joysticks.
+                            // TODO: reinterpret the signal range for analog triggers to map the
+                            // values correctly. This is required for the correct emulation of the
+                            // analog triggers of the GameCube controller.
+                            if (button_id == Settings::NativeButton::ZL ||
+                                button_id == Settings::NativeButton::ZR) {
+                                params.Set("direction", "+");
+                                params.Set("threshold", "0.5");
+                            }
+                            buttons_param[button_id] = std::move(params);
+                        },
+                        InputCommon::Polling::DeviceType::Button);
         });
         connect(button, &QPushButton::customContextMenuRequested, [=](const QPoint& menu_location) {
             QMenu context_menu;
@@ -289,13 +288,12 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
 
             analog_button->setContextMenuPolicy(Qt::CustomContextMenu);
             connect(analog_button, &QPushButton::clicked, [=]() {
-                HandleClick(
-                    analog_map_buttons[analog_id][sub_button_id],
-                    [=](const Common::ParamPackage& params) {
-                        SetAnalogButton(params, analogs_param[analog_id],
-                                        analog_sub_buttons[sub_button_id]);
-                    },
-                    InputCommon::Polling::DeviceType::Button);
+                HandleClick(analog_map_buttons[analog_id][sub_button_id],
+                            [=](const Common::ParamPackage& params) {
+                                SetAnalogButton(params, analogs_param[analog_id],
+                                                analog_sub_buttons[sub_button_id]);
+                            },
+                            InputCommon::Polling::DeviceType::Button);
             });
             connect(analog_button, &QPushButton::customContextMenuRequested,
                     [=](const QPoint& menu_location) {

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -247,7 +247,22 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         connect(button, &QPushButton::clicked, [=] {
             HandleClick(
                 button_map[button_id],
-                [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
+                [=](Common::ParamPackage params) {
+                    // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
+                    // Analog triggers (from controllers like the XBOX controller) would not work
+                    // due to a different range of their signals (from 0 to 255 on analog triggers
+                    // instead of -32768 to 32768 on analog joysticks). The SDL driver misinterprets
+                    // analog triggers as analog joysticks.
+                    // TODO: reinterpret the signal range for analog triggers to map the values
+                    // correctly. This is required for the correct emulation of the analog triggers
+                    // of the GameCube controller.
+                    if (button_id == Settings::NativeButton::ZL ||
+                        button_id == Settings::NativeButton::ZR) {
+                        params.Set("direction", "+");
+                        params.Set("threshold", "0.5");
+                    }
+                    buttons_param[button_id] = params;
+                },
                 InputCommon::Polling::DeviceType::Button);
         });
         connect(button, &QPushButton::customContextMenuRequested, [=](const QPoint& menu_location) {
@@ -274,12 +289,13 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
 
             analog_button->setContextMenuPolicy(Qt::CustomContextMenu);
             connect(analog_button, &QPushButton::clicked, [=]() {
-                HandleClick(analog_map_buttons[analog_id][sub_button_id],
-                            [=](const Common::ParamPackage& params) {
-                                SetAnalogButton(params, analogs_param[analog_id],
-                                                analog_sub_buttons[sub_button_id]);
-                            },
-                            InputCommon::Polling::DeviceType::Button);
+                HandleClick(
+                    analog_map_buttons[analog_id][sub_button_id],
+                    [=](const Common::ParamPackage& params) {
+                        SetAnalogButton(params, analogs_param[analog_id],
+                                        analog_sub_buttons[sub_button_id]);
+                    },
+                    InputCommon::Polling::DeviceType::Button);
             });
             connect(analog_button, &QPushButton::customContextMenuRequested,
                     [=](const QPoint& menu_location) {


### PR DESCRIPTION
Analog triggers (from controllers like the XBOX controller) would not work due to a different range of their signals (from 0 to 255 on analog triggers instead of -32768 to 32768 on analog joysticks).
The SDL driver misinterprets analog triggers as analog joysticks.

Fixes:
1659