### PR TITLE
gl_shader_decompiler/vk_shader_decompiler: Resolve implicit fallthrough cases 

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2316,10 +2316,13 @@ public:
             switch (index) {
             case Tegra::Shader::Pred::NeverExecute:
                 target = "false";
+                break;
             case Tegra::Shader::Pred::UnusedIndex:
                 target = "true";
+                break;
             default:
                 target = decomp.GetPredicate(index);
+                break;
             }
         } else if (const auto flag = std::get_if<InternalFlagNode>(&*cc)) {
             target = decomp.GetInternalFlag(flag->GetFlag());

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -1682,10 +1682,13 @@ public:
             switch (index) {
             case Tegra::Shader::Pred::NeverExecute:
                 target = decomp.v_false;
+                break;
             case Tegra::Shader::Pred::UnusedIndex:
                 target = decomp.v_true;
+                break;
             default:
                 target = decomp.predicates.at(index);
+                break;
             }
         } else if (const auto flag = std::get_if<InternalFlagNode>(&*cc)) {
             target = decomp.internal_flags.at(static_cast<u32>(flag->GetFlag()));


### PR DESCRIPTION
The `NeverExecute` and `UnusedIndex` entries were currently having their target overwritten and replaced with the default case. This amends that.