### PR TITLE
maxwell_3d: Silence implicit conversion warnings

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1166,6 +1166,8 @@ public:
 
     struct DirtyRegs {
         static constexpr std::size_t NUM_REGS = 256;
+        static_assert(NUM_REGS - 1 <= std::numeric_limits<u8>::max());
+
         union {
             struct {
                 bool null_dirty;


### PR DESCRIPTION
While we are at it, unify types for dirty reg pointers.