### PR TITLE
common/bit_field: Remove FORCE_INLINE calls

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -168,11 +168,11 @@ public:
     constexpr BitField(BitField&&) noexcept = default;
     constexpr BitField& operator=(BitField&&) noexcept = default;
 
-    constexpr FORCE_INLINE operator T() const {
+    constexpr operator T() const {
         return Value();
     }
 
-    constexpr FORCE_INLINE void Assign(const T& value) {
+    constexpr void Assign(const T& value) {
         storage = (static_cast<StorageType>(storage) & ~mask) | FormatValue(value);
     }
 


### PR DESCRIPTION
See bunneis comment here 
They were supposed to be removed by him, but he missed them.