### PR TITLE
common_func: Use std::array for INSERT_PADDING_* macros.

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -36,6 +36,13 @@
 #include "common/common_funcs.h"
 #include "common/swap.h"
 
+// Inlining
+#ifdef _WIN32
+#define FORCE_INLINE __forceinline
+#else
+#define FORCE_INLINE inline __attribute__((always_inline))
+#endif
+
 /*
  * Abstract bitfield class
  *

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -1,10 +1,11 @@
-// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Copyright 2019 yuzu emulator team
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <string>
 
 #if !defined(ARCHITECTURE_x86_64)
@@ -16,18 +17,15 @@
 #define CONCAT2(x, y) DO_CONCAT2(x, y)
 #define DO_CONCAT2(x, y) x##y
 
-// helper macro to properly align structure members.
-// Calling INSERT_PADDING_BYTES will add a new member variable with a name like "pad121",
-// depending on the current source line to make sure variable names are unique.
-#define INSERT_PADDING_BYTES(num_bytes) u8 CONCAT2(pad, __LINE__)[(num_bytes)]
-#define INSERT_PADDING_WORDS(num_words) u32 CONCAT2(pad, __LINE__)[(num_words)]
+/// Helper macros to insert unused bytes or words to properly align structs. These values will be
+/// zero-initialized.
+#define INSERT_PADDING_BYTES(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__){};
+#define INSERT_PADDING_WORDS(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__){};
 
-// Inlining
-#ifdef _WIN32
-#define FORCE_INLINE __forceinline
-#else
-#define FORCE_INLINE inline __attribute__((always_inline))
-#endif
+/// These are similar to the INSERT_PADDING_* macros, but are needed for padding unions. This is
+/// because unions can only be initialized by one member.
+#define INSERT_UNION_PADDING_BYTES(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__);
+#define INSERT_UNION_PADDING_WORDS(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__);
 
 #ifndef _MSC_VER
 

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -32,11 +32,28 @@ enum class NCASectionFilesystemType : u8 {
     ROMFS = 0x3,
 };
 
+struct IVFCLevel {
+    u64_le offset;
+    u64_le size;
+    u32_le block_size;
+    u32_le reserved;
+};
+static_assert(sizeof(IVFCLevel) == 0x18, "IVFCLevel has incorrect size.");
+
+struct IVFCHeader {
+    u32_le magic;
+    u32_le magic_number;
+    INSERT_UNION_PADDING_BYTES(8);
+    std::array<IVFCLevel, 6> levels;
+    INSERT_UNION_PADDING_BYTES(64);
+};
+static_assert(sizeof(IVFCHeader) == 0xE0, "IVFCHeader has incorrect size.");
+
 struct NCASectionHeaderBlock {
-    INSERT_PADDING_BYTES(3);
+    INSERT_UNION_PADDING_BYTES(3);
     NCASectionFilesystemType filesystem_type;
     NCASectionCryptoType crypto_type;
-    INSERT_PADDING_BYTES(3);
+    INSERT_UNION_PADDING_BYTES(3);
 };
 static_assert(sizeof(NCASectionHeaderBlock) == 0x8, "NCASectionHeaderBlock has incorrect size.");
 
@@ -44,7 +61,7 @@ struct NCASectionRaw {
     NCASectionHeaderBlock header;
     std::array<u8, 0x138> block_data;
     std::array<u8, 0x8> section_ctr;
-    INSERT_PADDING_BYTES(0xB8);
+    INSERT_UNION_PADDING_BYTES(0xB8);
 };
 static_assert(sizeof(NCASectionRaw) == 0x200, "NCASectionRaw has incorrect size.");
 
@@ -52,19 +69,19 @@ struct PFS0Superblock {
     NCASectionHeaderBlock header_block;
     std::array<u8, 0x20> hash;
     u32_le size;
-    INSERT_PADDING_BYTES(4);
+    INSERT_UNION_PADDING_BYTES(4);
     u64_le hash_table_offset;
     u64_le hash_table_size;
     u64_le pfs0_header_offset;
     u64_le pfs0_size;
-    INSERT_PADDING_BYTES(0x1B0);
+    INSERT_UNION_PADDING_BYTES(0x1B0);
 };
 static_assert(sizeof(PFS0Superblock) == 0x200, "PFS0Superblock has incorrect size.");
 
 struct RomFSSuperblock {
     NCASectionHeaderBlock header_block;
     IVFCHeader ivfc;
-    INSERT_PADDING_BYTES(0x118);
+    INSERT_UNION_PADDING_BYTES(0x118);
 };
 static_assert(sizeof(RomFSSuperblock) == 0x200, "RomFSSuperblock has incorrect size.");
 
@@ -72,24 +89,24 @@ struct BKTRHeader {
     u64_le offset;
     u64_le size;
     u32_le magic;
-    INSERT_PADDING_BYTES(0x4);
+    INSERT_UNION_PADDING_BYTES(0x4);
     u32_le number_entries;
-    INSERT_PADDING_BYTES(0x4);
+    INSERT_UNION_PADDING_BYTES(0x4);
 };
 static_assert(sizeof(BKTRHeader) == 0x20, "BKTRHeader has incorrect size.");
 
 struct BKTRSuperblock {
     NCASectionHeaderBlock header_block;
     IVFCHeader ivfc;
-    INSERT_PADDING_BYTES(0x18);
+    INSERT_UNION_PADDING_BYTES(0x18);
     BKTRHeader relocation;
     BKTRHeader subsection;
-    INSERT_PADDING_BYTES(0xC0);
+    INSERT_UNION_PADDING_BYTES(0xC0);
 };
 static_assert(sizeof(BKTRSuperblock) == 0x200, "BKTRSuperblock has incorrect size.");
 
 union NCASectionHeader {
-    NCASectionRaw raw;
+    NCASectionRaw raw{};
     PFS0Superblock pfs0;
     RomFSSuperblock romfs;
     BKTRSuperblock bktr;

--- a/src/core/file_sys/romfs.h
+++ b/src/core/file_sys/romfs.h
@@ -13,25 +13,6 @@
 
 namespace FileSys {
 
-struct RomFSHeader;
-
-struct IVFCLevel {
-    u64_le offset;
-    u64_le size;
-    u32_le block_size;
-    u32_le reserved;
-};
-static_assert(sizeof(IVFCLevel) == 0x18, "IVFCLevel has incorrect size.");
-
-struct IVFCHeader {
-    u32_le magic;
-    u32_le magic_number;
-    INSERT_PADDING_BYTES(8);
-    std::array<IVFCLevel, 6> levels;
-    INSERT_PADDING_BYTES(64);
-};
-static_assert(sizeof(IVFCHeader) == 0xE0, "IVFCHeader has incorrect size.");
-
 enum class RomFSExtractionType {
     Full,          // Includes data directory
     Truncated,     // Traverses into data directory

--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -160,7 +160,7 @@ struct DomainMessageHeader {
         // Used when responding to an IPC request, Server -> Client.
         struct {
             u32_le num_objects;
-            INSERT_PADDING_WORDS(3);
+            INSERT_UNION_PADDING_WORDS(3);
         };
 
         // Used when performing an IPC request, Client -> Server.
@@ -171,8 +171,10 @@ struct DomainMessageHeader {
                 BitField<16, 16, u32> size;
             };
             u32_le object_id;
-            INSERT_PADDING_WORDS(2);
+            INSERT_UNION_PADDING_WORDS(2);
         };
+
+        std::array<u32, 4> raw{};
     };
 };
 static_assert(sizeof(DomainMessageHeader) == 16, "DomainMessageHeader size is incorrect");

--- a/src/core/hle/service/am/applets/error.cpp
+++ b/src/core/hle/service/am/applets/error.cpp
@@ -20,9 +20,9 @@ namespace Service::AM::Applets {
 struct ShowError {
     u8 mode;
     bool jump;
-    INSERT_PADDING_BYTES(4);
+    INSERT_UNION_PADDING_BYTES(4);
     bool use_64bit_error_code;
-    INSERT_PADDING_BYTES(1);
+    INSERT_UNION_PADDING_BYTES(1);
     u64 error_code_64;
     u32 error_code_32;
 };
@@ -32,7 +32,7 @@ static_assert(sizeof(ShowError) == 0x14, "ShowError has incorrect size.");
 struct ShowErrorRecord {
     u8 mode;
     bool jump;
-    INSERT_PADDING_BYTES(6);
+    INSERT_UNION_PADDING_BYTES(6);
     u64 error_code_64;
     u64 posix_time;
 };
@@ -41,7 +41,7 @@ static_assert(sizeof(ShowErrorRecord) == 0x18, "ShowErrorRecord has incorrect si
 struct SystemErrorArg {
     u8 mode;
     bool jump;
-    INSERT_PADDING_BYTES(6);
+    INSERT_UNION_PADDING_BYTES(6);
     u64 error_code_64;
     std::array<char, 8> language_code;
     std::array<char, 0x800> main_text;
@@ -52,7 +52,7 @@ static_assert(sizeof(SystemErrorArg) == 0x1018, "SystemErrorArg has incorrect si
 struct ApplicationErrorArg {
     u8 mode;
     bool jump;
-    INSERT_PADDING_BYTES(6);
+    INSERT_UNION_PADDING_BYTES(6);
     u32 error_code;
     std::array<char, 8> language_code;
     std::array<char, 0x800> main_text;
@@ -65,6 +65,7 @@ union Error::ErrorArguments {
     ShowErrorRecord error_record;
     SystemErrorArg system_error;
     ApplicationErrorArg application_error;
+    std::array<u8, 0x1018> raw{};
 };
 
 namespace {

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -45,7 +45,7 @@ struct DisplayInfo {
 
     /// Whether or not the display has a limited number of layers.
     u8 has_limited_layers{1};
-    INSERT_PADDING_BYTES(7){};
+    INSERT_PADDING_BYTES(7);
 
     /// Indicates the total amount of layers supported by the display.
     /// @note This is only valid if has_limited_layers is set.

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -99,19 +99,19 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0x80);
+                INSERT_UNION_PADDING_WORDS(0x80);
 
                 Surface dst;
 
-                INSERT_PADDING_WORDS(2);
+                INSERT_UNION_PADDING_WORDS(2);
 
                 Surface src;
 
-                INSERT_PADDING_WORDS(0x15);
+                INSERT_UNION_PADDING_WORDS(0x15);
 
                 Operation operation;
 
-                INSERT_PADDING_WORDS(0x177);
+                INSERT_UNION_PADDING_WORDS(0x177);
 
                 union {
                     u32 raw;
@@ -119,7 +119,7 @@ public:
                     BitField<4, 1, Filter> filter;
                 } blit_control;
 
-                INSERT_PADDING_WORDS(0x8);
+                INSERT_UNION_PADDING_WORDS(0x8);
 
                 u32 blit_dst_x;
                 u32 blit_dst_y;
@@ -130,7 +130,7 @@ public:
                 u64 blit_src_x;
                 u64 blit_src_y;
 
-                INSERT_PADDING_WORDS(0x21);
+                INSERT_UNION_PADDING_WORDS(0x21);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -51,7 +51,7 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0x60);
+                INSERT_UNION_PADDING_WORDS(0x60);
 
                 Upload::Registers upload;
 
@@ -63,7 +63,7 @@ public:
 
                 u32 data_upload;
 
-                INSERT_PADDING_WORDS(0x3F);
+                INSERT_UNION_PADDING_WORDS(0x3F);
 
                 struct {
                     u32 address;
@@ -72,11 +72,11 @@ public:
                     }
                 } launch_desc_loc;
 
-                INSERT_PADDING_WORDS(0x1);
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 u32 launch;
 
-                INSERT_PADDING_WORDS(0x4A7);
+                INSERT_UNION_PADDING_WORDS(0x4A7);
 
                 struct {
                     u32 address_high;
@@ -88,7 +88,7 @@ public:
                     }
                 } tsc;
 
-                INSERT_PADDING_WORDS(0x3);
+                INSERT_UNION_PADDING_WORDS(0x3);
 
                 struct {
                     u32 address_high;
@@ -100,7 +100,7 @@ public:
                     }
                 } tic;
 
-                INSERT_PADDING_WORDS(0x22);
+                INSERT_UNION_PADDING_WORDS(0x22);
 
                 struct {
                     u32 address_high;
@@ -111,11 +111,11 @@ public:
                     }
                 } code_loc;
 
-                INSERT_PADDING_WORDS(0x3FE);
+                INSERT_UNION_PADDING_WORDS(0x3FE);
 
                 u32 tex_cb_index;
 
-                INSERT_PADDING_WORDS(0x374);
+                INSERT_UNION_PADDING_WORDS(0x374);
             };
             std::array<u32, NUM_REGS> reg_array;
         };
@@ -179,7 +179,7 @@ public:
         };
 
         INSERT_PADDING_WORDS(0x11);
-    } launch_description;
+    } launch_description{};
 
     struct {
         u32 write_offset = 0;

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -45,7 +45,7 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0x60);
+                INSERT_UNION_PADDING_WORDS(0x60);
 
                 Upload::Registers upload;
 
@@ -57,7 +57,7 @@ public:
 
                 u32 data;
 
-                INSERT_PADDING_WORDS(0x11);
+                INSERT_UNION_PADDING_WORDS(0x11);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -496,7 +496,7 @@ public:
             Equation equation_a;
             Factor factor_source_a;
             Factor factor_dest_a;
-            INSERT_PADDING_WORDS(1);
+            INSERT_UNION_PADDING_WORDS(1);
         };
 
         struct RenderTargetConfig {
@@ -517,7 +517,7 @@ public:
             };
             u32 layer_stride;
             u32 base_layer;
-            INSERT_PADDING_WORDS(7);
+            INSERT_UNION_PADDING_WORDS(7);
 
             GPUVAddr Address() const {
                 return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
@@ -542,7 +542,7 @@ public:
             f32 translate_x;
             f32 translate_y;
             f32 translate_z;
-            INSERT_PADDING_WORDS(2);
+            INSERT_UNION_PADDING_WORDS(2);
 
             Common::Rectangle<s32> GetRect() const {
                 return {
@@ -606,7 +606,7 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0x45);
+                INSERT_UNION_PADDING_WORDS(0x45);
 
                 struct {
                     u32 upload_address;
@@ -615,7 +615,7 @@ public:
                     u32 bind;
                 } macros;
 
-                INSERT_PADDING_WORDS(0x17);
+                INSERT_UNION_PADDING_WORDS(0x17);
 
                 Upload::Registers upload;
                 struct {
@@ -626,7 +626,7 @@ public:
 
                 u32 data_upload;
 
-                INSERT_PADDING_WORDS(0x44);
+                INSERT_UNION_PADDING_WORDS(0x44);
 
                 struct {
                     union {
@@ -636,11 +636,11 @@ public:
                     };
                 } sync_info;
 
-                INSERT_PADDING_WORDS(0x11E);
+                INSERT_UNION_PADDING_WORDS(0x11E);
 
                 u32 tfb_enabled;
 
-                INSERT_PADDING_WORDS(0x2E);
+                INSERT_UNION_PADDING_WORDS(0x2E);
 
                 std::array<RenderTargetConfig, NumRenderTargets> rt;
 
@@ -648,49 +648,49 @@ public:
 
                 std::array<ViewPort, NumViewports> viewports;
 
-                INSERT_PADDING_WORDS(0x1D);
+                INSERT_UNION_PADDING_WORDS(0x1D);
 
                 struct {
                     u32 first;
                     u32 count;
                 } vertex_buffer;
 
-                INSERT_PADDING_WORDS(1);
+                INSERT_UNION_PADDING_WORDS(1);
 
                 float clear_color[4];
                 float clear_depth;
 
-                INSERT_PADDING_WORDS(0x3);
+                INSERT_UNION_PADDING_WORDS(0x3);
 
                 s32 clear_stencil;
 
-                INSERT_PADDING_WORDS(0x7);
+                INSERT_UNION_PADDING_WORDS(0x7);
 
                 u32 polygon_offset_point_enable;
                 u32 polygon_offset_line_enable;
                 u32 polygon_offset_fill_enable;
 
-                INSERT_PADDING_WORDS(0xD);
+                INSERT_UNION_PADDING_WORDS(0xD);
 
                 std::array<ScissorTest, NumViewports> scissor_test;
 
-                INSERT_PADDING_WORDS(0x15);
+                INSERT_UNION_PADDING_WORDS(0x15);
 
                 s32 stencil_back_func_ref;
                 u32 stencil_back_mask;
                 u32 stencil_back_func_mask;
 
-                INSERT_PADDING_WORDS(0xC);
+                INSERT_UNION_PADDING_WORDS(0xC);
 
                 u32 color_mask_common;
 
-                INSERT_PADDING_WORDS(0x6);
+                INSERT_UNION_PADDING_WORDS(0x6);
 
                 u32 rt_separate_frag_data;
 
                 f32 depth_bounds[2];
 
-                INSERT_PADDING_WORDS(0xA);
+                INSERT_UNION_PADDING_WORDS(0xA);
 
                 struct {
                     u32 address_high;
@@ -710,7 +710,7 @@ public:
                     }
                 } zeta;
 
-                INSERT_PADDING_WORDS(0x41);
+                INSERT_UNION_PADDING_WORDS(0x41);
 
                 union {
                     BitField<0, 4, u32> stencil;
@@ -719,11 +719,11 @@ public:
                     BitField<12, 4, u32> viewport;
                 } clear_flags;
 
-                INSERT_PADDING_WORDS(0x19);
+                INSERT_UNION_PADDING_WORDS(0x19);
 
                 std::array<VertexAttribute, NumVertexAttributes> vertex_attrib_format;
 
-                INSERT_PADDING_WORDS(0xF);
+                INSERT_UNION_PADDING_WORDS(0xF);
 
                 struct {
                     union {
@@ -746,16 +746,16 @@ public:
                     }
                 } rt_control;
 
-                INSERT_PADDING_WORDS(0x2);
+                INSERT_UNION_PADDING_WORDS(0x2);
 
                 u32 zeta_width;
                 u32 zeta_height;
 
-                INSERT_PADDING_WORDS(0x27);
+                INSERT_UNION_PADDING_WORDS(0x27);
 
                 u32 depth_test_enable;
 
-                INSERT_PADDING_WORDS(0x5);
+                INSERT_UNION_PADDING_WORDS(0x5);
 
                 u32 independent_blend_enable;
 
@@ -763,7 +763,7 @@ public:
 
                 u32 alpha_test_enabled;
 
-                INSERT_PADDING_WORDS(0x6);
+                INSERT_UNION_PADDING_WORDS(0x6);
 
                 u32 d3d_cull_mode;
 
@@ -777,7 +777,7 @@ public:
                     float b;
                     float a;
                 } blend_color;
-                INSERT_PADDING_WORDS(0x4);
+                INSERT_UNION_PADDING_WORDS(0x4);
 
                 struct {
                     u32 separate_alpha;
@@ -786,7 +786,7 @@ public:
                     Blend::Factor factor_dest_rgb;
                     Blend::Equation equation_a;
                     Blend::Factor factor_source_a;
-                    INSERT_PADDING_WORDS(1);
+                    INSERT_UNION_PADDING_WORDS(1);
                     Blend::Factor factor_dest_a;
 
                     u32 enable_common;
@@ -802,7 +802,7 @@ public:
                 u32 stencil_front_func_mask;
                 u32 stencil_front_mask;
 
-                INSERT_PADDING_WORDS(0x2);
+                INSERT_UNION_PADDING_WORDS(0x2);
 
                 u32 frag_color_clamp;
 
@@ -811,12 +811,12 @@ public:
                     BitField<4, 1, u32> triangle_rast_flip;
                 } screen_y_control;
 
-                INSERT_PADDING_WORDS(0x21);
+                INSERT_UNION_PADDING_WORDS(0x21);
 
                 u32 vb_element_base;
                 u32 vb_base_instance;
 
-                INSERT_PADDING_WORDS(0x35);
+                INSERT_UNION_PADDING_WORDS(0x35);
 
                 union {
                     BitField<0, 1, u32> c0;
@@ -829,11 +829,11 @@ public:
                     BitField<7, 1, u32> c7;
                 } clip_distance_enabled;
 
-                INSERT_PADDING_WORDS(0x1);
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 float point_size;
 
-                INSERT_PADDING_WORDS(0x7);
+                INSERT_UNION_PADDING_WORDS(0x7);
 
                 u32 zeta_enable;
 
@@ -842,7 +842,7 @@ public:
                     BitField<4, 1, u32> alpha_to_one;
                 } multisample_control;
 
-                INSERT_PADDING_WORDS(0x4);
+                INSERT_UNION_PADDING_WORDS(0x4);
 
                 struct {
                     u32 address_high;
@@ -866,11 +866,11 @@ public:
                     }
                 } tsc;
 
-                INSERT_PADDING_WORDS(0x1);
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 float polygon_offset_factor;
 
-                INSERT_PADDING_WORDS(0x1);
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 struct {
                     u32 tic_address_high;
@@ -883,7 +883,7 @@ public:
                     }
                 } tic;
 
-                INSERT_PADDING_WORDS(0x5);
+                INSERT_UNION_PADDING_WORDS(0x5);
 
                 u32 stencil_two_side_enable;
                 StencilOp stencil_back_op_fail;
@@ -891,13 +891,13 @@ public:
                 StencilOp stencil_back_op_zpass;
                 ComparisonOp stencil_back_func_func;
 
-                INSERT_PADDING_WORDS(0x4);
+                INSERT_UNION_PADDING_WORDS(0x4);
 
                 u32 framebuffer_srgb;
 
                 float polygon_offset_units;
 
-                INSERT_PADDING_WORDS(0x11);
+                INSERT_UNION_PADDING_WORDS(0x11);
 
                 union {
                     BitField<2, 1, u32> coord_origin;
@@ -913,7 +913,7 @@ public:
                             (static_cast<GPUVAddr>(code_address_high) << 32) | code_address_low);
                     }
                 } code_address;
-                INSERT_PADDING_WORDS(1);
+                INSERT_UNION_PADDING_WORDS(1);
 
                 struct {
                     u32 vertex_end_gl;
@@ -925,14 +925,14 @@ public:
                     };
                 } draw;
 
-                INSERT_PADDING_WORDS(0xA);
+                INSERT_UNION_PADDING_WORDS(0xA);
 
                 struct {
                     u32 enabled;
                     u32 index;
                 } primitive_restart;
 
-                INSERT_PADDING_WORDS(0x5F);
+                INSERT_UNION_PADDING_WORDS(0x5F);
 
                 struct {
                     u32 start_addr_high;
@@ -973,9 +973,9 @@ public:
                     }
                 } index_array;
 
-                INSERT_PADDING_WORDS(0x7);
+                INSERT_UNION_PADDING_WORDS(0x7);
 
-                INSERT_PADDING_WORDS(0x1F);
+                INSERT_UNION_PADDING_WORDS(0x1F);
 
                 float polygon_offset_clamp;
 
@@ -989,17 +989,17 @@ public:
                     }
                 } instanced_arrays;
 
-                INSERT_PADDING_WORDS(0x6);
+                INSERT_UNION_PADDING_WORDS(0x6);
 
                 Cull cull;
 
                 u32 pixel_center_integer;
 
-                INSERT_PADDING_WORDS(0x1);
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 u32 viewport_transform_enabled;
 
-                INSERT_PADDING_WORDS(0x3);
+                INSERT_UNION_PADDING_WORDS(0x3);
 
                 union {
                     BitField<0, 1, u32> depth_range_0_1;
@@ -1007,13 +1007,13 @@ public:
                     BitField<4, 1, u32> depth_clamp_far;
                 } view_volume_clip_control;
 
-                INSERT_PADDING_WORDS(0x21);
+                INSERT_UNION_PADDING_WORDS(0x21);
                 struct {
                     u32 enable;
                     LogicOperation operation;
                 } logic_op;
 
-                INSERT_PADDING_WORDS(0x1);
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 union {
                     u32 raw;
@@ -1026,9 +1026,9 @@ public:
                     BitField<6, 4, u32> RT;
                     BitField<10, 11, u32> layer;
                 } clear_buffers;
-                INSERT_PADDING_WORDS(0xB);
+                INSERT_UNION_PADDING_WORDS(0xB);
                 std::array<ColorMask, NumRenderTargets> color_mask;
-                INSERT_PADDING_WORDS(0x38);
+                INSERT_UNION_PADDING_WORDS(0x38);
 
                 struct {
                     u32 query_address_high;
@@ -1050,7 +1050,7 @@ public:
                     }
                 } query;
 
-                INSERT_PADDING_WORDS(0x3C);
+                INSERT_UNION_PADDING_WORDS(0x3C);
 
                 struct {
                     union {
@@ -1090,10 +1090,10 @@ public:
                         BitField<4, 4, ShaderProgram> program;
                     };
                     u32 offset;
-                    INSERT_PADDING_WORDS(14);
+                    INSERT_UNION_PADDING_WORDS(14);
                 } shader_config[MaxShaderProgram];
 
-                INSERT_PADDING_WORDS(0x60);
+                INSERT_UNION_PADDING_WORDS(0x60);
 
                 u32 firmware[0x20];
 
@@ -1110,7 +1110,7 @@ public:
                     }
                 } const_buffer;
 
-                INSERT_PADDING_WORDS(0x10);
+                INSERT_UNION_PADDING_WORDS(0x10);
 
                 struct {
                     union {
@@ -1118,14 +1118,14 @@ public:
                         BitField<0, 1, u32> valid;
                         BitField<4, 5, u32> index;
                     };
-                    INSERT_PADDING_WORDS(7);
+                    INSERT_UNION_PADDING_WORDS(7);
                 } cb_bind[MaxShaderStage];
 
-                INSERT_PADDING_WORDS(0x56);
+                INSERT_UNION_PADDING_WORDS(0x56);
 
                 u32 tex_cb_index;
 
-                INSERT_PADDING_WORDS(0x395);
+                INSERT_UNION_PADDING_WORDS(0x395);
 
                 struct {
                     /// Compressed address of a buffer that holds information about bound SSBOs.
@@ -1137,14 +1137,14 @@ public:
                     }
                 } ssbo_info;
 
-                INSERT_PADDING_WORDS(0x11);
+                INSERT_UNION_PADDING_WORDS(0x11);
 
                 struct {
                     u32 address[MaxShaderStage];
                     u32 size[MaxShaderStage];
                 } tex_info_buffers;
 
-                INSERT_PADDING_WORDS(0xCC);
+                INSERT_UNION_PADDING_WORDS(0xCC);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -94,7 +94,7 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0xC0);
+                INSERT_UNION_PADDING_WORDS(0xC0);
 
                 struct {
                     union {
@@ -112,7 +112,7 @@ public:
                     };
                 } exec;
 
-                INSERT_PADDING_WORDS(0x3F);
+                INSERT_UNION_PADDING_WORDS(0x3F);
 
                 struct {
                     u32 address_high;
@@ -139,7 +139,7 @@ public:
                 u32 x_count;
                 u32 y_count;
 
-                INSERT_PADDING_WORDS(0xB8);
+                INSERT_UNION_PADDING_WORDS(0xB8);
 
                 u32 const0;
                 u32 const1;
@@ -162,11 +162,11 @@ public:
 
                 Parameters dst_params;
 
-                INSERT_PADDING_WORDS(1);
+                INSERT_UNION_PADDING_WORDS(1);
 
                 Parameters src_params;
 
-                INSERT_PADDING_WORDS(0x13);
+                INSERT_UNION_PADDING_WORDS(0x13);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/shader_header.h
+++ b/src/video_core/engines/shader_header.h
@@ -38,37 +38,37 @@ struct Header {
         BitField<26, 1, u32> does_load_or_store;
         BitField<27, 1, u32> does_fp64;
         BitField<28, 4, u32> stream_out_mask;
-    } common0;
+    } common0{};
 
     union {
         BitField<0, 24, u32> shader_local_memory_low_size;
         BitField<24, 8, u32> per_patch_attribute_count;
-    } common1;
+    } common1{};
 
     union {
         BitField<0, 24, u32> shader_local_memory_high_size;
         BitField<24, 8, u32> threads_per_input_primitive;
-    } common2;
+    } common2{};
 
     union {
         BitField<0, 24, u32> shader_local_memory_crs_size;
         BitField<24, 4, OutputTopology> output_topology;
         BitField<28, 4, u32> reserved;
-    } common3;
+    } common3{};
 
     union {
         BitField<0, 12, u32> max_output_vertices;
         BitField<12, 8, u32> store_req_start; // NOTE: not used by geometry shaders.
         BitField<24, 4, u32> reserved;
         BitField<12, 8, u32> store_req_end; // NOTE: not used by geometry shaders.
-    } common4;
+    } common4{};
 
     union {
         struct {
-            INSERT_PADDING_BYTES(3);  // ImapSystemValuesA
-            INSERT_PADDING_BYTES(1);  // ImapSystemValuesB
-            INSERT_PADDING_BYTES(16); // ImapGenericVector[32]
-            INSERT_PADDING_BYTES(2);  // ImapColor
+            INSERT_UNION_PADDING_BYTES(3);  // ImapSystemValuesA
+            INSERT_UNION_PADDING_BYTES(1);  // ImapSystemValuesB
+            INSERT_UNION_PADDING_BYTES(16); // ImapGenericVector[32]
+            INSERT_UNION_PADDING_BYTES(2);  // ImapColor
             union {
                 BitField<0, 8, u16> clip_distances;
                 BitField<8, 1, u16> point_sprite_s;
@@ -79,20 +79,20 @@ struct Header {
                 BitField<14, 1, u16> instance_id;
                 BitField<15, 1, u16> vertex_id;
             };
-            INSERT_PADDING_BYTES(5);  // ImapFixedFncTexture[10]
-            INSERT_PADDING_BYTES(1);  // ImapReserved
-            INSERT_PADDING_BYTES(3);  // OmapSystemValuesA
-            INSERT_PADDING_BYTES(1);  // OmapSystemValuesB
-            INSERT_PADDING_BYTES(16); // OmapGenericVector[32]
-            INSERT_PADDING_BYTES(2);  // OmapColor
-            INSERT_PADDING_BYTES(2);  // OmapSystemValuesC
-            INSERT_PADDING_BYTES(5);  // OmapFixedFncTexture[10]
-            INSERT_PADDING_BYTES(1);  // OmapReserved
+            INSERT_UNION_PADDING_BYTES(5);  // ImapFixedFncTexture[10]
+            INSERT_UNION_PADDING_BYTES(1);  // ImapReserved
+            INSERT_UNION_PADDING_BYTES(3);  // OmapSystemValuesA
+            INSERT_UNION_PADDING_BYTES(1);  // OmapSystemValuesB
+            INSERT_UNION_PADDING_BYTES(16); // OmapGenericVector[32]
+            INSERT_UNION_PADDING_BYTES(2);  // OmapColor
+            INSERT_UNION_PADDING_BYTES(2);  // OmapSystemValuesC
+            INSERT_UNION_PADDING_BYTES(5);  // OmapFixedFncTexture[10]
+            INSERT_UNION_PADDING_BYTES(1);  // OmapReserved
         } vtg;
 
         struct {
-            INSERT_PADDING_BYTES(3); // ImapSystemValuesA
-            INSERT_PADDING_BYTES(1); // ImapSystemValuesB
+            INSERT_UNION_PADDING_BYTES(3); // ImapSystemValuesA
+            INSERT_UNION_PADDING_BYTES(1); // ImapSystemValuesB
             union {
                 BitField<0, 2, AttributeUse> x;
                 BitField<2, 2, AttributeUse> y;
@@ -100,10 +100,10 @@ struct Header {
                 BitField<6, 2, AttributeUse> z;
                 u8 raw;
             } imap_generic_vector[32];
-            INSERT_PADDING_BYTES(2);  // ImapColor
-            INSERT_PADDING_BYTES(2);  // ImapSystemValuesC
-            INSERT_PADDING_BYTES(10); // ImapFixedFncTexture[10]
-            INSERT_PADDING_BYTES(2);  // ImapReserved
+            INSERT_UNION_PADDING_BYTES(2);  // ImapColor
+            INSERT_UNION_PADDING_BYTES(2);  // ImapSystemValuesC
+            INSERT_UNION_PADDING_BYTES(10); // ImapFixedFncTexture[10]
+            INSERT_UNION_PADDING_BYTES(2);  // ImapReserved
             struct {
                 u32 target;
                 union {
@@ -139,6 +139,8 @@ struct Header {
                 return result;
             }
         } ps;
+
+        std::array<u32, 0xF> raw{};
     };
 
     u64 GetLocalMemorySize() const {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -207,7 +207,7 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0x4);
+                INSERT_UNION_PADDING_WORDS(0x4);
                 struct {
                     u32 address_high;
                     u32 address_low;
@@ -220,12 +220,12 @@ public:
 
                 u32 semaphore_sequence;
                 u32 semaphore_trigger;
-                INSERT_PADDING_WORDS(0xC);
+                INSERT_UNION_PADDING_WORDS(0xC);
 
                 // The puser and the puller share the reference counter, the pusher only has read
                 // access
                 u32 reference_count;
-                INSERT_PADDING_WORDS(0x5);
+                INSERT_UNION_PADDING_WORDS(0x5);
 
                 u32 semaphore_acquire;
                 u32 semaphore_release;
@@ -234,7 +234,7 @@ public:
                     BitField<4, 4, u32> operation;
                     BitField<8, 8, u32> id;
                 } fence_action;
-                INSERT_PADDING_WORDS(0xE2);
+                INSERT_UNION_PADDING_WORDS(0xE2);
 
                 // Puller state
                 u32 acquire_mode;


### PR DESCRIPTION
*  Zero initialization here is useful for determinism.
