### PR TITLE
 Merge pull request yuzu-emu3104 from lioncash/xts 

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -56,7 +56,7 @@ std::string GetLastErrorMsg();
 namespace Common {
 
 constexpr u32 MakeMagic(char a, char b, char c, char d) {
-    return a | b << 8 | c << 16 | d << 24;
+    return u32(a) | u32(b) << 8 | u32(c) << 16 | u32(d) << 24;
 }
 
 } // namespace Common

--- a/src/core/file_sys/xts_archive.cpp
+++ b/src/core/file_sys/xts_archive.cpp
@@ -93,8 +93,7 @@ Loader::ResultStatus NAX::Parse(std::string_view path) {
     std::size_t i = 0;
     for (; i < sd_keys.size(); ++i) {
         std::array<Core::Crypto::Key128, 2> nax_keys{};
-        if (!CalculateHMAC256(nax_keys.data(), sd_keys[i].data(), 0x10, std::string(path).c_str(),
-                              path.size())) {
+        if (!CalculateHMAC256(nax_keys.data(), sd_keys[i].data(), 0x10, path.data(), path.size())) {
             return Loader::ResultStatus::ErrorNAXKeyHMACFailed;
         }
 


### PR DESCRIPTION
xts_archive: Remove redundant std::string constructor

