### PR TITLE
Kernel: Correct behavior of Condition Variables to be more similar to real hardware.

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -66,6 +66,9 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
         thread->SetMutexWaitAddress(0);
         thread->SetCondVarWaitAddress(0);
         thread->SetWaitHandle(0);
+        if (thread->GetStatus() == ThreadStatus::WaitCondVar) {
+            thread->GetOwnerProcess()->RemoveConditionVariableThread(thread);
+        }
 
         auto* const lock_owner = thread->GetLockOwner();
         // Threads waking up by timeout from WaitProcessWideKey do not perform priority inheritance

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -142,6 +142,52 @@ u64 Process::GetTotalPhysicalMemoryUsedWithoutSystemResource() const {
     return GetTotalPhysicalMemoryUsed() - GetSystemResourceUsage();
 }
 
+void Process::InsertConditionVariableThread(SharedPtr<Thread> thread) {
+    auto it = cond_var_threads.begin();
+    while (it != cond_var_threads.end()) {
+        const SharedPtr<Thread> current_thread = *it;
+        if (current_thread->GetCondVarWaitAddress() < thread->GetCondVarWaitAddress()) {
+            if (current_thread->GetCondVarWaitAddress() == thread->GetCondVarWaitAddress()) {
+                if (current_thread->GetPriority() > thread->GetPriority()) {
+                    cond_var_threads.insert(it, thread);
+                    return;
+                }
+            } else {
+                cond_var_threads.insert(it, thread);
+                return;
+            }
+        }
+        it++;
+    }
+    cond_var_threads.push_back(thread);
+}
+
+void Process::RemoveConditionVariableThread(SharedPtr<Thread> thread) {
+    auto it = cond_var_threads.begin();
+    while (it != cond_var_threads.end()) {
+        const SharedPtr<Thread> current_thread = *it;
+        if (current_thread.get() == thread.get()) {
+            cond_var_threads.erase(it);
+            return;
+        }
+        it++;
+    }
+    UNREACHABLE();
+}
+
+std::vector<SharedPtr<Thread>> Process::GetConditionVariableThreads(const VAddr cond_var_addr) {
+    std::vector<SharedPtr<Thread>> result{};
+    auto it = cond_var_threads.begin();
+    while (it != cond_var_threads.end()) {
+        SharedPtr<Thread> current_thread = *it;
+        if (current_thread->GetCondVarWaitAddress() == cond_var_addr) {
+            result.push_back(current_thread);
+        }
+        it++;
+    }
+    return result;
+}
+
 void Process::RegisterThread(const Thread* thread) {
     thread_list.push_back(thread);
 }

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -232,6 +232,15 @@ public:
         return thread_list;
     }
 
+    /// Insert a thread into the condition variable wait container
+    void InsertConditionVariableThread(SharedPtr<Thread> thread);
+
+    /// Remove a thread from the condition variable wait container
+    void RemoveConditionVariableThread(SharedPtr<Thread> thread);
+
+    /// Obtain all condition variable threads waiting for some address
+    std::vector<SharedPtr<Thread>> GetConditionVariableThreads(VAddr cond_var_addr);
+
     /// Registers a thread as being created under this process,
     /// adding it to this process' thread list.
     void RegisterThread(const Thread* thread);
@@ -374,6 +383,9 @@ private:
 
     /// List of threads that are running with this process as their owner.
     std::list<const Thread*> thread_list;
+
+    /// List of threads waiting for a condition variable
+    std::list<SharedPtr<Thread>> cond_var_threads;
 
     /// System context
     Core::System& system;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -318,7 +318,15 @@ void Thread::UpdatePriority() {
         return;
     }
 
+    if (GetStatus() == ThreadStatus::WaitCondVar) {
+        owner_process->RemoveConditionVariableThread(this);
+    }
+
     SetCurrentPriority(new_priority);
+
+    if (GetStatus() == ThreadStatus::WaitCondVar) {
+        owner_process->InsertConditionVariableThread(this);
+    }
 
     if (!lock_owner) {
         return;


### PR DESCRIPTION
This commit ensures cond var threads act exactly as they do in the real console. The original implementation uses an RBTree and the behavior of cond var threads is that at the same priority level they act like a FIFO.