### PR TITLE
gl_shader_gen: Apply default value to gl_Position

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -32,6 +32,7 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
 
     out += R"(
 void main() {
+    gl_Position = vec4(0.0f, 0.0f, 0.0f, 1.0f);
     execute_vertex();
 )";
     if (ir_b) {


### PR DESCRIPTION
Nvidia has sane default output values for varyings, but the other
vendors don't apply these. To properly emulate this we would have to
analyze the shader header. For the time being, apply the same default
Nvidia applies so we get the same behaviour on non-Nvidia drivers.