### PR TITLE
gl_texture_cache: Apply sRGB on blits

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -488,6 +488,7 @@ void TextureCacheOpenGL::ImageBlit(View& src_view, View& dst_view,
     OpenGLState state;
     state.draw.read_framebuffer = src_framebuffer.handle;
     state.draw.draw_framebuffer = dst_framebuffer.handle;
+    state.framebuffer_srgb.enabled = dst_params.srgb_conversion;
     state.AllDirty();
     state.Apply();
 


### PR DESCRIPTION
glBlitFramebuffer keeps in mind GL_FRAMEBUFFER_SRGB's state. Enable this
depending on the target surface pixel format.