### PR TITLE
file_sys/directory: Make EntryType an enum class

### DIFF
--- a/src/core/file_sys/directory.h
+++ b/src/core/file_sys/directory.h
@@ -15,7 +15,7 @@
 
 namespace FileSys {
 
-enum EntryType : u8 {
+enum class EntryType : u8 {
     Directory = 0,
     File = 1,
 };

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -256,8 +256,8 @@ public:
 
         // TODO(DarkLordZach): Verify that this is the correct behavior.
         // Build entry index now to save time later.
-        BuildEntryIndex(entries, backend->GetFiles(), FileSys::File);
-        BuildEntryIndex(entries, backend->GetSubdirectories(), FileSys::Directory);
+        BuildEntryIndex(entries, backend->GetFiles(), FileSys::EntryType::File);
+        BuildEntryIndex(entries, backend->GetSubdirectories(), FileSys::EntryType::Directory);
     }
 
 private:


### PR DESCRIPTION
This can trivially be an enum class rather than a regular enum, making
it more strongly typed.