### PR TITLE
texture_cache/surface_base: Fix out of bounds texture views

### DIFF
--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -254,16 +254,14 @@ public:
         if (!layer_mipmap) {
             return {};
         }
-        const u32 end_layer{layer_mipmap->first};
-        const u32 end_mipmap{layer_mipmap->second};
+        const auto [end_layer, end_mipmap] = *layer_mipmap;
         if (layer != end_layer) {
             if (mipmap == 0 && end_mipmap == 0) {
-                return GetView(ViewParams(view_params.target, layer, end_layer - layer + 1, 0, 1));
+                return GetView(ViewParams(view_params.target, layer, end_layer - layer, 0, 1));
             }
             return {};
         } else {
-            return GetView(
-                ViewParams(view_params.target, layer, 1, mipmap, end_mipmap - mipmap + 1));
+            return GetView(ViewParams(view_params.target, layer, 1, mipmap, end_mipmap - mipmap));
         }
     }
 
@@ -278,8 +276,7 @@ public:
         if (!layer_mipmap) {
             return {};
         }
-        const u32 layer{layer_mipmap->first};
-        const u32 mipmap{layer_mipmap->second};
+        const auto [layer, mipmap] = *layer_mipmap;
         if (GetMipmapSize(mipmap) != candidate_size) {
             return EmplaceIrregularView(view_params, view_addr, candidate_size, mipmap, layer);
         }


### PR DESCRIPTION
Some texture views were being created out of bounds (with more layers or
mipmaps than what the original texture has). This is because of a
miscalculation in mipmap bounding. end_layer and end_mipmap are out of
bounds (e.g. layer 6 in a cubemap), there's no need to add one more
there.

Fixes OpenGL errors and Vulkan crashes on Splatoon 2.