### PR TITLE
Texture Cache: Add HLE methods for building 3D textures

### DIFF
--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -138,13 +138,13 @@ public:
 
     std::size_t GetConvertedMipmapSize(u32 level) const;
 
-    // Get this texture Tegra Block size in guest memory layout
+    /// Get this texture Tegra Block size in guest memory layout
     u32 GetBlockSize() const;
 
-    // Get X, Y sizes of a block
+    /// Get X, Y sizes of a block
     std::pair<u32, u32> GetBlockXY() const;
 
-    // Get the offset in x, y, z coordinates from a memory offset
+    /// Get the offset in x, y, z coordinates from a memory offset
     std::tuple<u32, u32, u32> GetBlockOffsetXYZ(u32 offset) const;
 
     /// Returns the size of a layer in bytes in guest memory.

--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "common/alignment.h"
 #include "common/bit_util.h"
 #include "common/cityhash.h"
@@ -135,6 +137,15 @@ public:
     }
 
     std::size_t GetConvertedMipmapSize(u32 level) const;
+
+    // Get this texture Tegra Block size in guest memory layout
+    u32 GetBlockSize() const;
+
+    // Get X, Y sizes of a block
+    std::pair<u32, u32> GetBlockXY() const;
+
+    // Get the offset in x, y, z coordinates from a memory offset
+    std::tuple<u32, u32, u32> GetBlockOffsetXYZ(u32 offset) const;
 
     /// Returns the size of a layer in bytes in guest memory.
     std::size_t GetGuestLayerSize() const {
@@ -269,7 +280,8 @@ private:
 
     /// Returns the size of all mipmap levels and aligns as needed.
     std::size_t GetInnerMemorySize(bool as_host_size, bool layer_only, bool uncompressed) const {
-        return GetLayerSize(as_host_size, uncompressed) * (layer_only ? 1U : depth);
+        return GetLayerSize(as_host_size, uncompressed) *
+               (layer_only ? 1U : (is_layered ? depth : 1U));
     }
 
     /// Returns the size of a layer

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -616,6 +616,85 @@ private:
     }
 
     /**
+     * Takes care of managing 3D textures and its slices. Does some HLE methods when possible.
+     * Fallsback to LLE when it isn't possible.
+     *
+     * @param overlaps The overlapping surfaces registered in the cache.
+     * @param params   The parameters on the new surface.
+     * @param gpu_addr The starting address of the new surface.
+     * @param cache_addr The starting address of the new surface on physical memory.
+     * @param preserve_contents Indicates that the new surface should be loaded from memory or
+     *                          left blank.
+     */
+    std::optional<std::pair<TSurface, TView>> Manage3DSurfaces(std::vector<TSurface>& overlaps,
+                                                               const SurfaceParams& params,
+                                                               const GPUVAddr gpu_addr,
+                                                               const CacheAddr cache_addr,
+                                                               bool preserve_contents) {
+        if (params.target == SurfaceTarget::Texture3D) {
+            bool failed = false;
+            if (params.num_levels > 1) {
+                // We can't handle mipmaps in 3D textures yet, better fallback to LLE approach
+                return std::nullopt;
+            }
+            TSurface new_surface = GetUncachedSurface(gpu_addr, params);
+            bool modified = false;
+            for (auto& surface : overlaps) {
+                const SurfaceParams& src_params = surface->GetSurfaceParams();
+                if (src_params.target != SurfaceTarget::Texture2D) {
+                    failed = true;
+                    break;
+                }
+                if (src_params.height != params.height) {
+                    failed = true;
+                    break;
+                }
+                if (src_params.block_depth != params.block_depth ||
+                    src_params.block_height != params.block_height) {
+                    failed = true;
+                    break;
+                }
+                const u32 offset = static_cast<u32>(surface->GetCacheAddr() - cache_addr);
+                const auto [x, y, z] = params.GetBlockOffsetXYZ(offset);
+                modified |= surface->IsModified();
+                const CopyParams copy_params(0, 0, 0, 0, 0, z, 0, 0, params.width, params.height,
+                                             1);
+                ImageCopy(surface, new_surface, copy_params);
+            }
+            if (failed) {
+                return std::nullopt;
+            }
+            for (const auto& surface : overlaps) {
+                Unregister(surface);
+            }
+            new_surface->MarkAsModified(modified, Tick());
+            Register(new_surface);
+            return {{new_surface, new_surface->GetMainView()}};
+        } else {
+            for (const auto& surface : overlaps) {
+                if (!surface->MatchTarget(params.target)) {
+                    if (overlaps.size() == 1 && surface->GetCacheAddr() == cache_addr) {
+                        if (Settings::values.use_accurate_gpu_emulation) {
+                            return std::nullopt;
+                        }
+                        Unregister(surface);
+                        return InitializeSurface(gpu_addr, params, preserve_contents);
+                    }
+                    return std::nullopt;
+                }
+                if (surface->GetCacheAddr() != cache_addr) {
+                    continue;
+                }
+                const auto struct_result = surface->MatchesStructure(params);
+                if (struct_result == MatchStructureResult::FullMatch) {
+                    return {{surface, surface->GetMainView()}};
+                }
+            }
+            return InitializeSurface(gpu_addr, params, preserve_contents);
+        }
+    }
+
+    /**
      * Gets the starting address and parameters of a candidate surface and tries
      * to find a matching surface within the cache. This is done in 3 big steps:
      *
@@ -684,6 +763,15 @@ private:
             if (topological_result != MatchTopologyResult::FullMatch) {
                 return RecycleSurface(overlaps, params, gpu_addr, preserve_contents,
                                       topological_result);
+            }
+        }
+
+        // Look if it's a 3D texture
+        if (params.block_depth > 0) {
+            std::optional<std::pair<TSurface, TView>> surface =
+                Manage3DSurfaces(overlaps, params, gpu_addr, cache_addr, preserve_contents);
+            if (surface) {
+                return *surface;
             }
         }
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -619,10 +619,10 @@ private:
      * Takes care of managing 3D textures and its slices. Does some HLE methods when possible.
      * Fallsback to LLE when it isn't possible.
      *
-     * @param overlaps The overlapping surfaces registered in the cache.
-     * @param params   The parameters on the new surface.
-     * @param gpu_addr The starting address of the new surface.
-     * @param cache_addr The starting address of the new surface on physical memory.
+     * @param overlaps          The overlapping surfaces registered in the cache.
+     * @param params            The parameters on the new surface.
+     * @param gpu_addr          The starting address of the new surface.
+     * @param cache_addr        The starting address of the new surface on physical memory.
      * @param preserve_contents Indicates that the new surface should be loaded from memory or
      *                          left blank.
      */
@@ -669,7 +669,8 @@ private:
             }
             new_surface->MarkAsModified(modified, Tick());
             Register(new_surface);
-            return {{new_surface, new_surface->GetMainView()}};
+            auto view = new_surface->GetMainView();
+            return {{std::move(new_surface), view}};
         } else {
             for (const auto& surface : overlaps) {
                 if (!surface->MatchTarget(params.target)) {
@@ -685,8 +686,7 @@ private:
                 if (surface->GetCacheAddr() != cache_addr) {
                     continue;
                 }
-                const auto struct_result = surface->MatchesStructure(params);
-                if (struct_result == MatchStructureResult::FullMatch) {
+                if (surface->MatchesStructure(params) == MatchStructureResult::FullMatch) {
                     return {{surface, surface->GetMainView()}};
                 }
             }
@@ -768,7 +768,7 @@ private:
 
         // Look if it's a 3D texture
         if (params.block_depth > 0) {
-            std::optional<std::pair<TSurface, TView>> surface =
+            auto surface =
                 Manage3DSurfaces(overlaps, params, gpu_addr, cache_addr, preserve_contents);
             if (surface) {
                 return *surface;

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -12,6 +12,10 @@ namespace Tegra::Texture {
 
 // GOBSize constant. Calculated by 64 bytes in x multiplied by 8 y coords, represents
 // an small rect of (64/bytes_per_pixel)X8.
+inline std::size_t GetGOBSize() {
+    return 512;
+}
+
 inline std::size_t GetGOBSizeShift() {
     return 9;
 }


### PR DESCRIPTION
This commit adds a series of HLE methods for handling 3D textures in general. This helps games that generate 3D textures on every frame and may reduce loading times for certain games.