### PR TITLE
gl_shader_cache: Style changes 

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -112,25 +112,25 @@ constexpr GLenum GetGLShaderType(ShaderType shader_type) {
 }
 
 /// Describes primitive behavior on geometry shaders
-constexpr std::tuple<const char*, const char*, u32> GetPrimitiveDescription(GLenum primitive_mode) {
+constexpr std::pair<const char*, u32> GetPrimitiveDescription(GLenum primitive_mode) {
     switch (primitive_mode) {
     case GL_POINTS:
-        return {"points", "Points", 1};
+        return {"points", 1};
     case GL_LINES:
     case GL_LINE_STRIP:
-        return {"lines", "Lines", 2};
+        return {"lines", 2};
     case GL_LINES_ADJACENCY:
     case GL_LINE_STRIP_ADJACENCY:
-        return {"lines_adjacency", "LinesAdj", 4};
+        return {"lines_adjacency", 4};
     case GL_TRIANGLES:
     case GL_TRIANGLE_STRIP:
     case GL_TRIANGLE_FAN:
-        return {"triangles", "Triangles", 3};
+        return {"triangles", 3};
     case GL_TRIANGLES_ADJACENCY:
     case GL_TRIANGLE_STRIP_ADJACENCY:
-        return {"triangles_adjacency", "TrianglesAdj", 6};
+        return {"triangles_adjacency", 6};
     default:
-        return {"points", "Invalid", 1};
+        return {"points", 1};
     }
 }
 
@@ -267,11 +267,9 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ShaderTyp
     source += '\n';
 
     if (shader_type == ShaderType::Geometry) {
-        const auto [glsl_topology, debug_name, max_vertices] =
-            GetPrimitiveDescription(variant.primitive_mode);
-
-        source += fmt::format("layout ({}) in;\n\n", glsl_topology);
+        const auto [glsl_topology, max_vertices] = GetPrimitiveDescription(variant.primitive_mode);
         source += fmt::format("#define MAX_VERTEX_INPUT {}\n", max_vertices);
+        source += fmt::format("layout ({}) in;\n\n", glsl_topology);
     }
     if (shader_type == ShaderType::Compute) {
         source +=


### PR DESCRIPTION
Removes unused return values and invalid commentaries. Not dividing by 4 the size of shared memory is
not a hack; it describes the number of integers, not bytes. While we are at it sort the generated code to put preprocessor lines on the top.