### PR TITLE
maxwell_3d: Make dirty_pointers private

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1271,8 +1271,6 @@ public:
 
     } dirty{};
 
-    std::array<u8, Regs::NUM_REGS> dirty_pointers{};
-
     /// Reads a register value located at the input method address
     u32 GetRegisterValue(u32 method) const;
 
@@ -1366,6 +1364,8 @@ private:
     Upload::State upload_state;
 
     bool execute_on{true};
+
+    std::array<u8, Regs::NUM_REGS> dirty_pointers{};
 
     /// Retrieves information about a specific TIC entry from the TIC buffer.
     Texture::TICEntry GetTICEntry(u32 tic_index) const;


### PR DESCRIPTION
This isn't used outside of the class itself, so we can make it private
for the time being.