### PR TITLE
gl_state: Use bool instead of GLboolean

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1272,7 +1272,7 @@ void RasterizerOpenGL::SyncPointState() {
     const auto& regs = system.GPU().Maxwell3D().regs;
     // Limit the point size to 1 since nouveau sometimes sets a point size of 0 (and that's invalid
     // in OpenGL).
-    state.point.program_control = regs.vp_point_size.enable ? GL_TRUE : GL_FALSE;
+    state.point.program_control = regs.vp_point_size.enable != 0;
     state.point.size = std::max(1.0f, regs.point_size);
 }
 

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -131,8 +131,8 @@ public:
     std::array<Viewport, Tegra::Engines::Maxwell3D::Regs::NumViewports> viewports;
 
     struct {
-        GLboolean program_control = GL_FALSE; // GL_PROGRAM_POINT_SIZE
-        GLfloat size = 1.0f;                  // GL_POINT_SIZE
+        bool program_control = false; // GL_PROGRAM_POINT_SIZE
+        GLfloat size = 1.0f;          // GL_POINT_SIZE
     } point;
 
     struct {


### PR DESCRIPTION
This fixes template resolution considering GLboolean an integer instead
of a bool.