### PR TITLE
shader/texture: Fix illegal 3D texture assert

### DIFF
--- a/src/video_core/shader/decode/texture.cpp
+++ b/src/video_core/shader/decode/texture.cpp
@@ -527,7 +527,7 @@ Node4 ShaderIR::GetTextureCode(Instruction instr, TextureType texture_type,
     const bool is_bindless = bindless_reg.has_value();
 
     UNIMPLEMENTED_IF(texture_type == TextureType::TextureCube && is_array && is_shadow);
-    ASSERT_MSG(texture_type != TextureType::Texture3D || is_array || is_shadow,
+    ASSERT_MSG(texture_type != TextureType::Texture3D || !is_array || !is_shadow,
                "Illegal texture type");
 
     const SamplerInfo info{texture_type, is_array, is_shadow, false};


### PR DESCRIPTION
Fix typo in the illegal 3D texture assert logic. We care about catching
arrayed 3D textures or 3D shadow textures, not regular 3D textures.