### PR TITLE
audio_core: interpolate: Pad input with zeros, the algorithm reads pa…

### DIFF
--- a/src/audio_core/algorithm/interpolate.cpp
+++ b/src/audio_core/algorithm/interpolate.cpp
@@ -162,6 +162,11 @@ std::vector<s16> Interpolate(InterpolationState& state, std::vector<s16> input, 
 
     std::vector<s16> output(static_cast<std::size_t>(input.size() / ratio));
     int in_offset = 0;
+
+    // Pad the end with zeros, as the below algorithm reads a frame past the buffer on the final
+    // iteration. Fixes audio crackling in Crash Team Racing Nitro-Fueled.
+    input.resize(input.size() + 32);
+
     for (std::size_t out_offset = 0; out_offset < output.size(); out_offset += 2) {
         const int lut_index = (state.fraction >> 8) * 4;
 


### PR DESCRIPTION
…st on final frame.

- Fixes audio crackling in Crash Team Racing Nitro-Fueled.