### PR TITLE
audio_core: interpolate: Improvements to fix audio crackling.

### DIFF
--- a/src/audio_core/algorithm/interpolate.h
+++ b/src/audio_core/algorithm/interpolate.h
@@ -6,12 +6,17 @@
 
 #include <array>
 #include <vector>
+
 #include "common/common_types.h"
 
 namespace AudioCore {
 
 struct InterpolationState {
-    int fraction = 0;
+    static constexpr std::size_t taps{4};
+    static constexpr std::size_t history_size{taps * 2 - 1};
+    std::array<std::array<s16, 2>, history_size> history{};
+    double position{};
+    s32 fraction{};
 };
 
 /// Interpolates input signal to produce output signal.


### PR DESCRIPTION
- Fixes audio crackling in Crash Team Racing Nitro-Fueled, Super Mario Odyssey, and others.
- Addresses followup issues from 3310.