### PR TITLE
DirtyFlags: relax need to set render_targets as dirty

### DIFF
--- a/src/video_core/dirty_flags.cpp
+++ b/src/video_core/dirty_flags.cpp
@@ -15,14 +15,6 @@ namespace VideoCommon::Dirty {
 
 using Tegra::Engines::Maxwell3D;
 
-void SetupCommonOnWriteStores(Tegra::Engines::Maxwell3D::DirtyState::Flags& store) {
-    store[RenderTargets] = true;
-    store[ZetaBuffer] = true;
-    for (std::size_t i = 0; i < Maxwell3D::Regs::NumRenderTargets; ++i) {
-        store[ColorBuffer0 + i] = true;
-    }
-}
-
 void SetupDirtyRenderTargets(Tegra::Engines::Maxwell3D::DirtyState::Tables& tables) {
     static constexpr std::size_t num_per_rt = NUM(rt[0]);
     static constexpr std::size_t begin = OFF(rt);

--- a/src/video_core/dirty_flags.h
+++ b/src/video_core/dirty_flags.h
@@ -44,8 +44,6 @@ void FillBlock(Tegra::Engines::Maxwell3D::DirtyState::Tables& tables, std::size_
     FillBlock(tables[1], begin, num, index_b);
 }
 
-void SetupCommonOnWriteStores(Tegra::Engines::Maxwell3D::DirtyState::Flags& store);
-
 void SetupDirtyRenderTargets(Tegra::Engines::Maxwell3D::DirtyState::Tables& tables);
 
 } // namespace VideoCommon::Dirty

--- a/src/video_core/renderer_opengl/gl_state_tracker.cpp
+++ b/src/video_core/renderer_opengl/gl_state_tracker.cpp
@@ -238,7 +238,6 @@ void StateTracker::Initialize() {
     SetupDirtyMisc(tables);
 
     auto& store = dirty.on_write_stores;
-    SetupCommonOnWriteStores(store);
     store[VertexBuffers] = true;
     for (std::size_t i = 0; i < Regs::NumVertexArrays; ++i) {
         store[VertexBuffer0 + i] = true;

--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -90,8 +90,6 @@ void StateTracker::Initialize() {
     SetupDirtyBlendConstants(tables);
     SetupDirtyDepthBounds(tables);
     SetupDirtyStencilProperties(tables);
-
-    SetupCommonOnWriteStores(dirty.on_write_stores);
 }
 
 void StateTracker::InvalidateCommandBufferState() {


### PR DESCRIPTION
The texture cache already takes care of setting a render target to dirty 
when invalidated.