### PR TITLE
vk_rasterizer: Fix number of attachment in renderpasses

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -175,6 +175,10 @@ public:
         return {surface.GetAspectMask(), base_level, base_layer, num_layers};
     }
 
+    VideoCore::Surface::PixelFormat GetFormat() const {
+        return params.pixel_format;
+    }
+
     void Transition(vk::ImageLayout new_layout, vk::PipelineStageFlags new_stage_mask,
                     vk::AccessFlags new_access) const {
         surface.Transition(base_layer, num_layers, base_level, num_levels, new_stage_mask,


### PR DESCRIPTION
Fixes validation errors when clears with more than one present
attachment are used.