### PR TITLE
buffer_cache: Return handles instead of pointer to handles

### DIFF
--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -55,33 +55,31 @@ void OGLBufferCache::WriteBarrier() {
     glMemoryBarrier(GL_ALL_BARRIER_BITS);
 }
 
-const GLuint* OGLBufferCache::ToHandle(const Buffer& buffer) {
+GLuint OGLBufferCache::ToHandle(const Buffer& buffer) {
     return buffer->GetHandle();
 }
 
-const GLuint* OGLBufferCache::GetEmptyBuffer(std::size_t) {
-    static const GLuint null_buffer = 0;
-    return &null_buffer;
+GLuint OGLBufferCache::GetEmptyBuffer(std::size_t) {
+    return 0;
 }
 
 void OGLBufferCache::UploadBlockData(const Buffer& buffer, std::size_t offset, std::size_t size,
                                      const u8* data) {
-    glNamedBufferSubData(*buffer->GetHandle(), static_cast<GLintptr>(offset),
+    glNamedBufferSubData(buffer->GetHandle(), static_cast<GLintptr>(offset),
                          static_cast<GLsizeiptr>(size), data);
 }
 
 void OGLBufferCache::DownloadBlockData(const Buffer& buffer, std::size_t offset, std::size_t size,
                                        u8* data) {
     MICROPROFILE_SCOPE(OpenGL_Buffer_Download);
-    glGetNamedBufferSubData(*buffer->GetHandle(), static_cast<GLintptr>(offset),
+    glGetNamedBufferSubData(buffer->GetHandle(), static_cast<GLintptr>(offset),
                             static_cast<GLsizeiptr>(size), data);
 }
 
 void OGLBufferCache::CopyBlock(const Buffer& src, const Buffer& dst, std::size_t src_offset,
                                std::size_t dst_offset, std::size_t size) {
-    glCopyNamedBufferSubData(*src->GetHandle(), *dst->GetHandle(),
-                             static_cast<GLintptr>(src_offset), static_cast<GLintptr>(dst_offset),
-                             static_cast<GLsizeiptr>(size));
+    glCopyNamedBufferSubData(src->GetHandle(), dst->GetHandle(), static_cast<GLintptr>(src_offset),
+                             static_cast<GLintptr>(dst_offset), static_cast<GLsizeiptr>(size));
 }
 
 OGLBufferCache::BufferInfo OGLBufferCache::ConstBufferUpload(const void* raw_pointer,
@@ -89,7 +87,7 @@ OGLBufferCache::BufferInfo OGLBufferCache::ConstBufferUpload(const void* raw_poi
     DEBUG_ASSERT(cbuf_cursor < std::size(cbufs));
     const GLuint& cbuf = cbufs[cbuf_cursor++];
     glNamedBufferSubData(cbuf, 0, static_cast<GLsizeiptr>(size), raw_pointer);
-    return {&cbuf, 0};
+    return {cbuf, 0};
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -34,12 +34,12 @@ public:
     explicit CachedBufferBlock(VAddr cpu_addr, const std::size_t size);
     ~CachedBufferBlock();
 
-    const GLuint* GetHandle() const {
-        return &gl_buffer.handle;
+    GLuint GetHandle() const {
+        return gl_buffer.handle;
     }
 
 private:
-    OGLBuffer gl_buffer{};
+    OGLBuffer gl_buffer;
 };
 
 class OGLBufferCache final : public GenericBufferCache {
@@ -48,7 +48,7 @@ public:
                             const Device& device, std::size_t stream_size);
     ~OGLBufferCache();
 
-    const GLuint* GetEmptyBuffer(std::size_t) override;
+    GLuint GetEmptyBuffer(std::size_t) override;
 
     void Acquire() noexcept {
         cbuf_cursor = 0;
@@ -57,9 +57,9 @@ public:
 protected:
     Buffer CreateBlock(VAddr cpu_addr, std::size_t size) override;
 
-    void WriteBarrier() override;
+    GLuint ToHandle(const Buffer& buffer) override;
 
-    const GLuint* ToHandle(const Buffer& buffer) override;
+    void WriteBarrier() override;
 
     void UploadBlockData(const Buffer& buffer, std::size_t offset, std::size_t size,
                          const u8* data) override;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -188,10 +188,8 @@ void RasterizerOpenGL::SetupVertexBuffer() {
         ASSERT(end > start);
         const u64 size = end - start + 1;
         const auto [vertex_buffer, vertex_buffer_offset] = buffer_cache.UploadMemory(start, size);
-
-        // Bind the vertex array to the buffer at the current offset.
-        vertex_array_pushbuffer.SetVertexBuffer(static_cast<GLuint>(index), vertex_buffer,
-                                                vertex_buffer_offset, vertex_array.stride);
+        glBindVertexBuffer(static_cast<GLuint>(index), vertex_buffer, vertex_buffer_offset,
+                           vertex_array.stride);
     }
 }
 
@@ -222,7 +220,7 @@ GLintptr RasterizerOpenGL::SetupIndexBuffer() {
     const auto& regs = system.GPU().Maxwell3D().regs;
     const std::size_t size = CalculateIndexBufferSize();
     const auto [buffer, offset] = buffer_cache.UploadMemory(regs.index_array.IndexStart(), size);
-    vertex_array_pushbuffer.SetIndexBuffer(buffer);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer);
     return offset;
 }
 
@@ -523,7 +521,6 @@ void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
 
     // Prepare vertex array format.
     SetupVertexFormat();
-    vertex_array_pushbuffer.Setup();
 
     // Upload vertex and index data.
     SetupVertexBuffer();
@@ -533,17 +530,13 @@ void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
         index_buffer_offset = SetupIndexBuffer();
     }
 
-    // Prepare packed bindings.
-    bind_ubo_pushbuffer.Setup();
-    bind_ssbo_pushbuffer.Setup();
-
     // Setup emulation uniform buffer.
     GLShader::MaxwellUniformData ubo;
     ubo.SetFromRegs(gpu);
     const auto [buffer, offset] =
         buffer_cache.UploadHostMemory(&ubo, sizeof(ubo), device.GetUniformBufferAlignment());
-    bind_ubo_pushbuffer.Push(EmulationUniformBlockBinding, buffer, offset,
-                             static_cast<GLsizeiptr>(sizeof(ubo)));
+    glBindBufferRange(GL_UNIFORM_BUFFER, EmulationUniformBlockBinding, buffer, offset,
+                      static_cast<GLsizeiptr>(sizeof(ubo)));
 
     // Setup shaders and their used resources.
     texture_cache.GuardSamplers(true);
@@ -555,11 +548,6 @@ void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
 
     // Signal the buffer cache that we are not going to upload more things.
     buffer_cache.Unmap();
-
-    // Now that we are no longer uploading data, we can safely bind the buffers to OpenGL.
-    vertex_array_pushbuffer.Bind();
-    bind_ubo_pushbuffer.Bind();
-    bind_ssbo_pushbuffer.Bind();
 
     program_manager.BindGraphicsPipeline();
 
@@ -629,16 +617,10 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
         (Maxwell::MaxConstBufferSize + device.GetUniformBufferAlignment());
     buffer_cache.Map(buffer_size);
 
-    bind_ubo_pushbuffer.Setup();
-    bind_ssbo_pushbuffer.Setup();
-
     SetupComputeConstBuffers(kernel);
     SetupComputeGlobalMemory(kernel);
 
     buffer_cache.Unmap();
-
-    bind_ubo_pushbuffer.Bind();
-    bind_ssbo_pushbuffer.Bind();
 
     const auto& launch_desc = system.GPU().KeplerCompute().launch_description;
     glDispatchCompute(launch_desc.grid_dim_x, launch_desc.grid_dim_y, launch_desc.grid_dim_z);
@@ -770,8 +752,8 @@ void RasterizerOpenGL::SetupConstBuffer(u32 binding, const Tegra::Engines::Const
                                         const ConstBufferEntry& entry) {
     if (!buffer.enabled) {
         // Set values to zero to unbind buffers
-        bind_ubo_pushbuffer.Push(binding, buffer_cache.GetEmptyBuffer(sizeof(float)), 0,
-                                 sizeof(float));
+        glBindBufferRange(GL_UNIFORM_BUFFER, binding, buffer_cache.GetEmptyBuffer(sizeof(float)), 0,
+                          sizeof(float));
         return;
     }
 
@@ -782,7 +764,7 @@ void RasterizerOpenGL::SetupConstBuffer(u32 binding, const Tegra::Engines::Const
     const auto alignment = device.GetUniformBufferAlignment();
     const auto [cbuf, offset] = buffer_cache.UploadMemory(buffer.address, size, alignment, false,
                                                           device.HasFastBufferSubData());
-    bind_ubo_pushbuffer.Push(binding, cbuf, offset, size);
+    glBindBufferRange(GL_UNIFORM_BUFFER, binding, cbuf, offset, size);
 }
 
 void RasterizerOpenGL::SetupDrawGlobalMemory(std::size_t stage_index, const Shader& shader) {
@@ -818,7 +800,8 @@ void RasterizerOpenGL::SetupGlobalMemory(u32 binding, const GlobalMemoryEntry& e
     const auto alignment{device.GetShaderStorageBufferAlignment()};
     const auto [ssbo, buffer_offset] =
         buffer_cache.UploadMemory(gpu_addr, size, alignment, entry.IsWritten());
-    bind_ssbo_pushbuffer.Push(binding, ssbo, buffer_offset, static_cast<GLsizeiptr>(size));
+    glBindBufferRange(GL_SHADER_STORAGE_BUFFER, binding, ssbo, buffer_offset,
+                      static_cast<GLsizeiptr>(size));
 }
 
 void RasterizerOpenGL::SetupDrawTextures(std::size_t stage_index, const Shader& shader) {
@@ -1418,7 +1401,7 @@ void RasterizerOpenGL::EndTransformFeedback() {
         const GPUVAddr gpu_addr = binding.Address();
         const std::size_t size = binding.buffer_size;
         const auto [dest_buffer, offset] = buffer_cache.UploadMemory(gpu_addr, size, 4, true);
-        glCopyNamedBufferSubData(handle, *dest_buffer, 0, offset, static_cast<GLsizeiptr>(size));
+        glCopyNamedBufferSubData(handle, dest_buffer, 0, offset, static_cast<GLsizeiptr>(size));
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -228,9 +228,7 @@ private:
     static constexpr std::size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
     OGLBufferCache buffer_cache;
 
-    VertexArrayPushBuffer vertex_array_pushbuffer{state_tracker};
-    BindBuffersRangePushBuffer bind_ubo_pushbuffer{GL_UNIFORM_BUFFER};
-    BindBuffersRangePushBuffer bind_ssbo_pushbuffer{GL_SHADER_STORAGE_BUFFER};
+    GLint vertex_binding = 0;
 
     std::array<OGLBuffer, Tegra::Engines::Maxwell3D::Regs::NumTransformFeedbackBuffers>
         transform_feedback_buffers;

--- a/src/video_core/renderer_opengl/utils.cpp
+++ b/src/video_core/renderer_opengl/utils.cpp
@@ -14,68 +14,6 @@
 
 namespace OpenGL {
 
-struct VertexArrayPushBuffer::Entry {
-    GLuint binding_index{};
-    const GLuint* buffer{};
-    GLintptr offset{};
-    GLsizei stride{};
-};
-
-VertexArrayPushBuffer::VertexArrayPushBuffer(StateTracker& state_tracker)
-    : state_tracker{state_tracker} {}
-
-VertexArrayPushBuffer::~VertexArrayPushBuffer() = default;
-
-void VertexArrayPushBuffer::Setup() {
-    index_buffer = nullptr;
-    vertex_buffers.clear();
-}
-
-void VertexArrayPushBuffer::SetIndexBuffer(const GLuint* buffer) {
-    index_buffer = buffer;
-}
-
-void VertexArrayPushBuffer::SetVertexBuffer(GLuint binding_index, const GLuint* buffer,
-                                            GLintptr offset, GLsizei stride) {
-    vertex_buffers.push_back(Entry{binding_index, buffer, offset, stride});
-}
-
-void VertexArrayPushBuffer::Bind() {
-    if (index_buffer) {
-        state_tracker.BindIndexBuffer(*index_buffer);
-    }
-
-    for (const auto& entry : vertex_buffers) {
-        glBindVertexBuffer(entry.binding_index, *entry.buffer, entry.offset, entry.stride);
-    }
-}
-
-struct BindBuffersRangePushBuffer::Entry {
-    GLuint binding;
-    const GLuint* buffer;
-    GLintptr offset;
-    GLsizeiptr size;
-};
-
-BindBuffersRangePushBuffer::BindBuffersRangePushBuffer(GLenum target) : target{target} {}
-
-BindBuffersRangePushBuffer::~BindBuffersRangePushBuffer() = default;
-
-void BindBuffersRangePushBuffer::Setup() {
-    entries.clear();
-}
-
-void BindBuffersRangePushBuffer::Push(GLuint binding, const GLuint* buffer, GLintptr offset,
-                                      GLsizeiptr size) {
-    entries.push_back(Entry{binding, buffer, offset, size});
-}
-
-void BindBuffersRangePushBuffer::Bind() {
-    for (const Entry& entry : entries) {
-        glBindBufferRange(target, entry.binding, *entry.buffer, entry.offset, entry.size);
-    }
-}
-
 void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string_view extra_info) {
     if (!GLAD_GL_KHR_debug) {
         // We don't need to throw an error as this is just for debugging

--- a/src/video_core/renderer_opengl/utils.h
+++ b/src/video_core/renderer_opengl/utils.h
@@ -11,49 +11,6 @@
 
 namespace OpenGL {
 
-class StateTracker;
-
-class VertexArrayPushBuffer final {
-public:
-    explicit VertexArrayPushBuffer(StateTracker& state_tracker);
-    ~VertexArrayPushBuffer();
-
-    void Setup();
-
-    void SetIndexBuffer(const GLuint* buffer);
-
-    void SetVertexBuffer(GLuint binding_index, const GLuint* buffer, GLintptr offset,
-                         GLsizei stride);
-
-    void Bind();
-
-private:
-    struct Entry;
-
-    StateTracker& state_tracker;
-
-    const GLuint* index_buffer{};
-    std::vector<Entry> vertex_buffers;
-};
-
-class BindBuffersRangePushBuffer final {
-public:
-    explicit BindBuffersRangePushBuffer(GLenum target);
-    ~BindBuffersRangePushBuffer();
-
-    void Setup();
-
-    void Push(GLuint binding, const GLuint* buffer, GLintptr offset, GLsizeiptr size);
-
-    void Bind();
-
-private:
-    struct Entry;
-
-    GLenum target;
-    std::vector<Entry> entries;
-};
-
 void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string_view extra_info = {});
 
 } // namespace OpenGL

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -33,8 +33,8 @@ public:
                                VAddr cpu_addr, std::size_t size);
     ~CachedBufferBlock();
 
-    const vk::Buffer* GetHandle() const {
-        return &*buffer.handle;
+    vk::Buffer GetHandle() const {
+        return *buffer.handle;
     }
 
 private:
@@ -50,14 +50,14 @@ public:
                            VKScheduler& scheduler, VKStagingBufferPool& staging_pool);
     ~VKBufferCache();
 
-    const vk::Buffer* GetEmptyBuffer(std::size_t size) override;
+    vk::Buffer GetEmptyBuffer(std::size_t size) override;
 
 protected:
+    vk::Buffer ToHandle(const Buffer& buffer) override;
+
     void WriteBarrier() override {}
 
     Buffer CreateBlock(VAddr cpu_addr, std::size_t size) override;
-
-    const vk::Buffer* ToHandle(const Buffer& buffer) override;
 
     void UploadBlockData(const Buffer& buffer, std::size_t offset, std::size_t size,
                          const u8* data) override;

--- a/src/video_core/renderer_vulkan/vk_compute_pass.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.cpp
@@ -260,13 +260,13 @@ QuadArrayPass::QuadArrayPass(const VKDevice& device, VKScheduler& scheduler,
 
 QuadArrayPass::~QuadArrayPass() = default;
 
-std::pair<const vk::Buffer&, vk::DeviceSize> QuadArrayPass::Assemble(u32 num_vertices, u32 first) {
+std::pair<vk::Buffer, vk::DeviceSize> QuadArrayPass::Assemble(u32 num_vertices, u32 first) {
     const u32 num_triangle_vertices = num_vertices * 6 / 4;
     const std::size_t staging_size = num_triangle_vertices * sizeof(u32);
     auto& buffer = staging_buffer_pool.GetUnusedBuffer(staging_size, false);
 
     update_descriptor_queue.Acquire();
-    update_descriptor_queue.AddBuffer(&*buffer.handle, 0, staging_size);
+    update_descriptor_queue.AddBuffer(*buffer.handle, 0, staging_size);
     const auto set = CommitDescriptorSet(update_descriptor_queue, scheduler.GetFence());
 
     scheduler.RequestOutsideRenderPassOperationContext();
@@ -308,14 +308,14 @@ Uint8Pass::Uint8Pass(const VKDevice& device, VKScheduler& scheduler,
 
 Uint8Pass::~Uint8Pass() = default;
 
-std::pair<const vk::Buffer*, u64> Uint8Pass::Assemble(u32 num_vertices, vk::Buffer src_buffer,
-                                                      u64 src_offset) {
+std::pair<vk::Buffer, u64> Uint8Pass::Assemble(u32 num_vertices, vk::Buffer src_buffer,
+                                               u64 src_offset) {
     const auto staging_size = static_cast<u32>(num_vertices * sizeof(u16));
     auto& buffer = staging_buffer_pool.GetUnusedBuffer(staging_size, false);
 
     update_descriptor_queue.Acquire();
-    update_descriptor_queue.AddBuffer(&src_buffer, src_offset, num_vertices);
-    update_descriptor_queue.AddBuffer(&*buffer.handle, 0, staging_size);
+    update_descriptor_queue.AddBuffer(src_buffer, src_offset, num_vertices);
+    update_descriptor_queue.AddBuffer(*buffer.handle, 0, staging_size);
     const auto set = CommitDescriptorSet(update_descriptor_queue, scheduler.GetFence());
 
     scheduler.RequestOutsideRenderPassOperationContext();
@@ -333,7 +333,7 @@ std::pair<const vk::Buffer*, u64> Uint8Pass::Assemble(u32 num_vertices, vk::Buff
         cmdbuf.pipelineBarrier(vk::PipelineStageFlagBits::eComputeShader,
                                vk::PipelineStageFlagBits::eVertexInput, {}, {}, {barrier}, {}, dld);
     });
-    return {&*buffer.handle, 0};
+    return {*buffer.handle, 0};
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_compute_pass.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.h
@@ -50,7 +50,7 @@ public:
                            VKUpdateDescriptorQueue& update_descriptor_queue);
     ~QuadArrayPass();
 
-    std::pair<const vk::Buffer&, vk::DeviceSize> Assemble(u32 num_vertices, u32 first);
+    std::pair<vk::Buffer, vk::DeviceSize> Assemble(u32 num_vertices, u32 first);
 
 private:
     VKScheduler& scheduler;
@@ -65,8 +65,7 @@ public:
                        VKUpdateDescriptorQueue& update_descriptor_queue);
     ~Uint8Pass();
 
-    std::pair<const vk::Buffer*, u64> Assemble(u32 num_vertices, vk::Buffer src_buffer,
-                                               u64 src_offset);
+    std::pair<vk::Buffer, u64> Assemble(u32 num_vertices, vk::Buffer src_buffer, u64 src_offset);
 
 private:
     VKScheduler& scheduler;

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.cpp
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.cpp
@@ -35,12 +35,13 @@ void VKUpdateDescriptorQueue::Send(vk::DescriptorUpdateTemplate update_template,
         payload.clear();
     }
 
+    // TODO(Rodrigo): Rework to write the payload directly
     const auto payload_start = payload.data() + payload.size();
     for (const auto& entry : entries) {
         if (const auto image = std::get_if<vk::DescriptorImageInfo>(&entry)) {
             payload.push_back(*image);
-        } else if (const auto buffer = std::get_if<Buffer>(&entry)) {
-            payload.emplace_back(*buffer->buffer, buffer->offset, buffer->size);
+        } else if (const auto buffer = std::get_if<vk::DescriptorBufferInfo>(&entry)) {
+            payload.push_back(*buffer);
         } else if (const auto texel = std::get_if<vk::BufferView>(&entry)) {
             payload.push_back(*texel);
         } else {

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.h
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.h
@@ -22,8 +22,7 @@ public:
 
     DescriptorUpdateEntry(vk::DescriptorImageInfo image) : image{image} {}
 
-    DescriptorUpdateEntry(vk::Buffer buffer, vk::DeviceSize offset, vk::DeviceSize size)
-        : buffer{buffer, offset, size} {}
+    DescriptorUpdateEntry(vk::DescriptorBufferInfo buffer) : buffer{buffer} {}
 
     DescriptorUpdateEntry(vk::BufferView texel_buffer) : texel_buffer{texel_buffer} {}
 
@@ -54,8 +53,8 @@ public:
         entries.emplace_back(vk::DescriptorImageInfo{{}, image_view, {}});
     }
 
-    void AddBuffer(const vk::Buffer* buffer, u64 offset, std::size_t size) {
-        entries.push_back(Buffer{buffer, offset, size});
+    void AddBuffer(vk::Buffer buffer, u64 offset, std::size_t size) {
+        entries.push_back(vk::DescriptorBufferInfo{buffer, offset, size});
     }
 
     void AddTexelBuffer(vk::BufferView texel_buffer) {
@@ -67,14 +66,7 @@ public:
     }
 
 private:
-    struct Buffer {
-        const vk::Buffer* buffer{};
-        u64 offset{};
-        std::size_t size{};
-    };
-    using Variant = std::variant<vk::DescriptorImageInfo, Buffer, vk::BufferView>;
-    // Old gcc versions don't consider this trivially copyable.
-    // static_assert(std::is_trivially_copyable_v<Variant>);
+    using Variant = std::variant<vk::DescriptorImageInfo, vk::DescriptorBufferInfo, vk::BufferView>;
 
     const VKDevice& device;
     VKScheduler& scheduler;


### PR DESCRIPTION
The original idea of returning pointers is that handles can be moved.
The problem is that the implementation didn't take that in mind and made
everything harder to work with. This commit drops pointer to handles and
returns the handles themselves. While it is still true that handles can
be invalidated, this way we get an old handle instead of a dangling
pointer.

This problem can be solved in the future with sparse buffers.