### PR TITLE
gl_shader_cache: Use CompileDepth::FullDecompile on GLSL

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -34,6 +34,8 @@
 namespace OpenGL {
 
 using Tegra::Engines::ShaderType;
+using VideoCommon::Shader::CompileDepth;
+using VideoCommon::Shader::CompilerSettings;
 using VideoCommon::Shader::ProgramCode;
 using VideoCommon::Shader::Registry;
 using VideoCommon::Shader::ShaderIR;
@@ -43,7 +45,7 @@ namespace {
 constexpr u32 STAGE_MAIN_OFFSET = 10;
 constexpr u32 KERNEL_MAIN_OFFSET = 0;
 
-constexpr VideoCommon::Shader::CompilerSettings COMPILER_SETTINGS{};
+constexpr CompilerSettings COMPILER_SETTINGS{CompileDepth::FullDecompile};
 
 /// Gets the address for the specified shader stage program
 GPUVAddr GetShaderAddress(Core::System& system, Maxwell::ShaderProgram program) {


### PR DESCRIPTION
From my testing on a Splatoon 2 shader that takes 3800ms on average to
compile changing to FullDecompile reduces it to 900ms on average.

The shader decoder will automatically fallback to a more naive method if
it can't use full decompile.