### PR TITLE
gl_rasterizer: Implement constant vertex attributes

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -303,6 +303,10 @@ public:
                 return (type == Type::SignedNorm) || (type == Type::UnsignedNorm);
             }
 
+            bool IsConstant() const {
+                return constant;
+            }
+
             bool IsValid() const {
                 return size != Size::Invalid;
             }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -140,8 +140,8 @@ void RasterizerOpenGL::SetupVertexFormat() {
         const auto attrib = gpu.regs.vertex_attrib_format[index];
         const auto gl_index = static_cast<GLuint>(index);
 
-        // Ignore invalid attributes.
-        if (!attrib.IsValid()) {
+        // Disable constant attributes.
+        if (attrib.IsConstant()) {
             glDisableVertexAttribArray(gl_index);
             continue;
         }


### PR DESCRIPTION
Credits go to gdkchan from Ryujinx for finding constant attributes are
used in retail games.