### PR TITLE
file_util: Early-exit in WriteArray and ReadArray if specified length…

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -967,6 +967,34 @@ bool IOFile::Flush() {
     return IsOpen() && 0 == std::fflush(m_file);
 }
 
+std::size_t IOFile::ReadImpl(void* data, std::size_t length, std::size_t data_size) const {
+    if (!IsOpen()) {
+        return std::numeric_limits<std::size_t>::max();
+    }
+
+    if (length == 0) {
+        return 0;
+    }
+
+    DEBUG_ASSERT(data != nullptr);
+
+    return std::fread(data, data_size, length, m_file);
+}
+
+std::size_t IOFile::WriteImpl(const void* data, std::size_t length, std::size_t data_size) {
+    if (!IsOpen()) {
+        return std::numeric_limits<std::size_t>::max();
+    }
+
+    if (length == 0) {
+        return 0;
+    }
+
+    DEBUG_ASSERT(data != nullptr);
+
+    return std::fwrite(data, data_size, length, m_file);
+}
+
 bool IOFile::Resize(u64 size) {
     return IsOpen() && 0 ==
 #ifdef _WIN32

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -222,22 +222,15 @@ public:
         static_assert(std::is_trivially_copyable_v<T>,
                       "Given array does not consist of trivially copyable objects");
 
-        if (!IsOpen()) {
-            return std::numeric_limits<std::size_t>::max();
-        }
-
-        return std::fread(data, sizeof(T), length, m_file);
+        return ReadImpl(data, length, sizeof(T));
     }
 
     template <typename T>
     std::size_t WriteArray(const T* data, std::size_t length) {
         static_assert(std::is_trivially_copyable_v<T>,
                       "Given array does not consist of trivially copyable objects");
-        if (!IsOpen()) {
-            return std::numeric_limits<std::size_t>::max();
-        }
 
-        return std::fwrite(data, sizeof(T), length, m_file);
+        return WriteImpl(data, length, sizeof(T));
     }
 
     template <typename T>
@@ -278,6 +271,9 @@ public:
     }
 
 private:
+    std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size) const;
+    std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size);
+
     std::FILE* m_file = nullptr;
 };
 


### PR DESCRIPTION
…s are zero

It's undefined behavior to pass a null pointer to std::fread and
std::fwrite, even if the length passed in is zero, so we must perform
the precondition checking ourselves.

A common case where this can occur is when passing in the data of an
empty std::vector and size, as an empty vector will typically have a
null internal buffer.

While we're at it, we can move the implementation out of line and add
debug checks against passing in nullptr to std::fread and std::fwrite.