### PR TITLE
CMakeLists: Specify -Wextra on linux builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,11 @@ if (MSVC)
 else()
     add_compile_options(
         -Wall
+        -Werror=implicit-fallthrough
         -Werror=reorder
+        -Wextra
         -Wno-attributes
+        -Wno-unused-parameter
     )
 
     if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)

--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -123,7 +123,7 @@ Symbols GetSymbols(VAddr text_offset, Memory::Memory& memory) {
 std::optional<std::string> GetSymbolName(const Symbols& symbols, VAddr func_address) {
     const auto iter =
         std::find_if(symbols.begin(), symbols.end(), [func_address](const auto& pair) {
-            const auto& [symbol, name] = pair;
+            const auto& symbol = pair.first;
             const auto end_address = symbol.value + symbol.size;
             return func_address >= symbol.value && func_address < end_address;
         });
@@ -146,7 +146,7 @@ std::vector<ARM_Interface::BacktraceEntry> ARM_Interface::GetBacktrace() const {
     auto fp = GetReg(29);
     auto lr = GetReg(30);
     while (true) {
-        out.push_back({"", 0, lr, 0});
+        out.push_back({"", 0, lr, 0, ""});
         if (!fp) {
             break;
         }

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -440,7 +440,8 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
     // Game Updates
     const auto update_tid = GetUpdateTitleID(title_id);
     PatchManager update{update_tid};
-    auto [nacp, discard_icon_file] = update.GetControlMetadata();
+    const auto metadata = update.GetControlMetadata();
+    const auto& nacp = metadata.first;
 
     const auto update_disabled =
         std::find(disabled.cbegin(), disabled.cend(), "Update") != disabled.cend();

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -591,14 +591,18 @@ InstallResult RegisteredCache::InstallEntry(const NSP& nsp, bool overwrite_if_ex
 InstallResult RegisteredCache::InstallEntry(const NCA& nca, TitleType type,
                                             bool overwrite_if_exists, const VfsCopyFunction& copy) {
     CNMTHeader header{
-        nca.GetTitleId(), ///< Title ID
-        0,                ///< Ignore/Default title version
-        type,             ///< Type
-        {},               ///< Padding
-        0x10,             ///< Default table offset
-        1,                ///< 1 Content Entry
-        0,                ///< No Meta Entries
-        {},               ///< Padding
+        nca.GetTitleId(), // Title ID
+        0,                // Ignore/Default title version
+        type,             // Type
+        {},               // Padding
+        0x10,             // Default table offset
+        1,                // 1 Content Entry
+        0,                // No Meta Entries
+        {},               // Padding
+        {},               // Reserved 1
+        0,                // Is committed
+        0,                // Required download system version
+        {},               // Reserved 2
     };
     OptionalHeader opt_header{0, 0};
     ContentRecord c_rec{{}, {}, {}, GetCRTypeFromNCAType(nca.GetType()), {}};
@@ -848,7 +852,8 @@ VirtualFile ManualContentProvider::GetEntryUnparsed(u64 title_id, ContentRecordT
 VirtualFile ManualContentProvider::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     const auto iter =
         std::find_if(entries.begin(), entries.end(), [title_id, type](const auto& entry) {
-            const auto [title_type, content_type, e_title_id] = entry.first;
+            const auto content_type = std::get<1>(entry.first);
+            const auto e_title_id = std::get<2>(entry.first);
             return content_type == type && e_title_id == title_id;
         });
     if (iter == entries.end())

--- a/src/core/file_sys/vfs_libzip.cpp
+++ b/src/core/file_sys/vfs_libzip.cpp
@@ -42,11 +42,11 @@ VirtualDir ExtractZIP(VirtualFile file) {
             continue;
 
         if (name.back() != '/') {
-            std::unique_ptr<zip_file_t, decltype(&zip_fclose)> file{
+            std::unique_ptr<zip_file_t, decltype(&zip_fclose)> file2{
                 zip_fopen_index(zip.get(), i, 0), zip_fclose};
 
             std::vector<u8> buf(stat.size);
-            if (zip_fread(file.get(), buf.data(), buf.size()) != buf.size())
+            if (zip_fread(file2.get(), buf.data(), buf.size()) != s64(buf.size()))
                 return nullptr;
 
             const auto parts = FileUtil::SplitPathComponents(stat.name);

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -25,7 +25,7 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     ASSERT(height > 0);
     // The drawing code needs at least somewhat valid values for both screens
     // so just calculate them both even if the other isn't showing.
-    FramebufferLayout res{width, height};
+    FramebufferLayout res{width, height, false, {}};
 
     const float window_aspect_ratio = static_cast<float>(height) / width;
     const float emulation_aspect_ratio = EmulationAspectRatio(

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -284,17 +284,17 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(Thread& thread) {
 
 std::vector<u8> HLERequestContext::ReadBuffer(int buffer_index) const {
     std::vector<u8> buffer;
-    const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
+    const bool is_buffer_a{BufferDescriptorA().size() > std::size_t(buffer_index) &&
                            BufferDescriptorA()[buffer_index].Size()};
     auto& memory = Core::System::GetInstance().Memory();
 
     if (is_buffer_a) {
-        ASSERT_MSG(BufferDescriptorA().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorA().size() > std::size_t(buffer_index),
                    "BufferDescriptorA invalid buffer_index {}", buffer_index);
         buffer.resize(BufferDescriptorA()[buffer_index].Size());
         memory.ReadBlock(BufferDescriptorA()[buffer_index].Address(), buffer.data(), buffer.size());
     } else {
-        ASSERT_MSG(BufferDescriptorX().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorX().size() > std::size_t(buffer_index),
                    "BufferDescriptorX invalid buffer_index {}", buffer_index);
         buffer.resize(BufferDescriptorX()[buffer_index].Size());
         memory.ReadBlock(BufferDescriptorX()[buffer_index].Address(), buffer.data(), buffer.size());
@@ -310,7 +310,7 @@ std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
         return 0;
     }
 
-    const bool is_buffer_b{BufferDescriptorB().size() > buffer_index &&
+    const bool is_buffer_b{BufferDescriptorB().size() > std::size_t(buffer_index) &&
                            BufferDescriptorB()[buffer_index].Size()};
     const std::size_t buffer_size{GetWriteBufferSize(buffer_index)};
     if (size > buffer_size) {
@@ -321,13 +321,13 @@ std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
 
     auto& memory = Core::System::GetInstance().Memory();
     if (is_buffer_b) {
-        ASSERT_MSG(BufferDescriptorB().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorB().size() > std::size_t(buffer_index),
                    "BufferDescriptorB invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorB()[buffer_index].Size() >= size,
                    "BufferDescriptorB buffer_index {} is not large enough", buffer_index);
         memory.WriteBlock(BufferDescriptorB()[buffer_index].Address(), buffer, size);
     } else {
-        ASSERT_MSG(BufferDescriptorC().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorC().size() > std::size_t(buffer_index),
                    "BufferDescriptorC invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorC()[buffer_index].Size() >= size,
                    "BufferDescriptorC buffer_index {} is not large enough", buffer_index);
@@ -338,16 +338,16 @@ std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
 }
 
 std::size_t HLERequestContext::GetReadBufferSize(int buffer_index) const {
-    const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
+    const bool is_buffer_a{BufferDescriptorA().size() > std::size_t(buffer_index) &&
                            BufferDescriptorA()[buffer_index].Size()};
     if (is_buffer_a) {
-        ASSERT_MSG(BufferDescriptorA().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorA().size() > std::size_t(buffer_index),
                    "BufferDescriptorA invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorA()[buffer_index].Size() > 0,
                    "BufferDescriptorA buffer_index {} is empty", buffer_index);
         return BufferDescriptorA()[buffer_index].Size();
     } else {
-        ASSERT_MSG(BufferDescriptorX().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorX().size() > std::size_t(buffer_index),
                    "BufferDescriptorX invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorX()[buffer_index].Size() > 0,
                    "BufferDescriptorX buffer_index {} is empty", buffer_index);
@@ -356,14 +356,14 @@ std::size_t HLERequestContext::GetReadBufferSize(int buffer_index) const {
 }
 
 std::size_t HLERequestContext::GetWriteBufferSize(int buffer_index) const {
-    const bool is_buffer_b{BufferDescriptorB().size() > buffer_index &&
+    const bool is_buffer_b{BufferDescriptorB().size() > std::size_t(buffer_index) &&
                            BufferDescriptorB()[buffer_index].Size()};
     if (is_buffer_b) {
-        ASSERT_MSG(BufferDescriptorB().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorB().size() > std::size_t(buffer_index),
                    "BufferDescriptorB invalid buffer_index {}", buffer_index);
         return BufferDescriptorB()[buffer_index].Size();
     } else {
-        ASSERT_MSG(BufferDescriptorC().size() > buffer_index,
+        ASSERT_MSG(BufferDescriptorC().size() > std::size_t(buffer_index),
                    "BufferDescriptorC invalid buffer_index {}", buffer_index);
         return BufferDescriptorC()[buffer_index].Size();
     }

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -129,7 +129,7 @@ private:
         LOG_DEBUG(Service_Audio, "called. rendering_time_limit_percent={}",
                   rendering_time_limit_percent);
 
-        ASSERT(rendering_time_limit_percent >= 0 && rendering_time_limit_percent <= 100);
+        ASSERT(rendering_time_limit_percent <= 100);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -451,7 +451,8 @@ FileSys::SaveDataSize FileSystemController::ReadSaveDataSize(FileSys::SaveDataTy
 
         if (res != Loader::ResultStatus::Success) {
             FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID()};
-            auto [nacp_unique, discard] = pm.GetControlMetadata();
+            const auto metadata = pm.GetControlMetadata();
+            const auto& nacp_unique = metadata.first;
 
             if (nacp_unique != nullptr) {
                 new_size = {nacp_unique->GetDefaultNormalSaveSize(),

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -575,6 +575,7 @@ private:
                                 0,
                                 user_id->GetSize(),
                                 {},
+                                {},
                             });
 
                             continue;
@@ -594,6 +595,7 @@ private:
                                 save_id_numeric,
                                 stoull_be(title_id->GetName()),
                                 title_id->GetSize(),
+                                {},
                                 {},
                             });
                         }
@@ -618,6 +620,7 @@ private:
                                 stoull_be(type->GetName()),
                                 stoull_be(title_id->GetName()),
                                 title_id->GetSize(),
+                                {},
                                 {},
                             });
                         }

--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -309,7 +309,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
         offset = GetTZName(name, offset);
         std_len = offset;
     }
-    if (!std_len) {
+    if (std_len == 0) {
         return {};
     }
     if (!GetOffset(name, offset, std_offset)) {
@@ -320,7 +320,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
     int dest_len{};
     int dest_offset{};
     const char* dest_name{name + offset};
-    if (rule.chars.size() < char_count) {
+    if (rule.chars.size() < std::size_t(char_count)) {
         return {};
     }
 
@@ -343,7 +343,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
             return {};
         }
         char_count += dest_len + 1;
-        if (rule.chars.size() < char_count) {
+        if (rule.chars.size() < std::size_t(char_count)) {
             return {};
         }
         if (name[offset] != '\0' && name[offset] != ',' && name[offset] != ';') {
@@ -414,7 +414,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
                 if (is_reversed ||
                     (start_time < end_time &&
                      (end_time - start_time < (year_seconds + (std_offset - dest_offset))))) {
-                    if (rule.ats.size() - 2 < time_count) {
+                    if (rule.ats.size() - 2 < std::size_t(time_count)) {
                         break;
                     }
 
@@ -609,7 +609,7 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
     }
 
     const u64 position{(read_offset - sizeof(TzifHeader))};
-    const std::size_t bytes_read{vfs_file->GetSize() - sizeof(TzifHeader) - position};
+    const s64 bytes_read = s64(vfs_file->GetSize() - sizeof(TzifHeader) - position);
     if (bytes_read < 0) {
         return {};
     }
@@ -621,11 +621,11 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
     std::array<char, time_zone_name_max + 1> temp_name{};
     vfs_file->ReadArray(temp_name.data(), bytes_read, read_offset);
     if (bytes_read > 2 && temp_name[0] == '\n' && temp_name[bytes_read - 1] == '\n' &&
-        time_zone_rule.type_count + 2 <= time_zone_rule.ttis.size()) {
+        std::size_t(time_zone_rule.type_count) + 2 <= time_zone_rule.ttis.size()) {
         temp_name[bytes_read - 1] = '\0';
 
         std::array<char, time_zone_name_max> name{};
-        std::memcpy(name.data(), temp_name.data() + 1, bytes_read - 1);
+        std::memcpy(name.data(), temp_name.data() + 1, std::size_t(bytes_read - 1));
 
         TimeZoneRule temp_rule;
         if (ParsePosixName(name.data(), temp_rule)) {

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -101,8 +101,8 @@ public:
     }
 
     std::u16string ReadInterfaceToken() {
-        u32 unknown = Read<u32_le>();
-        u32 length = Read<u32_le>();
+        [[maybe_unused]] const u32 unknown = Read<u32_le>();
+        const u32 length = Read<u32_le>();
 
         std::u16string token{};
 

--- a/src/core/memory/dmnt_cheat_vm.cpp
+++ b/src/core/memory/dmnt_cheat_vm.cpp
@@ -55,7 +55,7 @@ void DmntCheatVm::LogOpcode(const CheatVmOpcode& opcode) {
             fmt::format("Cond Type: {:X}", static_cast<u32>(begin_cond->cond_type)));
         callbacks->CommandLog(fmt::format("Rel Addr:  {:X}", begin_cond->rel_address));
         callbacks->CommandLog(fmt::format("Value:     {:X}", begin_cond->value.bit64));
-    } else if (auto end_cond = std::get_if<EndConditionalOpcode>(&opcode.opcode)) {
+    } else if (std::holds_alternative<EndConditionalOpcode>(opcode.opcode)) {
         callbacks->CommandLog("Opcode: End Conditional");
     } else if (auto ctrl_loop = std::get_if<ControlLoopOpcode>(&opcode.opcode)) {
         if (ctrl_loop->start_loop) {
@@ -399,6 +399,7 @@ bool DmntCheatVm::DecodeNextOpcode(CheatVmOpcode& out) {
         // 8kkkkkkk
         // Just parse the mask.
         begin_keypress_cond.key_mask = first_dword & 0x0FFFFFFF;
+        opcode.opcode = begin_keypress_cond;
     } break;
     case CheatVmOpcodeType::PerformArithmeticRegister: {
         PerformArithmeticRegisterOpcode perform_math_reg{};
@@ -779,7 +780,7 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             if (!cond_met) {
                 SkipConditionalBlock();
             }
-        } else if (auto end_cond = std::get_if<EndConditionalOpcode>(&cur_opcode.opcode)) {
+        } else if (std::holds_alternative<EndConditionalOpcode>(cur_opcode.opcode)) {
             // Decrement the condition depth.
             // We will assume, graciously, that mismatched conditional block ends are a nop.
             if (condition_depth > 0) {

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -153,9 +153,9 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
         app_loader.ReadTitle(name);
 
         if (name.empty()) {
-            auto [nacp, icon_file] = FileSys::PatchManager(program_id).GetControlMetadata();
-            if (nacp != nullptr) {
-                name = nacp->GetApplicationName();
+            const auto metadata = FileSys::PatchManager(program_id).GetControlMetadata();
+            if (metadata.first != nullptr) {
+                name = metadata.first->GetApplicationName();
             }
         }
 

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -603,6 +603,7 @@ public:
                 if (std::abs(event.jaxis.value / 32767.0) < 0.5) {
                     break;
                 }
+                [[fallthrough]];
             case SDL_JOYBUTTONUP:
             case SDL_JOYHATMOTION:
                 return SDLEventToButtonParamPackage(state, event);

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1507,7 +1507,7 @@ union Instruction {
 
         TextureType GetTextureType() const {
             // The TLDS instruction has a weird encoding for the texture type.
-            if (texture_info >= 0 && texture_info <= 1) {
+            if (texture_info <= 1) {
                 return TextureType::Texture1D;
             }
             if (texture_info == 2 || texture_info == 8 || texture_info == 12 ||

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -835,7 +835,8 @@ private:
 
     void DeclareConstantBuffers() {
         u32 binding = device.GetBaseBindings(stage).uniform_buffer;
-        for (const auto& [index, cbuf] : ir.GetConstantBuffers()) {
+        for (const auto& buffers : ir.GetConstantBuffers()) {
+            const auto index = buffers.first;
             code.AddLine("layout (std140, binding = {}) uniform {} {{", binding++,
                          GetConstBufferBlock(index));
             code.AddLine("    uvec4 {}[{}];", GetConstBuffer(index), MAX_CONSTBUFFER_ELEMENTS);

--- a/src/video_core/shader/decode/image.cpp
+++ b/src/video_core/shader/decode/image.cpp
@@ -352,8 +352,10 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
                         registry.ObtainBoundSampler(static_cast<u32>(instr.image.index.Value()));
                 } else {
                     const Node image_register = GetRegister(instr.gpr39);
-                    const auto [base_image, buffer, offset] = TrackCbuf(
-                        image_register, global_code, static_cast<s64>(global_code.size()));
+                    const auto result = TrackCbuf(image_register, global_code,
+                                                  static_cast<s64>(global_code.size()));
+                    const auto buffer = std::get<1>(result);
+                    const auto offset = std::get<2>(result);
                     descriptor = registry.ObtainBindlessSampler(buffer, offset);
                 }
                 if (!descriptor) {
@@ -497,8 +499,11 @@ Image& ShaderIR::GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType t
 
 Image& ShaderIR::GetBindlessImage(Tegra::Shader::Register reg, Tegra::Shader::ImageType type) {
     const Node image_register = GetRegister(reg);
-    const auto [base_image, buffer, offset] =
+    const auto result =
         TrackCbuf(image_register, global_code, static_cast<s64>(global_code.size()));
+
+    const auto buffer = std::get<1>(result);
+    const auto offset = std::get<2>(result);
 
     const auto it =
         std::find_if(std::begin(used_images), std::end(used_images),

--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -56,8 +56,7 @@ Node ShaderIR::GetConstBuffer(u64 index_, u64 offset_) {
     const auto index = static_cast<u32>(index_);
     const auto offset = static_cast<u32>(offset_);
 
-    const auto [entry, is_new] = used_cbufs.try_emplace(index);
-    entry->second.MarkAsUsed(offset);
+    used_cbufs.try_emplace(index).first->second.MarkAsUsed(offset);
 
     return MakeNode<CbufNode>(index, Immediate(offset));
 }
@@ -66,8 +65,7 @@ Node ShaderIR::GetConstBufferIndirect(u64 index_, u64 offset_, Node node) {
     const auto index = static_cast<u32>(index_);
     const auto offset = static_cast<u32>(offset_);
 
-    const auto [entry, is_new] = used_cbufs.try_emplace(index);
-    entry->second.MarkAsUsedIndirect();
+    used_cbufs.try_emplace(index).first->second.MarkAsUsedIndirect();
 
     Node final_offset = [&] {
         // Attempt to inline constant buffer without a variable offset. This is done to allow
@@ -166,6 +164,7 @@ Node ShaderIR::ConvertIntegerSize(Node value, Register::Size size, bool is_signe
                                 std::move(value), Immediate(16));
         value = SignedOperation(OperationCode::IArithmeticShiftRight, is_signed, NO_PRECISE,
                                 std::move(value), Immediate(16));
+        return value;
     case Register::Size::Word:
         // Default - do nothing
         return value;

--- a/src/video_core/shader/track.cpp
+++ b/src/video_core/shader/track.cpp
@@ -27,8 +27,9 @@ std::pair<Node, s64> FindOperation(const NodeBlock& code, s64 cursor,
 
         if (const auto conditional = std::get_if<ConditionalNode>(&*node)) {
             const auto& conditional_code = conditional->GetCode();
-            auto [found, internal_cursor] = FindOperation(
+            auto result = FindOperation(
                 conditional_code, static_cast<s64>(conditional_code.size() - 1), operation_code);
+            auto& found = result.first;
             if (found) {
                 return {std::move(found), cursor};
             }
@@ -186,8 +187,8 @@ std::tuple<Node, u32, u32> ShaderIR::TrackCbuf(Node tracked, const NodeBlock& co
 std::optional<u32> ShaderIR::TrackImmediate(Node tracked, const NodeBlock& code, s64 cursor) const {
     // Reduce the cursor in one to avoid infinite loops when the instruction sets the same register
     // that it uses as operand
-    const auto [found, found_cursor] =
-        TrackRegister(&std::get<GprNode>(*tracked), code, cursor - 1);
+    const auto result = TrackRegister(&std::get<GprNode>(*tracked), code, cursor - 1);
+    const auto& found = result.first;
     if (!found) {
         return {};
     }

--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -167,7 +167,6 @@ SurfaceParams SurfaceParams::CreateForImage(const FormatLookupTable& lookup_tabl
 
 SurfaceParams SurfaceParams::CreateForDepthBuffer(Core::System& system) {
     const auto& regs = system.GPU().Maxwell3D().regs;
-    regs.zeta_width, regs.zeta_height, regs.zeta.format, regs.zeta.memory_layout.type;
     SurfaceParams params;
     params.is_tiled = regs.zeta.memory_layout.type ==
                       Tegra::Engines::Maxwell3D::Regs::InvMemoryLayout::BlockLinear;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -647,7 +647,8 @@ private:
                     break;
                 }
                 const u32 offset = static_cast<u32>(surface->GetCpuAddr() - cpu_addr);
-                const auto [x, y, z] = params.GetBlockOffsetXYZ(offset);
+                const auto offsets = params.GetBlockOffsetXYZ(offset);
+                const auto z = std::get<2>(offsets);
                 modified |= surface->IsModified();
                 const CopyParams copy_params(0, 0, 0, 0, 0, z, 0, 0, params.width, params.height,
                                              1);

--- a/src/yuzu/debugger/profiler.cpp
+++ b/src/yuzu/debugger/profiler.cpp
@@ -51,7 +51,8 @@ MicroProfileDialog::MicroProfileDialog(QWidget* parent) : QWidget(parent, Qt::Di
     setWindowTitle(tr("MicroProfile"));
     resize(1000, 600);
     // Remove the "?" button from the titlebar and enable the maximize button
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint | Qt::WindowMaximizeButtonHint);
+    setWindowFlags((windowFlags() & ~Qt::WindowContextHelpButtonHint) |
+                   Qt::WindowMaximizeButtonHint);
 
 #if MICROPROFILE_ENABLED
 

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -91,7 +91,8 @@ std::pair<std::vector<u8>, std::string> GetGameListCachedObject(
             return generator();
         }
 
-        if (file1.write(reinterpret_cast<const char*>(icon.data()), icon.size()) != icon.size()) {
+        if (file1.write(reinterpret_cast<const char*>(icon.data()), icon.size()) !=
+            s64(icon.size())) {
             LOG_ERROR(Frontend, "Failed to write data to cache file.");
             return generator();
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1019,9 +1019,9 @@ void GMainWindow::BootGame(const QString& filename) {
     std::string title_name;
     const auto res = Core::System::GetInstance().GetGameName(title_name);
     if (res != Loader::ResultStatus::Success) {
-        const auto [nacp, icon_file] = FileSys::PatchManager(title_id).GetControlMetadata();
-        if (nacp != nullptr)
-            title_name = nacp->GetApplicationName();
+        const auto metadata = FileSys::PatchManager(title_id).GetControlMetadata();
+        if (metadata.first != nullptr)
+            title_name = metadata.first->GetApplicationName();
 
         if (title_name.empty())
             title_name = FileUtil::GetFilename(filename.toStdString());
@@ -1628,7 +1628,7 @@ void GMainWindow::OnMenuInstallToNAND() {
         }
 
         FileSys::InstallResult res;
-        if (index >= static_cast<size_t>(FileSys::TitleType::Application)) {
+        if (index >= static_cast<s32>(FileSys::TitleType::Application)) {
             res = Core::System::GetInstance()
                       .GetFileSystemController()
                       .GetUserNANDContents()


### PR DESCRIPTION
Allows reporting more cases where logic errors may exist, such as
implicit fallthrough cases, etc.

We currently ignore unused parameters, since we currently have many
cases where this is intentional (virtual interfaces).

While we're at it, we can also tidy up any existing code that causes
warnings. This also uncovered a few bugs as well.