### PR TITLE
gl_query_cache: Resolve use-after-move in CachedQuery move assignment…

### DIFF
--- a/src/video_core/renderer_opengl/gl_query_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_query_cache.cpp
@@ -94,9 +94,9 @@ CachedQuery::CachedQuery(CachedQuery&& rhs) noexcept
     : VideoCommon::CachedQueryBase<HostCounter>(std::move(rhs)), cache{rhs.cache}, type{rhs.type} {}
 
 CachedQuery& CachedQuery::operator=(CachedQuery&& rhs) noexcept {
-    VideoCommon::CachedQueryBase<HostCounter>::operator=(std::move(rhs));
     cache = rhs.cache;
     type = rhs.type;
+    CachedQueryBase<HostCounter>::operator=(std::move(rhs));
     return *this;
 }
 


### PR DESCRIPTION
… operator

Avoids potential invalid junk data from being read.