### PR TITLE
hle_ipc: Remove std::size_t casts where applicable

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -282,19 +282,19 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(Thread& thread) {
     return RESULT_SUCCESS;
 }
 
-std::vector<u8> HLERequestContext::ReadBuffer(int buffer_index) const {
+std::vector<u8> HLERequestContext::ReadBuffer(std::size_t buffer_index) const {
     std::vector<u8> buffer;
-    const bool is_buffer_a{BufferDescriptorA().size() > std::size_t(buffer_index) &&
+    const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
                            BufferDescriptorA()[buffer_index].Size()};
     auto& memory = Core::System::GetInstance().Memory();
 
     if (is_buffer_a) {
-        ASSERT_MSG(BufferDescriptorA().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorA().size() > buffer_index,
                    "BufferDescriptorA invalid buffer_index {}", buffer_index);
         buffer.resize(BufferDescriptorA()[buffer_index].Size());
         memory.ReadBlock(BufferDescriptorA()[buffer_index].Address(), buffer.data(), buffer.size());
     } else {
-        ASSERT_MSG(BufferDescriptorX().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorX().size() > buffer_index,
                    "BufferDescriptorX invalid buffer_index {}", buffer_index);
         buffer.resize(BufferDescriptorX()[buffer_index].Size());
         memory.ReadBlock(BufferDescriptorX()[buffer_index].Address(), buffer.data(), buffer.size());
@@ -304,13 +304,13 @@ std::vector<u8> HLERequestContext::ReadBuffer(int buffer_index) const {
 }
 
 std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
-                                           int buffer_index) const {
+                                           std::size_t buffer_index) const {
     if (size == 0) {
         LOG_WARNING(Core, "skip empty buffer write");
         return 0;
     }
 
-    const bool is_buffer_b{BufferDescriptorB().size() > std::size_t(buffer_index) &&
+    const bool is_buffer_b{BufferDescriptorB().size() > buffer_index &&
                            BufferDescriptorB()[buffer_index].Size()};
     const std::size_t buffer_size{GetWriteBufferSize(buffer_index)};
     if (size > buffer_size) {
@@ -321,13 +321,13 @@ std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
 
     auto& memory = Core::System::GetInstance().Memory();
     if (is_buffer_b) {
-        ASSERT_MSG(BufferDescriptorB().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorB().size() > buffer_index,
                    "BufferDescriptorB invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorB()[buffer_index].Size() >= size,
                    "BufferDescriptorB buffer_index {} is not large enough", buffer_index);
         memory.WriteBlock(BufferDescriptorB()[buffer_index].Address(), buffer, size);
     } else {
-        ASSERT_MSG(BufferDescriptorC().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorC().size() > buffer_index,
                    "BufferDescriptorC invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorC()[buffer_index].Size() >= size,
                    "BufferDescriptorC buffer_index {} is not large enough", buffer_index);
@@ -337,17 +337,17 @@ std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
     return size;
 }
 
-std::size_t HLERequestContext::GetReadBufferSize(int buffer_index) const {
-    const bool is_buffer_a{BufferDescriptorA().size() > std::size_t(buffer_index) &&
+std::size_t HLERequestContext::GetReadBufferSize(std::size_t buffer_index) const {
+    const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
                            BufferDescriptorA()[buffer_index].Size()};
     if (is_buffer_a) {
-        ASSERT_MSG(BufferDescriptorA().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorA().size() > buffer_index,
                    "BufferDescriptorA invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorA()[buffer_index].Size() > 0,
                    "BufferDescriptorA buffer_index {} is empty", buffer_index);
         return BufferDescriptorA()[buffer_index].Size();
     } else {
-        ASSERT_MSG(BufferDescriptorX().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorX().size() > buffer_index,
                    "BufferDescriptorX invalid buffer_index {}", buffer_index);
         ASSERT_MSG(BufferDescriptorX()[buffer_index].Size() > 0,
                    "BufferDescriptorX buffer_index {} is empty", buffer_index);
@@ -355,15 +355,15 @@ std::size_t HLERequestContext::GetReadBufferSize(int buffer_index) const {
     }
 }
 
-std::size_t HLERequestContext::GetWriteBufferSize(int buffer_index) const {
-    const bool is_buffer_b{BufferDescriptorB().size() > std::size_t(buffer_index) &&
+std::size_t HLERequestContext::GetWriteBufferSize(std::size_t buffer_index) const {
+    const bool is_buffer_b{BufferDescriptorB().size() > buffer_index &&
                            BufferDescriptorB()[buffer_index].Size()};
     if (is_buffer_b) {
-        ASSERT_MSG(BufferDescriptorB().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorB().size() > buffer_index,
                    "BufferDescriptorB invalid buffer_index {}", buffer_index);
         return BufferDescriptorB()[buffer_index].Size();
     } else {
-        ASSERT_MSG(BufferDescriptorC().size() > std::size_t(buffer_index),
+        ASSERT_MSG(BufferDescriptorC().size() > buffer_index,
                    "BufferDescriptorC invalid buffer_index {}", buffer_index);
         return BufferDescriptorC()[buffer_index].Size();
     }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -179,10 +179,11 @@ public:
     }
 
     /// Helper function to read a buffer using the appropriate buffer descriptor
-    std::vector<u8> ReadBuffer(int buffer_index = 0) const;
+    std::vector<u8> ReadBuffer(std::size_t buffer_index = 0) const;
 
     /// Helper function to write a buffer using the appropriate buffer descriptor
-    std::size_t WriteBuffer(const void* buffer, std::size_t size, int buffer_index = 0) const;
+    std::size_t WriteBuffer(const void* buffer, std::size_t size,
+                            std::size_t buffer_index = 0) const;
 
     /* Helper function to write a buffer using the appropriate buffer descriptor
      *
@@ -194,7 +195,8 @@ public:
      */
     template <typename ContiguousContainer,
               typename = std::enable_if_t<!std::is_pointer_v<ContiguousContainer>>>
-    std::size_t WriteBuffer(const ContiguousContainer& container, int buffer_index = 0) const {
+    std::size_t WriteBuffer(const ContiguousContainer& container,
+                            std::size_t buffer_index = 0) const {
         using ContiguousType = typename ContiguousContainer::value_type;
 
         static_assert(std::is_trivially_copyable_v<ContiguousType>,
@@ -205,10 +207,10 @@ public:
     }
 
     /// Helper function to get the size of the input buffer
-    std::size_t GetReadBufferSize(int buffer_index = 0) const;
+    std::size_t GetReadBufferSize(std::size_t buffer_index = 0) const;
 
     /// Helper function to get the size of the output buffer
-    std::size_t GetWriteBufferSize(int buffer_index = 0) const;
+    std::size_t GetWriteBufferSize(std::size_t buffer_index = 0) const;
 
     template <typename T>
     std::shared_ptr<T> GetCopyObject(std::size_t index) {


### PR DESCRIPTION
These were added in the change that enabled -Wextra on linux builds so
as not to introduce interface changes in the same change as a
build-system flag addition.

Now that the flags are enabled, we can freely change the interface to
make these unnecessary.