### PR TITLE
gdbstub: Fix some gdbstub jankiness

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -1389,10 +1389,9 @@ void SendTrap(Kernel::Thread* thread, int trap) {
         return;
     }
 
-    if (!halt_loop || current_thread == thread) {
-        current_thread = thread;
-        SendSignal(thread, trap);
-    }
+    current_thread = thread;
+    SendSignal(thread, trap);
+
     halt_loop = true;
     send_trap = false;
 }


### PR DESCRIPTION
1. Ensure that register information available to gdbstub is most up-to-date.
2. There's no reason to check for current_thread == thread when emitting a trap.
   Doing this results in random hangs whenever a step happens upon a thread switch.