### PR TITLE
yuzu/main: Add better popup texts and remove duplicated actions

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -196,8 +196,6 @@ private slots:
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
     void OnMenuInstallToNAND();
-    /// Called whenever a user select the "File->Select -- Directory" where -- is NAND or SD Card
-    void OnMenuSelectEmulatedDirectory(EmulatedDirectoryTarget target);
     void OnMenuRecentFile();
     void OnConfigure();
     void OnLoadAmiibo();

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -64,8 +64,6 @@
     <addaction name="separator"/>
     <addaction name="menu_recent_files"/>
     <addaction name="separator"/>
-    <addaction name="action_Select_NAND_Directory"/>
-    <addaction name="action_Select_SDMC_Directory"/>
     <addaction name="separator"/>
     <addaction name="action_Load_Amiibo"/>
     <addaction name="separator"/>
@@ -215,22 +213,6 @@
    </property>
    <property name="text">
     <string>Show Status Bar</string>
-   </property>
-  </action>
-  <action name="action_Select_NAND_Directory">
-   <property name="text">
-    <string>Select NAND Directory...</string>
-   </property>
-   <property name="toolTip">
-    <string>Selects a folder to use as the root of the emulated NAND</string>
-   </property>
-  </action>
-  <action name="action_Select_SDMC_Directory">
-   <property name="text">
-    <string>Select SD Card Directory...</string>
-   </property>
-   <property name="toolTip">
-    <string>Selects a folder to use as the root of the emulated SD card</string>
    </property>
   </action>
   <action name="action_Fullscreen">


### PR DESCRIPTION
Makes popup texts more compact and clear and also links our quickstart guide now.
Also removes OnMenuSelectEmulatedDirectory from the File dropdown, as the action already exists in the Filesystem tab and provides better visual feedback there.