### PR TITLE
cmake: Silence -Werror=implicit-fallthrough in SDL2 headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if (ENABLE_SDL2)
             set(SDL2_LIBRARIES "SDL2::SDL2")
         endif()
 
-        include_directories(${SDL2_INCLUDE_DIRS})
+        include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
         add_library(SDL2 INTERFACE)
         target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
     endif()


### PR DESCRIPTION
In file included from src/input_common/sdl/sdl_impl.cpp:16:
In file included from /usr/local/include/SDL2/SDL.h:32:
In file included from /usr/local/include/SDL2/SDL_main.h:25:
/usr/local/include/SDL2/SDL_stdinc.h:445:9: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
        case 3:         *_p++ = _val;   /* fallthrough */
        ^
/usr/local/include/SDL2/SDL_stdinc.h:445:9: note: insert '[[fallthrough]];' to silence this warning
        case 3:         *_p++ = _val;   /* fallthrough */
        ^
        [[fallthrough]];
/usr/local/include/SDL2/SDL_stdinc.h:445:9: note: insert 'break;' to avoid fall-through
        case 3:         *_p++ = _val;   /* fallthrough */
        ^
        break;
/usr/local/include/SDL2/SDL_stdinc.h:446:9: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
        case 2:         *_p++ = _val;   /* fallthrough */
        ^
/usr/local/include/SDL2/SDL_stdinc.h:446:9: note: insert '[[fallthrough]];' to silence this warning
        case 2:         *_p++ = _val;   /* fallthrough */
        ^
        [[fallthrough]];
/usr/local/include/SDL2/SDL_stdinc.h:446:9: note: insert 'break;' to avoid fall-through
        case 2:         *_p++ = _val;   /* fallthrough */
        ^
        break;
/usr/local/include/SDL2/SDL_stdinc.h:447:9: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
        case 1:         *_p++ = _val;   /* fallthrough */
        ^
/usr/local/include/SDL2/SDL_stdinc.h:447:9: note: insert '[[fallthrough]];' to silence this warning
        case 1:         *_p++ = _val;   /* fallthrough */
        ^
        [[fallthrough]];
/usr/local/include/SDL2/SDL_stdinc.h:447:9: note: insert 'break;' to avoid fall-through
        case 1:         *_p++ = _val;   /* fallthrough */
        ^
        break;
3 errors generated.