### PR TITLE
page_table: Remove unused captures

### DIFF
--- a/src/core/hle/kernel/memory/page_table.cpp
+++ b/src/core/hle/kernel/memory/page_table.cpp
@@ -854,7 +854,7 @@ ResultCode PageTable::LockForDeviceAddressSpace(VAddr addr, std::size_t size) {
     }
 
     block_manager->UpdateLock(addr, size / PageSize,
-                              [perm](MemoryBlockManager::iterator block, MemoryPermission perm) {
+                              [](MemoryBlockManager::iterator block, MemoryPermission perm) {
                                   block->ShareToDevice(perm);
                               },
                               perm);
@@ -876,7 +876,7 @@ ResultCode PageTable::UnlockForDeviceAddressSpace(VAddr addr, std::size_t size) 
     }
 
     block_manager->UpdateLock(addr, size / PageSize,
-                              [perm](MemoryBlockManager::iterator block, MemoryPermission perm) {
+                              [](MemoryBlockManager::iterator block, MemoryPermission perm) {
                                   block->UnshareToDevice(perm);
                               },
                               perm);


### PR DESCRIPTION
Any time the lambda function is called, the permission being used in the
capture would be passed in as an argument to the lambda, so the capture
is unnecessary.