### PR TITLE
decode/arithmetic_half: Fix HADD2 and HMUL2 absolute and negation bits

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -817,11 +817,9 @@ union Instruction {
         BitField<32, 1, u64> saturate;
         BitField<49, 2, HalfMerge> merge;
 
-        BitField<43, 1, u64> negate_a;
         BitField<44, 1, u64> abs_a;
         BitField<47, 2, HalfType> type_a;
 
-        BitField<31, 1, u64> negate_b;
         BitField<30, 1, u64> abs_b;
         BitField<28, 2, HalfType> type_b;
 


### PR DESCRIPTION
The encoding for negation and absolute value was wrong.
Extracting is now done manually. Similar instructions having different
encodings is the rule, not the exception. To keep sanity and readability
I preferred to extract the desired bit manually.

This is implemented against nxas:
https://github.com/ReinUsesLisp/nxas/blob/8dbc38995711cc12206aa370145a3a02665fd989/table.h#L68

That is itself tested against nvdisasm (Nvidia's official disassembler).