### PR TITLE
vk_rasterizer: Skip index buffer setup when vertices are zero

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -896,6 +896,9 @@ void RasterizerVulkan::SetupVertexArrays(FixedPipelineState::VertexInput& vertex
 
 void RasterizerVulkan::SetupIndexBuffer(BufferBindings& buffer_bindings, DrawParameters& params,
                                         bool is_indexed) {
+    if (params.num_vertices == 0) {
+        return;
+    }
     const auto& regs = system.GPU().Maxwell3D().regs;
     switch (regs.draw.topology) {
     case Maxwell::PrimitiveTopology::Quads: {


### PR DESCRIPTION
Xenoblade 2 invokes a draw call with zero vertices.
This is likely due to indirect drawing (glDrawArraysIndirect).

This causes a crash in the staging buffer pool when trying to create a
buffer with a size of zero. To workaround this, skip index buffer setup
entirely when the number of indices is zero.