### PR TITLE
acc: Fix InitializeApplicationInfo

### DIFF
--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -35,7 +35,7 @@ public:
         void GetProfileEditor(Kernel::HLERequestContext& ctx);
 
     private:
-        ResultCode InitializeApplicationInfoBase(u64 process_id);
+        ResultCode InitializeApplicationInfoBase();
 
         enum class ApplicationType : u32_le {
             GameCard = 0,


### PR DESCRIPTION
We're not suppose to pop a u64, should just read the sent pid and check that