### PR TITLE
caps: Add missing service names to caps:su

### DIFF
--- a/src/core/hle/service/caps/caps_su.cpp
+++ b/src/core/hle/service/caps/caps_su.cpp
@@ -9,8 +9,11 @@ namespace Service::Capture {
 CAPS_SU::CAPS_SU() : ServiceFramework("caps:su") {
     // clang-format off
     static const FunctionInfo functions[] = {
+        {32, nullptr, "SetShimLibraryVersion"},
         {201, nullptr, "SaveScreenShot"},
         {203, nullptr, "SaveScreenShotEx0"},
+        {205, nullptr, "SaveScreenShotEx1"},
+        {210, nullptr, "SaveScreenShotEx2"},
     };
     // clang-format on
 


### PR DESCRIPTION
SetShimLibraryVersion, SaveScreenShotEx1 & SaveScreenShotEx2 were missing