### PR TITLE
acc: Add more error codes

### DIFF
--- a/src/core/hle/service/acc/errors.h
+++ b/src/core/hle/service/acc/errors.h
@@ -8,7 +8,14 @@
 
 namespace Service::Account {
 
+constexpr ResultCode ERR_ACCOUNTINFO_NULL_ARGUMENT{ErrorModule::Account, 20};
 constexpr ResultCode ERR_ACCOUNTINFO_BAD_APPLICATION{ErrorModule::Account, 22};
+constexpr ResultCode ERR_ACCOUNTINFO_NULL_INPUT_BUFFER_SIZE{ErrorModule::Account, 30};
+constexpr ResultCode ERR_ACCOUNTINFO_INVALID_INPUT_BUFFER_SIZE{ErrorModule::Account, 31};
+constexpr ResultCode ERR_ACCOUNTINFO_INVALID_INPUT_BUFFER{ErrorModule::Account, 32};
 constexpr ResultCode ERR_ACCOUNTINFO_ALREADY_INITIALIZED{ErrorModule::Account, 41};
+constexpr ResultCode ERR_ACCOUNTINFO_INTERNET_REQUEST_ACCEPT_FALSE{ErrorModule::Account, 59};
+constexpr ResultCode ERR_ACCOUNTINFO_USER_NOT_FOUND{ErrorModule::Account, 100};
+constexpr ResultCode ERR_ACCOUNTINFO_NULL_OBJECT{ErrorModule::Account, 302};
 
 } // namespace Service::Account


### PR DESCRIPTION
ERR_ACCOUNTINFO_NULL_ARGUMENT, ERR_ACCOUNTINFO_NULL_INPUT_BUFFER_SIZE, ERR_ACCOUNTINFO_INVALID_INPUT_BUFFER_SIZE, ERR_ACCOUNTINFO_INVALID_INPUT_BUFFER, ERR_ACCOUNTINFO_USER_NOT_FOUND and ERR_ACCOUNTINFO_NULL_OBJECT were taken from Ryujinx (https://github.com/Ryujinx/Ryujinx/), this file in particular: https://github.com/Ryujinx/Ryujinx/blob/master/Ryujinx.HLE/HOS/Services/Account/ResultCode.cs

ERR_ACCOUNTINFO_INTERNET_REQUEST_ACCEPT_FALSE (I can't find a better name) was taken from Switchbrew (https://switchbrew.org/wiki/Error_codes)
Regarding this error, SwitchBrew notes: "IsAnyInternetRequestAccepted with the output from GetClientId returned false."