### PR TITLE
fixed_pipeline_state: explicitly use template keyword after 

### DIFF
--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -88,7 +88,8 @@ public:
             }
             PopAsyncFlushes();
             if (current_fence->IsSemaphore()) {
-                memory_manager.Write<u32>(current_fence->GetAddress(), current_fence->GetPayload());
+                memory_manager.template Write<u32>(current_fence->GetAddress(),
+                                                   current_fence->GetPayload());
             } else {
                 gpu.IncrementSyncPoint(current_fence->GetPayload());
             }
@@ -134,7 +135,8 @@ private:
             }
             PopAsyncFlushes();
             if (current_fence->IsSemaphore()) {
-                memory_manager.Write<u32>(current_fence->GetAddress(), current_fence->GetPayload());
+                memory_manager.template Write<u32>(current_fence->GetAddress(),
+                                                   current_fence->GetPayload());
             } else {
                 gpu.IncrementSyncPoint(current_fence->GetPayload());
             }


### PR DESCRIPTION
In file included from src/video_core/renderer_opengl/renderer_opengl.cpp:25:
In file included from src/./video_core/renderer_opengl/gl_rasterizer.h:26:
In file included from src/./video_core/renderer_opengl/gl_fence_manager.h:11:
src/./video_core/fence_manager.h:91:32: error: use 'template' keyword
      to treat 'Write' as a dependent template name
                memory_manager.Write<u32>(current_fence->GetAddress(), current_fence->GetPayload());
                               ^
                               template
src/./video_core/fence_manager.h:137:32: error: use 'template'
      keyword to treat 'Write' as a dependent template name
                memory_manager.Write<u32>(current_fence->GetAddress(), current_fence->GetPayload());
                               ^
                               template