### PR TITLE
readable_event: Remove unnecessary semicolon in Signal()

### DIFF
--- a/src/core/hle/kernel/readable_event.cpp
+++ b/src/core/hle/kernel/readable_event.cpp
@@ -24,10 +24,12 @@ void ReadableEvent::Acquire(Thread* thread) {
 }
 
 void ReadableEvent::Signal() {
-    if (!is_signaled) {
-        is_signaled = true;
-        SynchronizationObject::Signal();
-    };
+    if (is_signaled) {
+        return;
+    }
+
+    is_signaled = true;
+    SynchronizationObject::Signal();
 }
 
 void ReadableEvent::Clear() {


### PR DESCRIPTION
Resolves a -Wextra-semi warning.

While we're at it, we can invert the branch to form a guard clause,
unindenting all of the contained code.