### PR TITLE
vk_graphics_pipeline: Implement rasterizer_enable on Vulkan

### DIFF
--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -92,6 +92,7 @@ void FixedPipelineState::Rasterizer::Fill(const Maxwell& regs) noexcept {
     tessellation_clockwise.Assign(regs.tess_mode.cw.Value());
     logic_op_enable.Assign(regs.logic_op.enable != 0 ? 1 : 0);
     logic_op.Assign(PackLogicOp(regs.logic_op.operation));
+    rasterize_enable.Assign(regs.rasterize_enable != 0 ? 1 : 0);
     std::memcpy(&point_size, &regs.point_size, sizeof(point_size)); // TODO: C++20 std::bit_cast
 }
 

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -164,6 +164,7 @@ struct FixedPipelineState {
             BitField<23, 1, u32> tessellation_clockwise;
             BitField<24, 1, u32> logic_op_enable;
             BitField<25, 4, u32> logic_op;
+            BitField<29, 1, u32> rasterize_enable;
         };
 
         // TODO(Rodrigo): Move this to push constants

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -250,7 +250,7 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpa
     rasterization_ci.pNext = nullptr;
     rasterization_ci.flags = 0;
     rasterization_ci.depthClampEnable = rs.depth_clamp_disabled == 0 ? VK_TRUE : VK_FALSE;
-    rasterization_ci.rasterizerDiscardEnable = VK_FALSE;
+    rasterization_ci.rasterizerDiscardEnable = rs.rasterize_enable == 0 ? VK_TRUE : VK_FALSE;
     rasterization_ci.polygonMode = VK_POLYGON_MODE_FILL;
     rasterization_ci.cullMode =
         rs.cull_enable ? MaxwellToVK::CullFace(rs.CullFace()) : VK_CULL_MODE_NONE;


### PR DESCRIPTION
We can simply enable rasterizer discard matching the current pipeline
key.