### PR TITLE
kernel/memory: Amend potential encoding warnings

### DIFF
--- a/src/core/hle/kernel/memory/address_space_info.cpp
+++ b/src/core/hle/kernel/memory/address_space_info.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphère, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphère-NX.
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #include <array>
 

--- a/src/core/hle/kernel/memory/address_space_info.h
+++ b/src/core/hle/kernel/memory/address_space_info.h
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphère, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphère-NX.
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #pragma once
 

--- a/src/core/hle/kernel/memory/memory_block.h
+++ b/src/core/hle/kernel/memory/memory_block.h
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphère, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphère-NX.
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #pragma once
 

--- a/src/core/hle/kernel/memory/page_heap.cpp
+++ b/src/core/hle/kernel/memory/page_heap.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphère, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphère-NX.
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #include "core/core.h"
 #include "core/hle/kernel/memory/page_heap.h"

--- a/src/core/hle/kernel/memory/page_heap.h
+++ b/src/core/hle/kernel/memory/page_heap.h
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphère, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphère-NX.
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #pragma once
 

--- a/src/core/hle/kernel/memory/slab_heap.h
+++ b/src/core/hle/kernel/memory/slab_heap.h
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphère, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphère-NX.
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #pragma once
 


### PR DESCRIPTION
While Ã¨is generally representable in some language encodings, in some
it isn't and will result in compilation warnings occurring. To remain
friendly with other language's codepages on Windows, we normalize it to
an ASCII e.