### PR TITLE
hle_ipc: Eliminate core memory globals

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -19,6 +19,10 @@
 
 union ResultCode;
 
+namespace Core::Memory {
+class Memory;
+}
+
 namespace Service {
 class ServiceFrameworkBase;
 }
@@ -28,6 +32,7 @@ namespace Kernel {
 class Domain;
 class HandleTable;
 class HLERequestContext;
+class KernelCore;
 class Process;
 class ServerSession;
 class Thread;
@@ -98,7 +103,8 @@ protected:
  */
 class HLERequestContext {
 public:
-    explicit HLERequestContext(std::shared_ptr<ServerSession> session,
+    explicit HLERequestContext(KernelCore& kernel, Core::Memory::Memory& memory,
+                               std::shared_ptr<ServerSession> session,
                                std::shared_ptr<Thread> thread);
     ~HLERequestContext();
 
@@ -305,6 +311,9 @@ private:
 
     std::vector<std::shared_ptr<SessionRequestHandler>> domain_request_handlers;
     bool is_thread_waiting{};
+
+    KernelCore& kernel;
+    Core::Memory::Memory& memory;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -137,8 +137,8 @@ ResultCode ServerSession::HandleDomainSyncRequest(Kernel::HLERequestContext& con
 ResultCode ServerSession::QueueSyncRequest(std::shared_ptr<Thread> thread,
                                            Core::Memory::Memory& memory) {
     u32* cmd_buf{reinterpret_cast<u32*>(memory.GetPointer(thread->GetTLSAddress()))};
-    std::shared_ptr<Kernel::HLERequestContext> context{
-        std::make_shared<Kernel::HLERequestContext>(SharedFrom(this), std::move(thread))};
+    auto context =
+        std::make_shared<HLERequestContext>(kernel, memory, SharedFrom(this), std::move(thread));
 
     context->PopulateFromIncomingCommandBuffer(kernel.CurrentProcess()->GetHandleTable(), cmd_buf);
     request_queue.Push(std::move(context));


### PR DESCRIPTION
We can just pass the required instances into the constructor of the
request, eliminating all usages of the global system accessor.