### PR TITLE
vk_rasterizer: Match OpenGL's FlushAndInvalidate behavior

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -569,7 +569,9 @@ void RasterizerVulkan::ReleaseFences() {
 }
 
 void RasterizerVulkan::FlushAndInvalidateRegion(VAddr addr, u64 size) {
-    FlushRegion(addr, size);
+    if (Settings::IsGPULevelExtreme()) {
+        FlushRegion(addr, size);
+    }
     InvalidateRegion(addr, size);
 }
 


### PR DESCRIPTION
Match OpenGL's behavior. This can fix or simplify bisecting issues on
Vulkan.