### PR TITLE
Log anisotropic filtering and gpu accuracy as readable strings

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -92,11 +92,12 @@ void LogSettings() {
     LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);
     LogSetting("Renderer_FrameLimit", Settings::values.frame_limit);
     LogSetting("Renderer_UseDiskShaderCache", Settings::values.use_disk_shader_cache);
-    LogSetting("Renderer_GPUAccuracyLevel", Settings::values.gpu_accuracy);
+    LogSetting("Renderer_GPUAccuracyLevel", GPUAccuracyLevelToChar(Settings::values.gpu_accuracy));
     LogSetting("Renderer_UseAsynchronousGpuEmulation",
                Settings::values.use_asynchronous_gpu_emulation);
     LogSetting("Renderer_UseVsync", Settings::values.use_vsync);
-    LogSetting("Renderer_AnisotropicFilteringLevel", Settings::values.max_anisotropy);
+    LogSetting("Renderer_AnisotropicFilteringLevel",
+               AnisotropicFilteringLevelToChar(Settings::values.max_anisotropy));
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);
@@ -108,6 +109,33 @@ void LogSettings() {
     LogSetting("Debugging_ProgramArgs", Settings::values.program_args);
     LogSetting("Services_BCATBackend", Settings::values.bcat_backend);
     LogSetting("Services_BCATBoxcatLocal", Settings::values.bcat_boxcat_local);
+}
+
+const char* GPUAccuracyLevelToChar(GPUAccuracy gpu_accuracy) {
+    switch (gpu_accuracy) {
+    case GPUAccuracy::Normal:
+        return "Normal";
+    case GPUAccuracy::High:
+        return "High";
+    case GPUAccuracy::Extreme:
+        return "Extreme";
+    }
+    return "Unknown";
+}
+
+const char* AnisotropicFilteringLevelToChar(Anisotropy anisotropy) {
+    switch (anisotropy) {
+    case Anisotropy::Default:
+        return "Default";
+    case Anisotropy::Filter2x:
+        return "2x";
+    case Anisotropy::Filter4x:
+        return "4x";
+    case Anisotropy::Filter8x:
+        return "8x";
+    case Anisotropy::Filter16x:
+        return "16x";
+    }
 }
 
 bool IsGPULevelExtreme() {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -382,6 +382,14 @@ enum class GPUAccuracy : u32 {
     Extreme = 2,
 };
 
+enum class Anisotropy {
+    Default = 0,
+    Filter2x = 1,
+    Filter4x = 2,
+    Filter8x = 3,
+    Filter16x = 4,
+};
+
 struct Values {
     // System
     bool use_docked_mode;
@@ -438,7 +446,7 @@ struct Values {
 
     float resolution_factor;
     int aspect_ratio;
-    int max_anisotropy;
+    Anisotropy max_anisotropy;
     bool use_frame_limit;
     u16 frame_limit;
     bool use_disk_shader_cache;
@@ -486,6 +494,10 @@ struct Values {
     // Add-Ons
     std::map<u64, std::vector<std::string>> disabled_addons;
 } extern values;
+
+const char* GPUAccuracyLevelToChar(GPUAccuracy gpu_accuracy);
+
+const char* AnisotropicFilteringLevelToChar(Anisotropy anisotropy);
 
 bool IsGPULevelExtreme();
 bool IsGPULevelHigh();

--- a/src/video_core/textures/texture.cpp
+++ b/src/video_core/textures/texture.cpp
@@ -48,17 +48,17 @@ constexpr std::array<float, 256> SRGB_CONVERSION_LUT = {
 };
 
 unsigned SettingsMinimumAnisotropy() noexcept {
-    switch (static_cast<Anisotropy>(Settings::values.max_anisotropy)) {
+    switch (Settings::values.max_anisotropy) {
     default:
-    case Anisotropy::Default:
+    case Settings::Anisotropy::Default:
         return 1U;
-    case Anisotropy::Filter2x:
+    case Settings::Anisotropy::Filter2x:
         return 2U;
-    case Anisotropy::Filter4x:
+    case Settings::Anisotropy::Filter4x:
         return 4U;
-    case Anisotropy::Filter8x:
+    case Settings::Anisotropy::Filter8x:
         return 8U;
-    case Anisotropy::Filter16x:
+    case Settings::Anisotropy::Filter16x:
         return 16U;
     }
 }

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -309,14 +309,6 @@ enum class TextureMipmapFilter : u32 {
     Linear = 3,
 };
 
-enum class Anisotropy {
-    Default,
-    Filter2x,
-    Filter4x,
-    Filter8x,
-    Filter16x,
-};
-
 struct TSCEntry {
     union {
         struct {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -632,7 +632,8 @@ void Config::ReadRendererValues() {
     Settings::values.resolution_factor =
         ReadSetting(QStringLiteral("resolution_factor"), 1.0).toFloat();
     Settings::values.aspect_ratio = ReadSetting(QStringLiteral("aspect_ratio"), 0).toInt();
-    Settings::values.max_anisotropy = ReadSetting(QStringLiteral("max_anisotropy"), 0).toInt();
+    const int max_anisotropy = ReadSetting(QStringLiteral("max_anisotropy"), 0).toInt();
+    Settings::values.max_anisotropy = static_cast<Settings::Anisotropy>(max_anisotropy);
     Settings::values.use_frame_limit =
         ReadSetting(QStringLiteral("use_frame_limit"), true).toBool();
     Settings::values.frame_limit = ReadSetting(QStringLiteral("frame_limit"), 100).toInt();
@@ -1078,7 +1079,8 @@ void Config::SaveRendererValues() {
     WriteSetting(QStringLiteral("resolution_factor"),
                  static_cast<double>(Settings::values.resolution_factor), 1.0);
     WriteSetting(QStringLiteral("aspect_ratio"), Settings::values.aspect_ratio, 0);
-    WriteSetting(QStringLiteral("max_anisotropy"), Settings::values.max_anisotropy, 0);
+    WriteSetting(QStringLiteral("max_anisotropy"),
+                 static_cast<int>(Settings::values.max_anisotropy), 0);
     WriteSetting(QStringLiteral("use_frame_limit"), Settings::values.use_frame_limit, true);
     WriteSetting(QStringLiteral("frame_limit"), Settings::values.frame_limit, 100);
     WriteSetting(QStringLiteral("use_disk_shader_cache"), Settings::values.use_disk_shader_cache,

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -25,17 +25,18 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time);
     ui->force_30fps_mode->setEnabled(runtime_lock);
     ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode);
-    ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
-    ui->anisotropic_filtering_combobox->setCurrentIndex(Settings::values.max_anisotropy);
+    ui->anisotropic_filtering->setEnabled(runtime_lock);
+    ui->anisotropic_filtering->setCurrentIndex(static_cast<int>(Settings::values.max_anisotropy));
 }
 
 void ConfigureGraphicsAdvanced::ApplyConfiguration() {
-    auto gpu_accuracy = static_cast<Settings::GPUAccuracy>(ui->gpu_accuracy->currentIndex());
-    Settings::values.gpu_accuracy = gpu_accuracy;
+    Settings::values.gpu_accuracy =
+        static_cast<Settings::GPUAccuracy>(ui->gpu_accuracy->currentIndex());
     Settings::values.use_vsync = ui->use_vsync->isChecked();
     Settings::values.use_fast_gpu_time = ui->use_fast_gpu_time->isChecked();
     Settings::values.force_30fps_mode = ui->force_30fps_mode->isChecked();
-    Settings::values.max_anisotropy = ui->anisotropic_filtering_combobox->currentIndex();
+    Settings::values.max_anisotropy =
+        static_cast<Settings::Anisotropy>(ui->anisotropic_filtering->currentIndex());
 }
 
 void ConfigureGraphicsAdvanced::changeEvent(QEvent* event) {

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -45,7 +45,7 @@
             </item>
             <item>
              <property name="text">
-              <string notr="true">Extreme(very slow)</string>
+              <string notr="true">Extreme (very slow)</string>
              </property>
             </item>
            </widget>
@@ -86,7 +86,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="anisotropic_filtering_combobox">
+           <widget class="QComboBox" name="anisotropic_filtering">
             <item>
              <property name="text">
               <string>Default</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -381,8 +381,9 @@ void Config::ReadValues() {
         static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
     Settings::values.aspect_ratio =
         static_cast<int>(sdl2_config->GetInteger("Renderer", "aspect_ratio", 0));
-    Settings::values.max_anisotropy =
+    const int max_anisotropy =
         static_cast<int>(sdl2_config->GetInteger("Renderer", "max_anisotropy", 0));
+    Settings::values.max_anisotropy = static_cast<Settings::Anisotropy>(max_anisotropy);
     Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -120,8 +120,9 @@ void Config::ReadValues() {
         static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
     Settings::values.aspect_ratio =
         static_cast<int>(sdl2_config->GetInteger("Renderer", "aspect_ratio", 0));
-    Settings::values.max_anisotropy =
+    const int max_anisotropy =
         static_cast<int>(sdl2_config->GetInteger("Renderer", "max_anisotropy", 0));
+    Settings::values.max_anisotropy = static_cast<Settings::Anisotropy>(max_anisotropy);
     Settings::values.use_frame_limit = false;
     Settings::values.frame_limit = 100;
     Settings::values.use_disk_shader_cache =


### PR DESCRIPTION
Log them as readable strings instead of their respective combobox indices.

- Move Anisotropy enum to settings.h
- nit Extreme(very slow) -> Extreme (very slow) in gpu accuracy combobox