### PR TITLE
gl_shader_manager: Unbind GLSL program when binding a host pipeline

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -47,6 +47,10 @@ void ProgramManager::BindHostPipeline(GLuint pipeline) {
             old_state.geometry = 0;
             glDisable(GL_GEOMETRY_PROGRAM_NV);
         }
+    } else {
+        if (!is_graphics_bound) {
+            glUseProgram(0);
+        }
     }
     glBindProgramPipeline(pipeline);
 }


### PR DESCRIPTION
Fixes regression in Link's Awakening caused by 