### PR TITLE
renderer_opengl: Only enable DEBUG_OUTPUT when graphics debugging is …

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -751,11 +751,9 @@ void RendererOpenGL::RenderScreenshot() {
 }
 
 bool RendererOpenGL::Init() {
-    if (GLAD_GL_KHR_debug) {
+    if (Settings::values.renderer_debug && GLAD_GL_KHR_debug) {
         glEnable(GL_DEBUG_OUTPUT);
-        if (Settings::values.renderer_debug) {
-            glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-        }
+        glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
         glDebugMessageCallback(DebugHandler, nullptr);
     }
 


### PR DESCRIPTION
…enabled

Avoids logging when it's not relevant. This can potentially reduce
driver's internal thread overhead.