### PR TITLE
Fix: fatal error CVT1100 when compiling manifest file

### DIFF
--- a/src/yuzu/yuzu.rc
+++ b/src/yuzu/yuzu.rc
@@ -16,4 +16,4 @@ IDI_ICON1               ICON                    "../../dist/yuzu.ico"
 // RT_MANIFEST
 //
 
-1                       RT_MANIFEST             "../../dist/yuzu.manifest"
+0                       RT_MANIFEST             "../../dist/yuzu.manifest"

--- a/src/yuzu_cmd/yuzu.rc
+++ b/src/yuzu_cmd/yuzu.rc
@@ -14,4 +14,4 @@ YUZU_ICON               ICON                    "../../dist/yuzu.ico"
 // RT_MANIFEST
 //
 
-1                       RT_MANIFEST             "../../dist/yuzu.manifest"
+0                       RT_MANIFEST             "../../dist/yuzu.manifest"

--- a/src/yuzu_tester/yuzu.rc
+++ b/src/yuzu_tester/yuzu.rc
@@ -14,4 +14,4 @@ YUZU_ICON               ICON                    "../../dist/yuzu.ico"
 // RT_MANIFEST
 //
 
-1                       RT_MANIFEST             "../../dist/yuzu.manifest"
+0                       RT_MANIFEST             "../../dist/yuzu.manifest"


### PR DESCRIPTION
Occurs when doing a local compile in MSVC build. The compiler I'm using is as below:
Microsoft Visual Studio Community 2019 Preview
Version 16.6.0 Preview 5.0

Fixes this error:
CVTRES : fatal error CVT1100: duplicate resource. type:MANIFEST, name:1, language:0x0409
LINK : fatal error LNK1123: failure during conversion to COFF: file invalid or corrupt

I have put 0 since previous name was 1. If have other names in mind, please let me know.

