### PR TITLE
nvdrv/nvmap: Add cases for "Compr" and "Base"

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -200,8 +200,13 @@ u32 nvmap::IocParam(const std::vector<u8>& input, std::vector<u8>& output) {
     case ParamTypes::Kind:
         params.result = object->kind;
         break;
+    case ParamTypes::Compr:
+        params.result = 0;
+        break;
+    case ParamTypes::Base:
     default:
-        UNIMPLEMENTED();
+        return static_cast<u32>(NvErrCodes::InvalidValue);
+        break;
     }
 
     std::memcpy(output.data(), &params, sizeof(params));


### PR DESCRIPTION
From Switchbrew (https://switchbrew.org/wiki/NV_services):

"Returns info about a nvmap object. Identical to Linux driver, but extended with further params.

struct {
   __in  u32 handle;
   __in  u32 param;  // 1=SIZE, 2=ALIGNMENT, 3=BASE (returns error), 4=HEAP (always 0x40000000), 5=KIND, 6=COMPR (unused)
   __out u32 result;
 }; "

Base always returns an error (not sure if it's "InvalidValue" though), while Compr is unused, so nothing should change functionality-wise, I think