### PR TITLE
CMakeLists: Update fmt to 7.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ macro(yuzu_find_packages)
     #    Cmake Pkg Prefix  Version     Conan Pkg
         "Boost             1.71        boost/1.72.0"
         "Catch2            2.11        catch2/2.11.0"
-        "fmt               6.2         fmt/6.2.0"
+        "fmt               7.0         fmt/7.0.1"
     # can't use until https://github.com/bincrafters/community/issues/1173
         #"libzip            1.5         libzip/1.5.2@bincrafters/stable"
         "lz4               1.8         lz4/1.9.2"


### PR DESCRIPTION
Keeps the package up to date with the latest major release of fmt.

This version brings in quite a bit of improvements, such as code size
reduction, etc.