### PR TITLE
udp: Silence a C++20 deprecation warning

### DIFF
--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -234,7 +234,7 @@ CalibrationConfigurationJob::CalibrationConfigurationJob(
     std::function<void(Status)> status_callback,
     std::function<void(u16, u16, u16, u16)> data_callback) {
 
-    std::thread([=] {
+    std::thread([=, this] {
         constexpr u16 CALIBRATION_THRESHOLD = 100;
 
         u16 min_x{UINT16_MAX};


### PR DESCRIPTION
C++20 deprecates using the = lambda capture to implicitly capture the
this pointer. Instead, we must specify it explicitly.