### PR TITLE
memory_layout: Remove unused data member

### DIFF
--- a/src/core/hle/kernel/memory/memory_layout.h
+++ b/src/core/hle/kernel/memory/memory_layout.h
@@ -66,8 +66,6 @@ private:
     const MemoryRegion application;
     const MemoryRegion applet;
     const MemoryRegion system;
-
-    const PAddr start_address{};
 };
 
 } // namespace Kernel::Memory


### PR DESCRIPTION
This isn't used, so it can be removed entirely, shrinking the structure
size by 8 bytes.