### PR TITLE
main: Set async gpu properly after loading per-game setting

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1053,6 +1053,10 @@ void GMainWindow::BootGame(const QString& filename) {
     if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
         // Load per game settings
         Config per_game_config(fmt::format("{:016X}.ini", title_id), false);
+
+        Settings::values.use_asynchronous_gpu_emulation.SetValue(
+            Settings::values.use_asynchronous_gpu_emulation.GetValue() ||
+            Settings::values.use_multi_core.GetValue());
     }
 
     Settings::LogSettings();


### PR DESCRIPTION
Another error that got pass me and only noticed when I was doing the per-game settings UI rework. This prevents asynchronous GPU emulation from being disabled while multi core is enabled as a result of a poorly put together per-game config.