### PR TITLE
hid: Only update keyboard & debug pad inputs if enabled

### DIFF
--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -39,33 +39,36 @@ void Controller_DebugPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;
-    cur_entry.attribute.connected.Assign(1);
-    auto& pad = cur_entry.pad_state;
 
-    using namespace Settings::NativeButton;
-    pad.a.Assign(buttons[A - BUTTON_HID_BEGIN]->GetStatus());
-    pad.b.Assign(buttons[B - BUTTON_HID_BEGIN]->GetStatus());
-    pad.x.Assign(buttons[X - BUTTON_HID_BEGIN]->GetStatus());
-    pad.y.Assign(buttons[Y - BUTTON_HID_BEGIN]->GetStatus());
-    pad.l.Assign(buttons[L - BUTTON_HID_BEGIN]->GetStatus());
-    pad.r.Assign(buttons[R - BUTTON_HID_BEGIN]->GetStatus());
-    pad.zl.Assign(buttons[ZL - BUTTON_HID_BEGIN]->GetStatus());
-    pad.zr.Assign(buttons[ZR - BUTTON_HID_BEGIN]->GetStatus());
-    pad.plus.Assign(buttons[Plus - BUTTON_HID_BEGIN]->GetStatus());
-    pad.minus.Assign(buttons[Minus - BUTTON_HID_BEGIN]->GetStatus());
-    pad.d_left.Assign(buttons[DLeft - BUTTON_HID_BEGIN]->GetStatus());
-    pad.d_up.Assign(buttons[DUp - BUTTON_HID_BEGIN]->GetStatus());
-    pad.d_right.Assign(buttons[DRight - BUTTON_HID_BEGIN]->GetStatus());
-    pad.d_down.Assign(buttons[DDown - BUTTON_HID_BEGIN]->GetStatus());
+    if (Settings::values.debug_pad_enabled) {
+        cur_entry.attribute.connected.Assign(1);
+        auto& pad = cur_entry.pad_state;
 
-    const auto [stick_l_x_f, stick_l_y_f] =
-        analogs[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetStatus();
-    const auto [stick_r_x_f, stick_r_y_f] =
-        analogs[static_cast<std::size_t>(JoystickId::Joystick_Right)]->GetStatus();
-    cur_entry.l_stick.x = static_cast<s32>(stick_l_x_f * HID_JOYSTICK_MAX);
-    cur_entry.l_stick.y = static_cast<s32>(stick_l_y_f * HID_JOYSTICK_MAX);
-    cur_entry.r_stick.x = static_cast<s32>(stick_r_x_f * HID_JOYSTICK_MAX);
-    cur_entry.r_stick.y = static_cast<s32>(stick_r_y_f * HID_JOYSTICK_MAX);
+        using namespace Settings::NativeButton;
+        pad.a.Assign(buttons[A - BUTTON_HID_BEGIN]->GetStatus());
+        pad.b.Assign(buttons[B - BUTTON_HID_BEGIN]->GetStatus());
+        pad.x.Assign(buttons[X - BUTTON_HID_BEGIN]->GetStatus());
+        pad.y.Assign(buttons[Y - BUTTON_HID_BEGIN]->GetStatus());
+        pad.l.Assign(buttons[L - BUTTON_HID_BEGIN]->GetStatus());
+        pad.r.Assign(buttons[R - BUTTON_HID_BEGIN]->GetStatus());
+        pad.zl.Assign(buttons[ZL - BUTTON_HID_BEGIN]->GetStatus());
+        pad.zr.Assign(buttons[ZR - BUTTON_HID_BEGIN]->GetStatus());
+        pad.plus.Assign(buttons[Plus - BUTTON_HID_BEGIN]->GetStatus());
+        pad.minus.Assign(buttons[Minus - BUTTON_HID_BEGIN]->GetStatus());
+        pad.d_left.Assign(buttons[DLeft - BUTTON_HID_BEGIN]->GetStatus());
+        pad.d_up.Assign(buttons[DUp - BUTTON_HID_BEGIN]->GetStatus());
+        pad.d_right.Assign(buttons[DRight - BUTTON_HID_BEGIN]->GetStatus());
+        pad.d_down.Assign(buttons[DDown - BUTTON_HID_BEGIN]->GetStatus());
+
+        const auto [stick_l_x_f, stick_l_y_f] =
+            analogs[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetStatus();
+        const auto [stick_r_x_f, stick_r_y_f] =
+            analogs[static_cast<std::size_t>(JoystickId::Joystick_Right)]->GetStatus();
+        cur_entry.l_stick.x = static_cast<s32>(stick_l_x_f * HID_JOYSTICK_MAX);
+        cur_entry.l_stick.y = static_cast<s32>(stick_l_y_f * HID_JOYSTICK_MAX);
+        cur_entry.r_stick.x = static_cast<s32>(stick_r_x_f * HID_JOYSTICK_MAX);
+        cur_entry.r_stick.y = static_cast<s32>(stick_r_y_f * HID_JOYSTICK_MAX);
+    }
 
     std::memcpy(data, &shared_memory, sizeof(SharedMemory));
 }

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -40,15 +40,16 @@ void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
 
     cur_entry.key.fill(0);
     cur_entry.modifier = 0;
+    if (Settings::values.keyboard_enabled) {
+        for (std::size_t i = 0; i < keyboard_keys.size(); ++i) {
+            cur_entry.key[i / KEYS_PER_BYTE] |=
+                (keyboard_keys[i]->GetStatus() << (i % KEYS_PER_BYTE));
+        }
 
-    for (std::size_t i = 0; i < keyboard_keys.size(); ++i) {
-        cur_entry.key[i / KEYS_PER_BYTE] |= (keyboard_keys[i]->GetStatus() << (i % KEYS_PER_BYTE));
+        for (std::size_t i = 0; i < keyboard_mods.size(); ++i) {
+            cur_entry.modifier |= (keyboard_mods[i]->GetStatus() << i);
+        }
     }
-
-    for (std::size_t i = 0; i < keyboard_mods.size(); ++i) {
-        cur_entry.modifier |= (keyboard_mods[i]->GetStatus() << i);
-    }
-
     std::memcpy(data + SHARED_MEMORY_OFFSET, &shared_memory, sizeof(SharedMemory));
 }
 


### PR DESCRIPTION
Previously we would ignore this setting and would update the states regardless of the user setting