### PR TITLE
gl_arb_decompiler: Execute BAR even when inside control flow

### DIFF
--- a/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
@@ -2044,10 +2044,6 @@ std::string ARBDecompiler::ShuffleIndexed(Operation operation) {
 }
 
 std::string ARBDecompiler::Barrier(Operation) {
-    if (!ir.IsDecompiled()) {
-        LOG_ERROR(Render_OpenGL, "BAR used but shader is not decompiled");
-        return {};
-    }
     AddLine("BAR;");
     return {};
 }


### PR DESCRIPTION
Unlike GLSL, GLASM allows us to call BAR inside control flow.

- Fixes graphical artifacts in Paper Mario.