### PR TITLE
buffer_cache: Eliminate redundant map lookup in MarkRegionAsWritten()

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -524,11 +524,8 @@ private:
     void MarkRegionAsWritten(VAddr start, VAddr end) {
         const u64 page_end = end >> WRITE_PAGE_BIT;
         for (u64 page_start = start >> WRITE_PAGE_BIT; page_start <= page_end; ++page_start) {
-            auto it = written_pages.find(page_start);
-            if (it != written_pages.end()) {
-                it->second = it->second + 1;
-            } else {
-                written_pages.insert_or_assign(page_start, 1);
+            if (const auto [it, inserted] = written_pages.emplace(page_start, 1); !inserted) {
+                ++it->second;
             }
         }
     }
@@ -539,7 +536,7 @@ private:
             auto it = written_pages.find(page_start);
             if (it != written_pages.end()) {
                 if (it->second > 1) {
-                    it->second = it->second - 1;
+                    --it->second;
                 } else {
                     written_pages.erase(it);
                 }


### PR DESCRIPTION
We can make use of emplace()'s return value to determine whether or not
we need to perform an increment.

emplace() performs no insertion if an element already exist, so this can
eliminate a find() call.