### PR TITLE
common/string_util: Remove unimplemented function prototype (4414)

### DIFF
--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -74,16 +74,4 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, std::size_t 
 std::u16string UTF16StringFromFixedZeroTerminatedBuffer(std::u16string_view buffer,
                                                         std::size_t max_len);
 
-/**
- * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
- * intended to be used to strip a system-specific build directory from the `__FILE__` macro,
- * leaving only the path relative to the sources root.
- *
- * @param path The input file path as a null-terminated string
- * @param root The name of the root source directory as a null-terminated string. Path up to and
- *             including the last occurrence of this name will be stripped
- * @return A pointer to the same string passed as `path`, but starting at the trimmed portion
- */
-const char* TrimSourcePath(const char* path, const char* root = "src");
-
 } // namespace Common


### PR DESCRIPTION
This function was relocated to log.h as a constexpr function, so this
can be removed.