### PR TITLE
device_memory: Remove unused system member

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -146,7 +146,7 @@ struct System::Impl {
     ResultStatus Init(System& system, Frontend::EmuWindow& emu_window) {
         LOG_DEBUG(HW_Memory, "initialized OK");
 
-        device_memory = std::make_unique<Core::DeviceMemory>(system);
+        device_memory = std::make_unique<Core::DeviceMemory>();
 
         is_multicore = Settings::values.use_multi_core.GetValue();
         is_async_gpu = is_multicore || Settings::values.use_asynchronous_gpu_emulation.GetValue();

--- a/src/core/device_memory.cpp
+++ b/src/core/device_memory.cpp
@@ -2,14 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/core.h"
 #include "core/device_memory.h"
-#include "core/memory.h"
 
 namespace Core {
 
-DeviceMemory::DeviceMemory(System& system) : buffer{DramMemoryMap::Size}, system{system} {}
-
+DeviceMemory::DeviceMemory() : buffer{DramMemoryMap::Size} {}
 DeviceMemory::~DeviceMemory() = default;
 
 } // namespace Core

--- a/src/core/device_memory.h
+++ b/src/core/device_memory.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#include "common/assert.h"
-#include "common/common_funcs.h"
+#include "common/common_types.h"
 #include "common/virtual_buffer.h"
 
 namespace Core {
-
-class System;
 
 namespace DramMemoryMap {
 enum : u64 {
@@ -26,7 +23,7 @@ enum : u64 {
 
 class DeviceMemory : NonCopyable {
 public:
-    explicit DeviceMemory(Core::System& system);
+    explicit DeviceMemory();
     ~DeviceMemory();
 
     template <typename T>
@@ -45,7 +42,6 @@ public:
 
 private:
     Common::VirtualBuffer<u8> buffer;
-    Core::System& system;
 };
 
 } // namespace Core


### PR DESCRIPTION
This isn't used by anything in particular, so it can be removed.