### PR TITLE
cpu_manager: Remove redundant std::function declarations

### DIFF
--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -52,15 +52,15 @@ void CpuManager::Shutdown() {
 }
 
 std::function<void(void*)> CpuManager::GetGuestThreadStartFunc() {
-    return std::function<void(void*)>(GuestThreadFunction);
+    return GuestThreadFunction;
 }
 
 std::function<void(void*)> CpuManager::GetIdleThreadStartFunc() {
-    return std::function<void(void*)>(IdleThreadFunction);
+    return IdleThreadFunction;
 }
 
 std::function<void(void*)> CpuManager::GetSuspendThreadStartFunc() {
-    return std::function<void(void*)>(SuspendThreadFunction);
+    return SuspendThreadFunction;
 }
 
 void CpuManager::GuestThreadFunction(void* cpu_manager_) {


### PR DESCRIPTION
We can just return the function directly. Making for less reading.