### PR TITLE
patch_manager: Resolve -Wignored-qualifier warnings

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -288,8 +288,8 @@ std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
     }
 
     Core::Memory::TextCheatParser parser;
-    return parser.Parse(
-        system, std::string_view(reinterpret_cast<const char* const>(data.data()), data.size()));
+    return parser.Parse(system,
+                        std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
 }
 
 } // Anonymous namespace


### PR DESCRIPTION
Top level const will always be ignored in this case, so it can be
removed.