### PR TITLE
logging/backend: Make use of designated initializers

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -113,19 +113,19 @@ private:
     Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
                       const char* function, std::string message) const {
         using std::chrono::duration_cast;
+        using std::chrono::microseconds;
         using std::chrono::steady_clock;
 
-        Entry entry;
-        entry.timestamp =
-            duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
-        entry.log_class = log_class;
-        entry.log_level = log_level;
-        entry.filename = filename;
-        entry.line_num = line_nr;
-        entry.function = function;
-        entry.message = std::move(message);
-
-        return entry;
+        return {
+            .timestamp = duration_cast<microseconds>(steady_clock::now() - time_origin),
+            .log_class = log_class,
+            .log_level = log_level,
+            .filename = filename,
+            .line_num = line_nr,
+            .function = function,
+            .message = std::move(message),
+            .final_entry = false,
+        };
     }
 
     std::mutex writing_mutex;

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -21,19 +21,13 @@ class Filter;
  */
 struct Entry {
     std::chrono::microseconds timestamp;
-    Class log_class;
-    Level log_level;
-    const char* filename;
-    unsigned int line_num;
+    Class log_class{};
+    Level log_level{};
+    const char* filename = nullptr;
+    unsigned int line_num = 0;
     std::string function;
     std::string message;
     bool final_entry = false;
-
-    Entry() = default;
-    Entry(Entry&& o) = default;
-
-    Entry& operator=(Entry&& o) = default;
-    Entry& operator=(const Entry& o) = default;
 };
 
 /**


### PR DESCRIPTION
Same behavior, less code.