### PR TITLE
video_core: Remove redundant pixel format type

### DIFF
--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -96,7 +96,6 @@ SurfaceParams SurfaceParams::CreateForTexture(const FormatLookupTable& lookup_ta
         }
         params.type = GetFormatType(params.pixel_format);
     }
-    params.type = GetFormatType(params.pixel_format);
     // TODO: on 1DBuffer we should use the tic info.
     if (tic.IsBuffer()) {
         params.target = SurfaceTarget::TextureBuffer;


### PR DESCRIPTION
We already get the format type before converting shadow formats and during shadow formats.