### PR TITLE
system_control: Make functions internally linked where applicable

### DIFF
--- a/src/core/hle/kernel/memory/system_control.cpp
+++ b/src/core/hle/kernel/memory/system_control.cpp
@@ -7,22 +7,15 @@
 #include "core/hle/kernel/memory/system_control.h"
 
 namespace Kernel::Memory::SystemControl {
-
-u64 GenerateRandomU64ForInit() {
-    static std::random_device device;
-    static std::mt19937 gen(device());
-    static std::uniform_int_distribution<u64> distribution(1, std::numeric_limits<u64>::max());
-    return distribution(gen);
-}
-
+namespace {
 template <typename F>
 u64 GenerateUniformRange(u64 min, u64 max, F f) {
-    /* Handle the case where the difference is too large to represent. */
+    // Handle the case where the difference is too large to represent.
     if (max == std::numeric_limits<u64>::max() && min == std::numeric_limits<u64>::min()) {
         return f();
     }
 
-    /* Iterate until we get a value in range. */
+    // Iterate until we get a value in range.
     const u64 range_size = ((max + 1) - min);
     const u64 effective_max = (std::numeric_limits<u64>::max() / range_size) * range_size;
     while (true) {
@@ -31,6 +24,14 @@ u64 GenerateUniformRange(u64 min, u64 max, F f) {
         }
     }
 }
+
+u64 GenerateRandomU64ForInit() {
+    static std::random_device device;
+    static std::mt19937 gen(device());
+    static std::uniform_int_distribution<u64> distribution(1, std::numeric_limits<u64>::max());
+    return distribution(gen);
+}
+} // Anonymous namespace
 
 u64 GenerateRandomRange(u64 min, u64 max) {
     return GenerateUniformRange(min, max, GenerateRandomU64ForInit);

--- a/src/core/hle/kernel/memory/system_control.h
+++ b/src/core/hle/kernel/memory/system_control.h
@@ -8,11 +8,6 @@
 
 namespace Kernel::Memory::SystemControl {
 
-u64 GenerateRandomU64ForInit();
-
-template <typename F>
-u64 GenerateUniformRange(u64 min, u64 max, F f);
-
 u64 GenerateRandomRange(u64 min, u64 max);
 
 } // namespace Kernel::Memory::SystemControl


### PR DESCRIPTION
These functions are only ever used internally as implementation details
for GenerateRandomRange(), so these can be given internal linkage.