### PR TITLE
maxwell_3d: Resolve -Wextra-semi warning

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -647,7 +647,7 @@ public:
                     GetX() + GetWidth(),  // right
                     GetY()                // bottom
                 };
-            };
+            }
 
             f32 GetX() const {
                 return std::max(0.0f, translate_x - std::fabs(scale_x));


### PR DESCRIPTION
Semicolons after a function definition aren't necessary.