### PR TITLE
async_shaders: Resolve -Wpessimizing-move warning

### DIFF
--- a/src/video_core/shader/async_shaders.cpp
+++ b/src/video_core/shader/async_shaders.cpp
@@ -34,8 +34,8 @@ void AsyncShaders::AllocateWorkers(std::size_t num_workers) {
     // Create workers
     for (std::size_t i = 0; i < num_workers; i++) {
         context_list.push_back(emu_window.CreateSharedContext());
-        worker_threads.push_back(std::move(
-            std::thread(&AsyncShaders::ShaderCompilerThread, this, context_list[i].get())));
+        worker_threads.push_back(
+            std::thread(&AsyncShaders::ShaderCompilerThread, this, context_list[i].get()));
     }
 }
 


### PR DESCRIPTION
Prevents pessimization of the move constructor (which thankfully didn't
actually happen in practice here, given std::thread isn't copyable).