### PR TITLE
vulkan/wrapper: Avoid unnecessary copy in EnumerateInstanceExtensionP…

### DIFF
--- a/src/video_core/renderer_vulkan/wrapper.cpp
+++ b/src/video_core/renderer_vulkan/wrapper.cpp
@@ -786,7 +786,7 @@ std::optional<std::vector<VkExtensionProperties>> EnumerateInstanceExtensionProp
         VK_SUCCESS) {
         return std::nullopt;
     }
-    return properties;
+    return std::move(properties);
 }
 
 std::optional<std::vector<VkLayerProperties>> EnumerateInstanceLayerProperties(


### PR DESCRIPTION
…roperties()

Given this is implicitly creating a std::optional, we can move the
vector into it.