### PR TITLE
macro-interpreter: Resolve -Wself-assign-field warning

### DIFF
--- a/src/video_core/macro/macro_interpreter.cpp
+++ b/src/video_core/macro/macro_interpreter.cpp
@@ -34,7 +34,6 @@ void MacroInterpreterImpl::Execute(const std::vector<u32>& parameters, u32 metho
         this->parameters = std::make_unique<u32[]>(num_parameters);
     }
     std::memcpy(this->parameters.get(), parameters.data(), num_parameters * sizeof(u32));
-    this->num_parameters = num_parameters;
 
     // Execute the code until we hit an exit condition.
     bool keep_executing = true;


### PR DESCRIPTION
This was assigning the field to itself, which is a no-op. The size
doesn't change between its initial assignment and this one, so this is a
safe change to make.