### PR TITLE
configuration_shared: Simplify name lookup in highlighting functions

### DIFF
--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -72,18 +72,18 @@ void ConfigurationShared::SetPerGameSetting(
                                                            ConfigurationShared::USE_GLOBAL_OFFSET);
 }
 
-void ConfigurationShared::SetHighlight(QWidget* widget, const std::string& name, bool highlighted) {
+void ConfigurationShared::SetHighlight(QWidget* widget, bool highlighted) {
     if (highlighted) {
         widget->setStyleSheet(QStringLiteral("QWidget#%1 { background-color:rgba(0,203,255,0.5) }")
-                                  .arg(QString::fromStdString(name)));
+                                  .arg(widget->objectName()));
     } else {
         widget->setStyleSheet(QStringLiteral("QWidget#%1 { background-color:rgba(0,0,0,0) }")
-                                  .arg(QString::fromStdString(name)));
+                                  .arg(widget->objectName()));
     }
     widget->show();
 }
 
-void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, const std::string& name,
+void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox,
                                              const Settings::Setting<bool>& setting,
                                              CheckState& tracker) {
     if (setting.UsingGlobal()) {
@@ -91,45 +91,39 @@ void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, const std::str
     } else {
         tracker = (setting.GetValue() == setting.GetValue(true)) ? CheckState::On : CheckState::Off;
     }
-    SetHighlight(checkbox, name, tracker != CheckState::Global);
-    QObject::connect(checkbox, &QCheckBox::clicked, checkbox,
-                     [checkbox, name, setting, &tracker]() {
-                         tracker = static_cast<CheckState>((static_cast<int>(tracker) + 1) %
-                                                           static_cast<int>(CheckState::Count));
-                         if (tracker == CheckState::Global) {
-                             checkbox->setChecked(setting.GetValue(true));
-                         }
-                         SetHighlight(checkbox, name, tracker != CheckState::Global);
-                     });
+    SetHighlight(checkbox, tracker != CheckState::Global);
+    QObject::connect(checkbox, &QCheckBox::clicked, checkbox, [checkbox, setting, &tracker] {
+        tracker = static_cast<CheckState>((static_cast<int>(tracker) + 1) %
+                                          static_cast<int>(CheckState::Count));
+        if (tracker == CheckState::Global) {
+            checkbox->setChecked(setting.GetValue(true));
+        }
+        SetHighlight(checkbox, tracker != CheckState::Global);
+    });
 }
 
-void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, const std::string& name,
-                                             bool global, bool state, bool global_state,
-                                             CheckState& tracker) {
+void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, bool global, bool state,
+                                             bool global_state, CheckState& tracker) {
     if (global) {
         tracker = CheckState::Global;
     } else {
         tracker = (state == global_state) ? CheckState::On : CheckState::Off;
     }
-    SetHighlight(checkbox, name, tracker != CheckState::Global);
-    QObject::connect(checkbox, &QCheckBox::clicked, checkbox,
-                     [checkbox, name, global_state, &tracker]() {
-                         tracker = static_cast<CheckState>((static_cast<int>(tracker) + 1) %
-                                                           static_cast<int>(CheckState::Count));
-                         if (tracker == CheckState::Global) {
-                             checkbox->setChecked(global_state);
-                         }
-                         SetHighlight(checkbox, name, tracker != CheckState::Global);
-                     });
+    SetHighlight(checkbox, tracker != CheckState::Global);
+    QObject::connect(checkbox, &QCheckBox::clicked, checkbox, [checkbox, global_state, &tracker] {
+        tracker = static_cast<CheckState>((static_cast<int>(tracker) + 1) %
+                                          static_cast<int>(CheckState::Count));
+        if (tracker == CheckState::Global) {
+            checkbox->setChecked(global_state);
+        }
+        SetHighlight(checkbox, tracker != CheckState::Global);
+    });
 }
 
-void ConfigurationShared::SetColoredComboBox(QComboBox* combobox, QWidget* target,
-                                             const std::string& target_name, int global) {
+void ConfigurationShared::SetColoredComboBox(QComboBox* combobox, QWidget* target, int global) {
     InsertGlobalItem(combobox, global);
-    QObject::connect(combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), target,
-                     [target, target_name](int index) {
-                         ConfigurationShared::SetHighlight(target, target_name, index != 0);
-                     });
+    QObject::connect(combobox, qOverload<int>(&QComboBox::activated), target,
+                     [target](int index) { SetHighlight(target, index != 0); });
 }
 
 void ConfigurationShared::InsertGlobalItem(QComboBox* combobox, int global_index) {

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -39,13 +39,12 @@ void SetPerGameSetting(QComboBox* combobox,
 void SetPerGameSetting(QComboBox* combobox,
                        const Settings::Setting<Settings::GPUAccuracy>* setting);
 
-void SetHighlight(QWidget* widget, const std::string& name, bool highlighted);
-void SetColoredTristate(QCheckBox* checkbox, const std::string& name,
-                        const Settings::Setting<bool>& setting, CheckState& tracker);
-void SetColoredTristate(QCheckBox* checkbox, const std::string& name, bool global, bool state,
-                        bool global_state, CheckState& tracker);
-void SetColoredComboBox(QComboBox* combobox, QWidget* target, const std::string& target_name,
-                        int global);
+void SetHighlight(QWidget* widget, bool highlighted);
+void SetColoredTristate(QCheckBox* checkbox, const Settings::Setting<bool>& setting,
+                        CheckState& tracker);
+void SetColoredTristate(QCheckBox* checkbox, bool global, bool state, bool global_state,
+                        CheckState& tracker);
+void SetColoredComboBox(QComboBox* combobox, QWidget* target, int global);
 
 void InsertGlobalItem(QComboBox* combobox, int global_index);
 

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -59,7 +59,7 @@ void ConfigureAudio::SetConfiguration() {
             ui->volume_combo_box->setCurrentIndex(1);
             ui->volume_slider->setEnabled(true);
         }
-        ConfigurationShared::SetHighlight(ui->volume_layout, "volume_layout",
+        ConfigurationShared::SetHighlight(ui->volume_layout,
                                           !Settings::values.volume.UsingGlobal());
     }
     SetVolumeIndicatorText(ui->volume_slider->sliderPosition());
@@ -173,14 +173,13 @@ void ConfigureAudio::SetupPerGameUI() {
         return;
     }
 
-    ConfigurationShared::SetColoredTristate(ui->toggle_audio_stretching, "toggle_audio_stretching",
+    ConfigurationShared::SetColoredTristate(ui->toggle_audio_stretching,
                                             Settings::values.enable_audio_stretching,
                                             enable_audio_stretching);
-    connect(ui->volume_combo_box, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
-            this, [this](int index) {
-                ui->volume_slider->setEnabled(index == 1);
-                ConfigurationShared::SetHighlight(ui->volume_layout, "volume_layout", index == 1);
-            });
+    connect(ui->volume_combo_box, qOverload<int>(&QComboBox::activated), this, [this](int index) {
+        ui->volume_slider->setEnabled(index == 1);
+        ConfigurationShared::SetHighlight(ui->volume_layout, index == 1);
+    });
 
     ui->output_sink_combo_box->setVisible(false);
     ui->output_sink_label->setVisible(false);

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -105,10 +105,10 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->toggle_background_pause->setVisible(false);
     ui->toggle_hide_mouse->setVisible(false);
 
-    ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit, "toggle_frame_limit",
+    ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit,
                                             Settings::values.use_frame_limit, use_frame_limit);
-    ConfigurationShared::SetColoredTristate(ui->use_multi_core, "use_multi_core",
-                                            Settings::values.use_multi_core, use_multi_core);
+    ConfigurationShared::SetColoredTristate(ui->use_multi_core, Settings::values.use_multi_core,
+                                            use_multi_core);
 
     connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {
         ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked() &&

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -34,9 +34,8 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     connect(ui->api, qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
         UpdateDeviceComboBox();
         if (!Settings::configuring_global) {
-            ConfigurationShared::SetHighlight(ui->api_layout, "api_layout",
-                                              ui->api->currentIndex() !=
-                                                  ConfigurationShared::USE_GLOBAL_INDEX);
+            ConfigurationShared::SetHighlight(
+                ui->api_layout, ui->api->currentIndex() != ConfigurationShared::USE_GLOBAL_INDEX);
         }
     });
     connect(ui->device, qOverload<int>(&QComboBox::activated), this,
@@ -80,17 +79,16 @@ void ConfigureGraphics::SetConfiguration() {
         ui->aspect_ratio_combobox->setCurrentIndex(Settings::values.aspect_ratio.GetValue());
     } else {
         ConfigurationShared::SetPerGameSetting(ui->api, &Settings::values.renderer_backend);
-        ConfigurationShared::SetHighlight(ui->api_layout, "api_layout",
+        ConfigurationShared::SetHighlight(ui->api_layout,
                                           !Settings::values.renderer_backend.UsingGlobal());
         ConfigurationShared::SetPerGameSetting(ui->aspect_ratio_combobox,
                                                &Settings::values.aspect_ratio);
 
         ui->bg_combobox->setCurrentIndex(Settings::values.bg_red.UsingGlobal() ? 0 : 1);
         ui->bg_button->setEnabled(!Settings::values.bg_red.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->ar_label, "ar_label",
+        ConfigurationShared::SetHighlight(ui->ar_label,
                                           !Settings::values.aspect_ratio.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->bg_layout, "bg_layout",
-                                          !Settings::values.bg_red.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->bg_layout, !Settings::values.bg_red.UsingGlobal());
     }
 
     UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red.GetValue(),
@@ -248,20 +246,18 @@ void ConfigureGraphics::SetupPerGameUI() {
         return;
     }
 
-    connect(ui->bg_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
-            [this](int index) {
-                ui->bg_button->setEnabled(index == 1);
-                ConfigurationShared::SetHighlight(ui->bg_layout, "bg_layout", index == 1);
-            });
+    connect(ui->bg_combobox, qOverload<int>(&QComboBox::activated), this, [this](int index) {
+        ui->bg_button->setEnabled(index == 1);
+        ConfigurationShared::SetHighlight(ui->bg_layout, index == 1);
+    });
 
-    ConfigurationShared::SetColoredTristate(ui->use_disk_shader_cache, "use_disk_shader_cache",
-                                            Settings::values.use_disk_shader_cache,
-                                            use_disk_shader_cache);
     ConfigurationShared::SetColoredTristate(
-        ui->use_asynchronous_gpu_emulation, "use_asynchronous_gpu_emulation",
-        Settings::values.use_asynchronous_gpu_emulation, use_asynchronous_gpu_emulation);
+        ui->use_disk_shader_cache, Settings::values.use_disk_shader_cache, use_disk_shader_cache);
+    ConfigurationShared::SetColoredTristate(ui->use_asynchronous_gpu_emulation,
+                                            Settings::values.use_asynchronous_gpu_emulation,
+                                            use_asynchronous_gpu_emulation);
 
-    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label, "ar_label",
+    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label,
                                             Settings::values.aspect_ratio.GetValue(true));
     ConfigurationShared::InsertGlobalItem(
         ui->api, static_cast<int>(Settings::values.renderer_backend.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -41,9 +41,9 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
         ConfigurationShared::SetPerGameSetting(ui->gpu_accuracy, &Settings::values.gpu_accuracy);
         ConfigurationShared::SetPerGameSetting(ui->anisotropic_filtering_combobox,
                                                &Settings::values.max_anisotropy);
-        ConfigurationShared::SetHighlight(ui->label_gpu_accuracy, "label_gpu_accuracy",
+        ConfigurationShared::SetHighlight(ui->label_gpu_accuracy,
                                           !Settings::values.gpu_accuracy.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->af_label, "af_label",
+        ConfigurationShared::SetHighlight(ui->af_label,
                                           !Settings::values.max_anisotropy.UsingGlobal());
     }
 }
@@ -131,20 +131,18 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         return;
     }
 
-    ConfigurationShared::SetColoredTristate(ui->use_vsync, "use_vsync", Settings::values.use_vsync,
-                                            use_vsync);
-    ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_assembly_shaders",
-                                            Settings::values.use_assembly_shaders,
-                                            use_assembly_shaders);
+    ConfigurationShared::SetColoredTristate(ui->use_vsync, Settings::values.use_vsync, use_vsync);
     ConfigurationShared::SetColoredTristate(
-        ui->use_asynchronous_shaders, "use_asynchronous_shaders",
-        Settings::values.use_asynchronous_shaders, use_asynchronous_shaders);
-    ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time, "use_fast_gpu_time",
+        ui->use_assembly_shaders, Settings::values.use_assembly_shaders, use_assembly_shaders);
+    ConfigurationShared::SetColoredTristate(ui->use_asynchronous_shaders,
+                                            Settings::values.use_asynchronous_shaders,
+                                            use_asynchronous_shaders);
+    ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time,
                                             Settings::values.use_fast_gpu_time, use_fast_gpu_time);
     ConfigurationShared::SetColoredComboBox(
-        ui->gpu_accuracy, ui->label_gpu_accuracy, "label_gpu_accuracy",
+        ui->gpu_accuracy, ui->label_gpu_accuracy,
         static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));
     ConfigurationShared::SetColoredComboBox(
-        ui->anisotropic_filtering_combobox, ui->af_label, "af_label",
+        ui->anisotropic_filtering_combobox, ui->af_label,
         static_cast<int>(Settings::values.max_anisotropy.GetValue(true)));
 }

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -90,13 +90,13 @@ void ConfigureSystem::SetConfiguration() {
                                                &Settings::values.time_zone_index);
         ConfigurationShared::SetPerGameSetting(ui->combo_sound, &Settings::values.sound_index);
 
-        ConfigurationShared::SetHighlight(ui->label_language, "label_language",
+        ConfigurationShared::SetHighlight(ui->label_language,
                                           !Settings::values.language_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_region, "label_region",
+        ConfigurationShared::SetHighlight(ui->label_region,
                                           !Settings::values.region_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_timezone, "label_timezone",
+        ConfigurationShared::SetHighlight(ui->label_timezone,
                                           !Settings::values.time_zone_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_sound, "label_sound",
+        ConfigurationShared::SetHighlight(ui->label_sound,
                                           !Settings::values.sound_index.UsingGlobal());
     }
 }
@@ -224,22 +224,20 @@ void ConfigureSystem::SetupPerGameUI() {
     }
 
     ConfigurationShared::SetColoredComboBox(ui->combo_language, ui->label_language,
-                                            "label_language",
                                             Settings::values.language_index.GetValue(true));
-    ConfigurationShared::SetColoredComboBox(ui->combo_region, ui->label_region, "label_region",
+    ConfigurationShared::SetColoredComboBox(ui->combo_region, ui->label_region,
                                             Settings::values.region_index.GetValue(true));
     ConfigurationShared::SetColoredComboBox(ui->combo_time_zone, ui->label_timezone,
-                                            "label_timezone",
                                             Settings::values.time_zone_index.GetValue(true));
-    ConfigurationShared::SetColoredComboBox(ui->combo_sound, ui->label_sound, "label_sound",
+    ConfigurationShared::SetColoredComboBox(ui->combo_sound, ui->label_sound,
                                             Settings::values.sound_index.GetValue(true));
 
     ConfigurationShared::SetColoredTristate(
-        ui->rng_seed_checkbox, "rng_seed_checkbox", Settings::values.rng_seed.UsingGlobal(),
+        ui->rng_seed_checkbox, Settings::values.rng_seed.UsingGlobal(),
         Settings::values.rng_seed.GetValue().has_value(),
         Settings::values.rng_seed.GetValue(true).has_value(), use_rng_seed);
     ConfigurationShared::SetColoredTristate(
-        ui->custom_rtc_checkbox, "custom_rtc_checkbox", Settings::values.custom_rtc.UsingGlobal(),
+        ui->custom_rtc_checkbox, Settings::values.custom_rtc.UsingGlobal(),
         Settings::values.custom_rtc.GetValue().has_value(),
         Settings::values.custom_rtc.GetValue(true).has_value(), use_custom_rtc);
 }


### PR DESCRIPTION
We can query the given object name directly from the widget itself. This
removes any potential for forgetting to change the name if the widget
gets renamed and makes the API much simpler (just pass in the widget,
and not worry about its name).