### PR TITLE
file_sys: Replace inclusions with forward declarations where applicable

### DIFF
--- a/src/core/crypto/partition_data_manager.cpp
+++ b/src/core/crypto/partition_data_manager.cpp
@@ -26,6 +26,7 @@
 #include "core/file_sys/vfs.h"
 #include "core/file_sys/vfs_offset.h"
 #include "core/file_sys/vfs_vector.h"
+#include "core/loader/loader.h"
 
 using Common::AsArray;
 

--- a/src/core/file_sys/bis_factory.cpp
+++ b/src/core/file_sys/bis_factory.cpp
@@ -8,7 +8,6 @@
 #include "core/file_sys/bis_factory.h"
 #include "core/file_sys/mode.h"
 #include "core/file_sys/registered_cache.h"
-#include "core/settings.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/bis_factory.h
+++ b/src/core/file_sys/bis_factory.h
@@ -6,7 +6,8 @@
 
 #include <memory>
 
-#include "core/file_sys/vfs.h"
+#include "common/common_types.h"
+#include "core/file_sys/vfs_types.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -8,11 +8,11 @@
 #include <fmt/ostream.h>
 
 #include "common/logging/log.h"
+#include "core/crypto/key_manager.h"
 #include "core/file_sys/card_image.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/partition_filesystem.h"
-#include "core/file_sys/romfs.h"
 #include "core/file_sys/submission_package.h"
 #include "core/file_sys/vfs_concat.h"
 #include "core/file_sys/vfs_offset.h"
@@ -31,7 +31,8 @@ constexpr std::array partition_names{
 
 XCI::XCI(VirtualFile file_)
     : file(std::move(file_)), program_nca_status{Loader::ResultStatus::ErrorXCIMissingProgramNCA},
-      partitions(partition_names.size()), partitions_raw(partition_names.size()) {
+      partitions(partition_names.size()),
+      partitions_raw(partition_names.size()), keys{Core::Crypto::KeyManager::Instance()} {
     if (file->ReadObject(&header) != sizeof(GamecardHeader)) {
         status = Loader::ResultStatus::ErrorBadXCIHeader;
         return;

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -9,8 +9,11 @@
 #include <vector>
 #include "common/common_types.h"
 #include "common/swap.h"
-#include "core/crypto/key_manager.h"
 #include "core/file_sys/vfs.h"
+
+namespace Core::Crypto {
+class KeyManager;
+}
 
 namespace Loader {
 enum class ResultStatus : u16;
@@ -140,6 +143,6 @@ private:
 
     u64 update_normal_partition_end;
 
-    Core::Crypto::KeyManager& keys = Core::Crypto::KeyManager::Instance();
+    Core::Crypto::KeyManager& keys;
 };
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -10,10 +10,10 @@
 #include "common/logging/log.h"
 #include "core/crypto/aes_util.h"
 #include "core/crypto/ctr_encryption_layer.h"
+#include "core/crypto/key_manager.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/nca_patch.h"
 #include "core/file_sys/partition_filesystem.h"
-#include "core/file_sys/romfs.h"
 #include "core/file_sys/vfs_offset.h"
 #include "core/loader/loader.h"
 
@@ -119,7 +119,8 @@ static bool IsValidNCA(const NCAHeader& header) {
 }
 
 NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_offset)
-    : file(std::move(file_)), bktr_base_romfs(std::move(bktr_base_romfs_)) {
+    : file(std::move(file_)),
+      bktr_base_romfs(std::move(bktr_base_romfs_)), keys{Core::Crypto::KeyManager::Instance()} {
     if (file == nullptr) {
         status = Loader::ResultStatus::ErrorNullFile;
         return;

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -158,7 +158,7 @@ private:
     bool encrypted = false;
     bool is_update = false;
 
-    Core::Crypto::KeyManager& keys = Core::Crypto::KeyManager::Instance();
+    Core::Crypto::KeyManager& keys;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -5,6 +5,7 @@
 #include "common/string_util.h"
 #include "common/swap.h"
 #include "core/file_sys/control_metadata.h"
+#include "core/file_sys/vfs.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -10,7 +10,7 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/kernel_executable.cpp
+++ b/src/core/file_sys/kernel_executable.cpp
@@ -2,9 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
+
 #include "common/string_util.h"
 #include "core/file_sys/kernel_executable.h"
 #include "core/file_sys/vfs_offset.h"
+#include "core/loader/loader.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/kernel_executable.h
+++ b/src/core/file_sys/kernel_executable.h
@@ -4,10 +4,17 @@
 
 #pragma once
 
+#include <array>
+#include <vector>
+
 #include "common/common_funcs.h"
+#include "common/common_types.h"
 #include "common/swap.h"
 #include "core/file_sys/vfs_types.h"
-#include "core/loader/loader.h"
+
+namespace Loader {
+enum class ResultStatus : u16;
+}
 
 namespace FileSys {
 

--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -7,6 +7,7 @@
 #include "common/logging/log.h"
 #include "common/swap.h"
 #include "core/file_sys/nca_metadata.h"
+#include "core/file_sys/vfs.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -10,7 +10,7 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 
 namespace FileSys {
 class CNMT;

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -21,7 +21,7 @@ bool PartitionFilesystem::Header::HasValidMagicValue() const {
            magic == Common::MakeMagic('P', 'F', 'S', '0');
 }
 
-PartitionFilesystem::PartitionFilesystem(std::shared_ptr<VfsFile> file) {
+PartitionFilesystem::PartitionFilesystem(VirtualFile file) {
     // At least be as large as the header
     if (file->GetSize() < sizeof(Header)) {
         status = Loader::ResultStatus::ErrorBadPFSHeader;
@@ -89,11 +89,11 @@ std::map<std::string, u64> PartitionFilesystem::GetFileSizes() const {
     return sizes;
 }
 
-std::vector<std::shared_ptr<VfsFile>> PartitionFilesystem::GetFiles() const {
+std::vector<VirtualFile> PartitionFilesystem::GetFiles() const {
     return pfs_files;
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> PartitionFilesystem::GetSubdirectories() const {
+std::vector<VirtualDir> PartitionFilesystem::GetSubdirectories() const {
     return {};
 }
 
@@ -101,7 +101,7 @@ std::string PartitionFilesystem::GetName() const {
     return is_hfs ? "HFS0" : "PFS0";
 }
 
-std::shared_ptr<VfsDirectory> PartitionFilesystem::GetParentDirectory() const {
+VirtualDir PartitionFilesystem::GetParentDirectory() const {
     // TODO(DarkLordZach): Add support for nested containers.
     return nullptr;
 }

--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -24,7 +24,7 @@ namespace FileSys {
  */
 class PartitionFilesystem : public ReadOnlyVfsDirectory {
 public:
-    explicit PartitionFilesystem(std::shared_ptr<VfsFile> file);
+    explicit PartitionFilesystem(VirtualFile file);
     ~PartitionFilesystem() override;
 
     Loader::ResultStatus GetStatus() const;
@@ -32,10 +32,10 @@ public:
     std::map<std::string, u64> GetFileOffsets() const;
     std::map<std::string, u64> GetFileSizes() const;
 
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualFile> GetFiles() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
     std::string GetName() const override;
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
+    VirtualDir GetParentDirectory() const override;
     void PrintDebugInfo() const;
 
 private:

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -49,8 +49,7 @@ std::string FormatTitleVersion(u32 version, TitleVersionFormat format) {
     return fmt::format("v{}.{}.{}", bytes[3], bytes[2], bytes[1]);
 }
 
-std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<VfsDirectory> dir,
-                                                       std::string_view name) {
+VirtualDir FindSubdirectoryCaseless(const VirtualDir dir, std::string_view name) {
 #ifdef _WIN32
     return dir->GetSubdirectory(name);
 #else

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -9,7 +9,7 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/nca_metadata.h"
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 #include "core/memory/dmnt_cheat_types.h"
 
 namespace Core {
@@ -31,8 +31,7 @@ std::string FormatTitleVersion(u32 version,
 
 // Returns a directory with name matching name case-insensitive. Returns nullptr if directory
 // doesn't have a directory with name.
-std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<VfsDirectory> dir,
-                                                       std::string_view name);
+VirtualDir FindSubdirectoryCaseless(VirtualDir dir, std::string_view name);
 
 // A centralized class to manage patches to games.
 class PatchManager {

--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -7,6 +7,7 @@
 
 #include "common/logging/log.h"
 #include "core/file_sys/program_metadata.h"
+#include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
 
 namespace FileSys {

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -9,7 +9,7 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/swap.h"
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 
 namespace Loader {
 enum class ResultStatus : u16;

--- a/src/core/file_sys/romfs.h
+++ b/src/core/file_sys/romfs.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <array>
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {

--- a/src/core/file_sys/sdmc_factory.cpp
+++ b/src/core/file_sys/sdmc_factory.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/sdmc_factory.h"
+#include "core/file_sys/vfs.h"
 #include "core/file_sys/xts_archive.h"
-#include "core/settings.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/sdmc_factory.h
+++ b/src/core/file_sys/sdmc_factory.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <memory>
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 #include "core/hle/result.h"
 
 namespace FileSys {

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -54,7 +54,7 @@ void SetTicketKeys(const std::vector<VirtualFile>& files) {
 
 NSP::NSP(VirtualFile file_)
     : file(std::move(file_)), status{Loader::ResultStatus::Success},
-      pfs(std::make_shared<PartitionFilesystem>(file)) {
+      pfs(std::make_shared<PartitionFilesystem>(file)), keys{Core::Crypto::KeyManager::Instance()} {
     if (pfs->GetStatus() != Loader::ResultStatus::Success) {
         status = pfs->GetStatus();
         return;

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -10,6 +10,10 @@
 #include "common/common_types.h"
 #include "core/file_sys/vfs.h"
 
+namespace Core::Crypto {
+class KeyManager;
+}
+
 namespace Loader {
 enum class ResultStatus : u16;
 }
@@ -73,7 +77,7 @@ private:
     std::map<u64, std::map<std::pair<TitleType, ContentRecordType>, std::shared_ptr<NCA>>> ncas;
     std::vector<VirtualFile> ticket_files;
 
-    Core::Crypto::KeyManager& keys = Core::Crypto::KeyManager::Instance();
+    Core::Crypto::KeyManager& keys;
 
     VirtualFile romfs;
     VirtualDir exefs;

--- a/src/core/file_sys/xts_archive.h
+++ b/src/core/file_sys/xts_archive.h
@@ -9,11 +9,15 @@
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/crypto/key_manager.h"
-#include "core/file_sys/content_archive.h"
 #include "core/file_sys/vfs.h"
-#include "core/loader/loader.h"
+
+namespace Loader {
+enum class ResultStatus : u16;
+}
 
 namespace FileSys {
+
+class NCA;
 
 struct NAXHeader {
     std::array<u8, 0x20> hmac;
@@ -62,6 +66,6 @@ private:
 
     VirtualFile dec_file;
 
-    Core::Crypto::KeyManager& keys = Core::Crypto::KeyManager::Instance();
+    Core::Crypto::KeyManager& keys;
 };
 } // namespace FileSys

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -5,6 +5,7 @@
 #include "common/logging/log.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
+#include "core/file_sys/vfs.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/ns/errors.h"


### PR DESCRIPTION
Same behavior, minus unnecessary inclusions where not necessary.