### PR TITLE
vk_device: Blacklist AMD proprietary from VK_EXT_extended_dynamic_state

### DIFF
--- a/src/video_core/renderer_vulkan/vk_device.cpp
+++ b/src/video_core/renderer_vulkan/vk_device.cpp
@@ -691,7 +691,12 @@ std::vector<const char*> VKDevice::LoadExtensions() {
         }
     }
 
-    if (has_ext_extended_dynamic_state) {
+    if (has_ext_extended_dynamic_state && driver_id == VK_DRIVER_ID_AMD_PROPRIETARY) {
+        // AMD's proprietary driver supports VK_EXT_extended_dynamic_state but the <stride> field
+        // seems to be bugged. Blacklisting it for now.
+        LOG_WARNING(Render_Vulkan,
+                    "Blacklisting AMD proprietary from VK_EXT_extended_dynamic_state");
+    } else if (has_ext_extended_dynamic_state) {
         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT dynamic_state;
         dynamic_state.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT;
         dynamic_state.pNext = nullptr;


### PR DESCRIPTION
Vertex binding's <stride> is bugged on AMD's proprietary drivers when
using VK_EXT_extended_dynamic_state. Blacklist it for now while we
investigate how to report this issue to AMD.