### PR TITLE
common_funcs: Add missing XOR operators to DECLARE_ENUM_FLAG_OPERATORS

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -64,14 +64,20 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
         using T = std::underlying_type_t<type>;                                                    \
         return static_cast<type>(static_cast<T>(a) & static_cast<T>(b));                           \
     }                                                                                              \
-    constexpr type& operator|=(type& a, type b) noexcept {                                         \
+    [[nodiscard]] constexpr type operator^(type a, type b) noexcept {                              \
         using T = std::underlying_type_t<type>;                                                    \
-        a = static_cast<type>(static_cast<T>(a) | static_cast<T>(b));                              \
+        return static_cast<type>(static_cast<T>(a) ^ static_cast<T>(b));                           \
+    }                                                                                              \
+    constexpr type& operator|=(type& a, type b) noexcept {                                         \
+        a = a | b;                                                                                 \
         return a;                                                                                  \
     }                                                                                              \
     constexpr type& operator&=(type& a, type b) noexcept {                                         \
-        using T = std::underlying_type_t<type>;                                                    \
-        a = static_cast<type>(static_cast<T>(a) & static_cast<T>(b));                              \
+        a = a & b;                                                                                 \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator^=(type& a, type b) noexcept {                                         \
+        a = a ^ b;                                                                                 \
         return a;                                                                                  \
     }                                                                                              \
     [[nodiscard]] constexpr type operator~(type key) noexcept {                                    \


### PR DESCRIPTION
Ensures that the full set of bitwise operators are available for types
that make use of this macro.