### PR TITLE
gc_adapter: Disable MSVC nonstandard extension warning on libusb.h

### DIFF
--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -4,7 +4,16 @@
 
 #include <chrono>
 #include <thread>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4200) // nonstandard extension used : zero-sized array in struct/union
+#endif
 #include <libusb.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include "common/logging/log.h"
 #include "input_common/gcadapter/gc_adapter.h"
 


### PR DESCRIPTION
Pragma disable zero-sized array nonstandard extension warning on MSVC.