### PR TITLE
arm_dynarmic_cp15: Initialize member variables

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_cp15.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_cp15.h
@@ -35,8 +35,8 @@ public:
                                               std::optional<u8> option) override;
 
     ARM_Dynarmic_32& parent;
-    u32 uprw;
-    u32 uro;
+    u32 uprw = 0;
+    u32 uro = 0;
 };
 
 } // namespace Core


### PR DESCRIPTION
Ensures that the member variables are always initialized to a
deterministic value on creation.