### PR TITLE
settings: Simplify initializer of resolution factor

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -101,7 +101,7 @@ struct Values {
     bool renderer_debug;
     Setting<int> vulkan_device;
 
-    Setting<u16> resolution_factor = Setting(static_cast<u16>(1));
+    Setting<u16> resolution_factor{1};
     Setting<int> aspect_ratio;
     Setting<int> max_anisotropy;
     Setting<bool> use_frame_limit;


### PR DESCRIPTION
This can use a braced initializer to accomplish the same thing with less
code.