### PR TITLE
configure_input_player: Use static qualifier for IsProfileNameValid()

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -1137,7 +1137,7 @@ void ConfigureInputPlayer::CreateProfile() {
         return;
     }
 
-    if (!profiles->IsProfileNameValid(profile_name.toStdString())) {
+    if (!InputProfiles::IsProfileNameValid(profile_name.toStdString())) {
         QMessageBox::critical(this, tr("Create Input Profile"),
                               tr("The given profile name is not valid!"));
         return;


### PR DESCRIPTION
This is a static member function, so we don't need use an existing
instance to call this function.