### PR TITLE
game_list_p: Resolve deprecated usage of QVariant operator<

### DIFF
--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -174,7 +174,8 @@ public:
     }
 
     bool operator<(const QStandardItem& other) const override {
-        return data(CompatNumberRole) < other.data(CompatNumberRole);
+        return data(CompatNumberRole).value<QString>() <
+               other.data(CompatNumberRole).value<QString>();
     }
 };
 


### PR DESCRIPTION
This is designated as obsolete in Qt's docs (see:
https://doc.qt.io/qt-5/qvariant-obsolete.html#operator-lt)