### PR TITLE
yuzu_cmd: Remove 'users_size'

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -345,7 +345,6 @@ void Config::ReadValues() {
     // System
     Settings::values.use_docked_mode.SetValue(
         sdl2_config->GetBoolean("System", "use_docked_mode", false));
-    const auto size = sdl2_config->GetInteger("System", "users_size", 0);
 
     Settings::values.current_user = std::clamp<int>(
         sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);


### PR DESCRIPTION
Specifically:

    const auto size = sdl2_config->GetInteger("System", "users_size", 0);

The variable is never used, producing a warning.  I wondered if this
ought to be assigning something to in `Settings`, but nothing else in
the codebase ever mentions a setting called "users_size", so I guess
it's safe to remove...