### PR TITLE
map_interval: Change field order to address uninitialized field warning

### DIFF
--- a/src/video_core/buffer_cache/map_interval.h
+++ b/src/video_core/buffer_cache/map_interval.h
@@ -84,9 +84,10 @@ private:
     void FillFreeList(Chunk& chunk);
 
     std::vector<MapInterval*> free_list;
-    std::unique_ptr<Chunk>* new_chunk = &first_chunk.next;
 
     Chunk first_chunk;
+
+    std::unique_ptr<Chunk>* new_chunk = &first_chunk.next;
 };
 
 } // namespace VideoCommon


### PR DESCRIPTION
Clang complains about `new_chunk`'s constructor using the
then-uninitialized `first_chunk` (even though it's just to get a pointer
into it).