### PR TITLE
configure_motion_touch: Fix unescaped backslash in regex

### DIFF
--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -183,8 +183,8 @@ void ConfigureMotionTouch::ConnectEvents() {
 }
 
 void ConfigureMotionTouch::OnUDPAddServer() {
-    QRegExp re(tr("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?["
-                  "0-9][0-9]?)$")); // a valid ip address
+    QRegExp re(tr(R"re(^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4]"
+                  "[0-9]|[01]?[0-9][0-9]?)$)re")); // a valid ip address
     bool ok;
     QString port_text = ui->udp_port->text();
     QString server_text = ui->udp_server->text();


### PR DESCRIPTION
Since this is inside a string literal, backslashes that are part of
regex syntax have to be escaped.  But that's ugly, so convert to a raw
string instead.