### PR TITLE
network, sockets: Replace `POLL_IN`, `POLL_OUT`, etc. constants with …

### DIFF
--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -489,18 +489,18 @@ std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u
     }
 
     for (PollFD& pollfd : fds) {
-        ASSERT(pollfd.revents == 0);
+        ASSERT(False(pollfd.revents));
 
         if (pollfd.fd > static_cast<s32>(MAX_FD) || pollfd.fd < 0) {
             LOG_ERROR(Service, "File descriptor handle={} is invalid", pollfd.fd);
-            pollfd.revents = 0;
+            pollfd.revents = PollEvents{};
             return {0, Errno::SUCCESS};
         }
 
         const std::optional<FileDescriptor>& descriptor = file_descriptors[pollfd.fd];
         if (!descriptor) {
             LOG_ERROR(Service, "File descriptor handle={} is not allocated", pollfd.fd);
-            pollfd.revents = POLL_NVAL;
+            pollfd.revents = PollEvents::Nval;
             return {0, Errno::SUCCESS};
         }
     }
@@ -510,7 +510,7 @@ std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u
         Network::PollFD result;
         result.socket = file_descriptors[pollfd.fd]->socket.get();
         result.events = TranslatePollEventsToHost(pollfd.events);
-        result.revents = 0;
+        result.revents = Network::PollEvents{};
         return result;
     });
 

--- a/src/core/hle/service/sockets/sockets.h
+++ b/src/core/hle/service/sockets/sockets.h
@@ -69,23 +69,28 @@ struct SockAddrIn {
     std::array<u8, 8> zeroes;
 };
 
+enum class PollEvents : u16 {
+    // Using Pascal case because IN is a macro on Windows.
+    In = 1 << 0,
+    Pri = 1 << 1,
+    Out = 1 << 2,
+    Err = 1 << 3,
+    Hup = 1 << 4,
+    Nval = 1 << 5,
+};
+
+DECLARE_ENUM_FLAG_OPERATORS(PollEvents);
+
 struct PollFD {
     s32 fd;
-    u16 events;
-    u16 revents;
+    PollEvents events;
+    PollEvents revents;
 };
 
 struct Linger {
     u32 onoff;
     u32 linger;
 };
-
-constexpr u16 POLL_IN = 0x01;
-constexpr u16 POLL_PRI = 0x02;
-constexpr u16 POLL_OUT = 0x04;
-constexpr u16 POLL_ERR = 0x08;
-constexpr u16 POLL_HUP = 0x10;
-constexpr u16 POLL_NVAL = 0x20;
 
 constexpr u32 FLAG_MSG_DONTWAIT = 0x80;
 

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -89,43 +89,43 @@ Network::Protocol Translate(Type type, Protocol protocol) {
     }
 }
 
-u16 TranslatePollEventsToHost(u32 flags) {
-    u32 result = 0;
-    const auto translate = [&result, &flags](u32 from, u32 to) {
-        if ((flags & from) != 0) {
+Network::PollEvents TranslatePollEventsToHost(PollEvents flags) {
+    Network::PollEvents result{};
+    const auto translate = [&result, &flags](PollEvents from, Network::PollEvents to) {
+        if (True(flags & from)) {
             flags &= ~from;
             result |= to;
         }
     };
-    translate(POLL_IN, Network::POLL_IN);
-    translate(POLL_PRI, Network::POLL_PRI);
-    translate(POLL_OUT, Network::POLL_OUT);
-    translate(POLL_ERR, Network::POLL_ERR);
-    translate(POLL_HUP, Network::POLL_HUP);
-    translate(POLL_NVAL, Network::POLL_NVAL);
+    translate(PollEvents::In, Network::PollEvents::In);
+    translate(PollEvents::Pri, Network::PollEvents::Pri);
+    translate(PollEvents::Out, Network::PollEvents::Out);
+    translate(PollEvents::Err, Network::PollEvents::Err);
+    translate(PollEvents::Hup, Network::PollEvents::Hup);
+    translate(PollEvents::Nval, Network::PollEvents::Nval);
 
-    UNIMPLEMENTED_IF_MSG(flags != 0, "Unimplemented flags={}", flags);
-    return static_cast<u16>(result);
+    UNIMPLEMENTED_IF_MSG((u16)flags != 0, "Unimplemented flags={}", (u16)flags);
+    return result;
 }
 
-u16 TranslatePollEventsToGuest(u32 flags) {
-    u32 result = 0;
-    const auto translate = [&result, &flags](u32 from, u32 to) {
-        if ((flags & from) != 0) {
+PollEvents TranslatePollEventsToGuest(Network::PollEvents flags) {
+    PollEvents result{};
+    const auto translate = [&result, &flags](Network::PollEvents from, PollEvents to) {
+        if (True(flags & from)) {
             flags &= ~from;
             result |= to;
         }
     };
 
-    translate(Network::POLL_IN, POLL_IN);
-    translate(Network::POLL_PRI, POLL_PRI);
-    translate(Network::POLL_OUT, POLL_OUT);
-    translate(Network::POLL_ERR, POLL_ERR);
-    translate(Network::POLL_HUP, POLL_HUP);
-    translate(Network::POLL_NVAL, POLL_NVAL);
+    translate(Network::PollEvents::In, PollEvents::In);
+    translate(Network::PollEvents::Pri, PollEvents::Pri);
+    translate(Network::PollEvents::Out, PollEvents::Out);
+    translate(Network::PollEvents::Err, PollEvents::Err);
+    translate(Network::PollEvents::Hup, PollEvents::Hup);
+    translate(Network::PollEvents::Nval, PollEvents::Nval);
 
-    UNIMPLEMENTED_IF_MSG(flags != 0, "Unimplemented flags={}", flags);
-    return static_cast<u16>(result);
+    UNIMPLEMENTED_IF_MSG((u16)flags != 0, "Unimplemented flags={}", (u16)flags);
+    return result;
 }
 
 Network::SockAddrIn Translate(SockAddrIn value) {

--- a/src/core/hle/service/sockets/sockets_translate.h
+++ b/src/core/hle/service/sockets/sockets_translate.h
@@ -31,10 +31,10 @@ Network::Type Translate(Type type);
 Network::Protocol Translate(Type type, Protocol protocol);
 
 /// Translate abstract poll event flags to guest poll event flags
-u16 TranslatePollEventsToHost(u32 flags);
+Network::PollEvents TranslatePollEventsToHost(PollEvents flags);
 
 /// Translate guest poll event flags to abstract poll event flags
-u16 TranslatePollEventsToGuest(u32 flags);
+PollEvents TranslatePollEventsToGuest(Network::PollEvents flags);
 
 /// Translate guest socket address structure to abstract socket address structure
 Network::SockAddrIn Translate(SockAddrIn value);

--- a/src/core/network/network.h
+++ b/src/core/network/network.h
@@ -61,18 +61,24 @@ struct SockAddrIn {
 };
 
 /// Cross-platform poll fd structure
-struct PollFD {
-    Socket* socket;
-    u16 events;
-    u16 revents;
+
+enum class PollEvents : u16 {
+    // Using Pascal case because IN is a macro on Windows.
+    In = 1 << 0,
+    Pri = 1 << 1,
+    Out = 1 << 2,
+    Err = 1 << 3,
+    Hup = 1 << 4,
+    Nval = 1 << 5,
 };
 
-constexpr u16 POLL_IN = 1 << 0;
-constexpr u16 POLL_PRI = 1 << 1;
-constexpr u16 POLL_OUT = 1 << 2;
-constexpr u16 POLL_ERR = 1 << 3;
-constexpr u16 POLL_HUP = 1 << 4;
-constexpr u16 POLL_NVAL = 1 << 5;
+DECLARE_ENUM_FLAG_OPERATORS(PollEvents);
+
+struct PollFD {
+    Socket* socket;
+    PollEvents events;
+    PollEvents revents;
+};
 
 class NetworkInstance {
 public:


### PR DESCRIPTION
…an `enum class PollEvents`

Actually, two enum classes, since for some reason there are two separate
yet identical `PollFD` types used in the codebase.  I get that one is
ABI-compatible with the Switch while the other is an abstract type used
for the host, but why not use `WSAPOLLFD` directly for the latter?

Anyway, why make this change?  Because on Apple platforms, `POLL_IN`,
`POLL_OUT`, etc. (with an underscore) are defined as macros in
<sys/signal.h>.  (This is inherited from FreeBSD.)  So defining
a variable with the same name causes a compile error.

I could just rename the variables, but while I was at it I thought I
might as well switch to an enum for stronger typing.

Also, change the type used for values copied directly to/from the
`events` and `revents` fields of the host *native*
`pollfd`/`WSASPOLLFD`, from `u32` to `short`, as `short` is the correct
canonical type on both Unix and Windows.