### PR TITLE
core: Remove unnecessary enum casts in log calls

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -237,7 +237,7 @@ struct System::Impl {
             Kernel::Process::Create(system, "main", Kernel::Process::ProcessType::Userland);
         const auto [load_result, load_parameters] = app_loader->Load(*main_process, system);
         if (load_result != Loader::ResultStatus::Success) {
-            LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", static_cast<int>(load_result));
+            LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", load_result);
             Shutdown();
 
             return static_cast<ResultStatus>(static_cast<u32>(ResultStatus::ErrorLoader) +
@@ -267,8 +267,7 @@ struct System::Impl {
 
         u64 title_id{0};
         if (app_loader->ReadProgramId(title_id) != Loader::ResultStatus::Success) {
-            LOG_ERROR(Core, "Failed to find title id for ROM (Error {})",
-                      static_cast<u32>(load_result));
+            LOG_ERROR(Core, "Failed to find title id for ROM (Error {})", load_result);
         }
         perf_stats = std::make_unique<PerfStats>(title_id);
         // Reset counters and set time origin to current frame

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -410,8 +410,9 @@ u8 NCA::GetCryptoRevision() const {
 std::optional<Core::Crypto::Key128> NCA::GetKeyAreaKey(NCASectionCryptoType type) const {
     const auto master_key_id = GetCryptoRevision();
 
-    if (!keys.HasKey(Core::Crypto::S128KeyType::KeyArea, master_key_id, header.key_index))
-        return {};
+    if (!keys.HasKey(Core::Crypto::S128KeyType::KeyArea, master_key_id, header.key_index)) {
+        return std::nullopt;
+    }
 
     std::vector<u8> key_area(header.key_area.begin(), header.key_area.end());
     Core::Crypto::AESCipher<Core::Crypto::Key128> cipher(
@@ -420,15 +421,17 @@ std::optional<Core::Crypto::Key128> NCA::GetKeyAreaKey(NCASectionCryptoType type
     cipher.Transcode(key_area.data(), key_area.size(), key_area.data(), Core::Crypto::Op::Decrypt);
 
     Core::Crypto::Key128 out;
-    if (type == NCASectionCryptoType::XTS)
+    if (type == NCASectionCryptoType::XTS) {
         std::copy(key_area.begin(), key_area.begin() + 0x10, out.begin());
-    else if (type == NCASectionCryptoType::CTR || type == NCASectionCryptoType::BKTR)
+    } else if (type == NCASectionCryptoType::CTR || type == NCASectionCryptoType::BKTR) {
         std::copy(key_area.begin() + 0x20, key_area.begin() + 0x30, out.begin());
-    else
+    } else {
         LOG_CRITICAL(Crypto, "Called GetKeyAreaKey on invalid NCASectionCryptoType type={:02X}",
-                     static_cast<u8>(type));
+                     type);
+    }
+
     u128 out_128{};
-    memcpy(out_128.data(), out.data(), 16);
+    std::memcpy(out_128.data(), out.data(), sizeof(u128));
     LOG_TRACE(Crypto, "called with crypto_rev={:02X}, kak_index={:02X}, key={:016X}{:016X}",
               master_key_id, header.key_index, out_128[1], out_128[0]);
 
@@ -507,7 +510,7 @@ VirtualFile NCA::Decrypt(const NCASectionHeader& s_header, VirtualFile in, u64 s
         // TODO(DarkLordZach): Find a test case for XTS-encrypted NCAs
     default:
         LOG_ERROR(Crypto, "called with unhandled crypto type={:02X}",
-                  static_cast<u8>(s_header.raw.header.crypto_type));
+                  s_header.raw.header.crypto_type);
         return nullptr;
     }
 }

--- a/src/core/frontend/applets/error.cpp
+++ b/src/core/frontend/applets/error.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
 #include "core/frontend/applets/error.h"
 
 namespace Core::Frontend {
@@ -10,7 +11,7 @@ ErrorApplet::~ErrorApplet() = default;
 
 void DefaultErrorApplet::ShowError(ResultCode error, std::function<void()> finished) const {
     LOG_CRITICAL(Service_Fatal, "Application requested error display: {:04}-{:04} (raw={:08X})",
-                 static_cast<u32>(error.module.Value()), error.description.Value(), error.raw);
+                 error.module.Value(), error.description.Value(), error.raw);
 }
 
 void DefaultErrorApplet::ShowErrorWithTimestamp(ResultCode error, std::chrono::seconds time,
@@ -18,7 +19,7 @@ void DefaultErrorApplet::ShowErrorWithTimestamp(ResultCode error, std::chrono::s
     LOG_CRITICAL(
         Service_Fatal,
         "Application requested error display: {:04X}-{:04X} (raw={:08X}) with timestamp={:016X}",
-        static_cast<u32>(error.module.Value()), error.description.Value(), error.raw, time.count());
+        error.module.Value(), error.description.Value(), error.raw, time.count());
 }
 
 void DefaultErrorApplet::ShowCustomErrorText(ResultCode error, std::string main_text,
@@ -26,7 +27,7 @@ void DefaultErrorApplet::ShowCustomErrorText(ResultCode error, std::string main_
                                              std::function<void()> finished) const {
     LOG_CRITICAL(Service_Fatal,
                  "Application requested custom error with error_code={:04X}-{:04X} (raw={:08X})",
-                 static_cast<u32>(error.module.Value()), error.description.Value(), error.raw);
+                 error.module.Value(), error.description.Value(), error.raw);
     LOG_CRITICAL(Service_Fatal, "    Main Text: {}", main_text);
     LOG_CRITICAL(Service_Fatal, "    Detail Text: {}", detail_text);
 }

--- a/src/core/hle/kernel/process_capability.cpp
+++ b/src/core/hle/kernel/process_capability.cpp
@@ -199,7 +199,7 @@ ResultCode ProcessCapabilities::ParseSingleFlagCapability(u32& set_flags, u32& s
         break;
     }
 
-    LOG_ERROR(Kernel, "Invalid capability type! type={}", static_cast<u32>(type));
+    LOG_ERROR(Kernel, "Invalid capability type! type={}", type);
     return ERR_INVALID_CAPABILITY_DESCRIPTOR;
 }
 

--- a/src/core/hle/kernel/resource_limit.cpp
+++ b/src/core/hle/kernel/resource_limit.cpp
@@ -65,8 +65,8 @@ ResultCode ResourceLimit::SetLimitValue(ResourceType resource, s64 value) {
         limit[index] = value;
         return RESULT_SUCCESS;
     } else {
-        LOG_ERROR(Kernel, "Limit value is too large! resource={}, value={}, index={}",
-                  static_cast<u32>(resource), value, index);
+        LOG_ERROR(Kernel, "Limit value is too large! resource={}, value={}, index={}", resource,
+                  value, index);
         return ERR_INVALID_STATE;
     }
 }

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -130,8 +130,7 @@ ResultCode ServerSession::HandleDomainSyncRequest(Kernel::HLERequestContext& con
     }
     }
 
-    LOG_CRITICAL(IPC, "Unknown domain command={}",
-                 static_cast<int>(domain_message_header.command.Value()));
+    LOG_CRITICAL(IPC, "Unknown domain command={}", domain_message_header.command.Value());
     ASSERT(false);
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1092,14 +1092,14 @@ void ILibraryAppletCreator::CreateLibraryApplet(Kernel::HLERequestContext& ctx) 
     const auto applet_id = rp.PopRaw<Applets::AppletId>();
     const auto applet_mode = rp.PopRaw<u32>();
 
-    LOG_DEBUG(Service_AM, "called with applet_id={:08X}, applet_mode={:08X}",
-              static_cast<u32>(applet_id), applet_mode);
+    LOG_DEBUG(Service_AM, "called with applet_id={:08X}, applet_mode={:08X}", applet_id,
+              applet_mode);
 
     const auto& applet_manager{system.GetAppletManager()};
     const auto applet = applet_manager.GetApplet(applet_id);
 
     if (applet == nullptr) {
-        LOG_ERROR(Service_AM, "Applet doesn't exist! applet_id={}", static_cast<u32>(applet_id));
+        LOG_ERROR(Service_AM, "Applet doesn't exist! applet_id={}", applet_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_UNKNOWN);
@@ -1290,7 +1290,7 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto kind = rp.PopEnum<LaunchParameterKind>();
 
-    LOG_DEBUG(Service_AM, "called, kind={:08X}", static_cast<u8>(kind));
+    LOG_DEBUG(Service_AM, "called, kind={:08X}", kind);
 
     if (kind == LaunchParameterKind::ApplicationSpecific && !launch_popped_application_specific) {
         const auto backend = BCAT::CreateBackendFromSettings(system, [this](u64 tid) {
@@ -1537,8 +1537,8 @@ void IApplicationFunctions::GetSaveDataSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto [type, user_id] = rp.PopRaw<Parameters>();
 
-    LOG_DEBUG(Service_AM, "called with type={:02X}, user_id={:016X}{:016X}", static_cast<u8>(type),
-              user_id[1], user_id[0]);
+    LOG_DEBUG(Service_AM, "called with type={:02X}, user_id={:016X}{:016X}", type, user_id[1],
+              user_id[0]);
 
     const auto size = system.GetFileSystemController().ReadSaveDataSize(
         type, system.CurrentProcess()->GetTitleID(), user_id);

--- a/src/core/hle/service/am/applets/error.cpp
+++ b/src/core/hle/service/am/applets/error.cpp
@@ -125,7 +125,7 @@ void Error::Initialize() {
         error_code = Decode64BitError(args->error_record.error_code_64);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented LibAppletError mode={:02X}!", static_cast<u8>(mode));
+        UNIMPLEMENTED_MSG("Unimplemented LibAppletError mode={:02X}!", mode);
     }
 }
 
@@ -179,7 +179,7 @@ void Error::Execute() {
             error_code, std::chrono::seconds{args->error_record.posix_time}, callback);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented LibAppletError mode={:02X}!", static_cast<u8>(mode));
+        UNIMPLEMENTED_MSG("Unimplemented LibAppletError mode={:02X}!", mode);
         DisplayCompleted();
     }
 }

--- a/src/core/hle/service/am/applets/general_backend.cpp
+++ b/src/core/hle/service/am/applets/general_backend.cpp
@@ -90,7 +90,7 @@ void Auth::Execute() {
     const auto unimplemented_log = [this] {
         UNIMPLEMENTED_MSG("Unimplemented Auth applet type for type={:08X}, arg0={:02X}, "
                           "arg1={:02X}, arg2={:02X}",
-                          static_cast<u32>(type), arg0, arg1, arg2);
+                          type, arg0, arg1, arg2);
     };
 
     switch (type) {
@@ -193,7 +193,7 @@ void PhotoViewer::Execute() {
         frontend.ShowAllPhotos(callback);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented PhotoViewer applet mode={:02X}!", static_cast<u8>(mode));
+        UNIMPLEMENTED_MSG("Unimplemented PhotoViewer applet mode={:02X}!", mode);
     }
 }
 

--- a/src/core/hle/service/apm/controller.cpp
+++ b/src/core/hle/service/apm/controller.cpp
@@ -48,8 +48,7 @@ void Controller::SetPerformanceConfiguration(PerformanceMode mode,
                                    [config](const auto& entry) { return entry.first == config; });
 
     if (iter == config_to_speed.cend()) {
-        LOG_ERROR(Service_APM, "Invalid performance configuration value provided: {}",
-                  static_cast<u32>(config));
+        LOG_ERROR(Service_APM, "Invalid performance configuration value provided: {}", config);
         return;
     }
 

--- a/src/core/hle/service/apm/interface.cpp
+++ b/src/core/hle/service/apm/interface.cpp
@@ -28,8 +28,7 @@ private:
 
         const auto mode = rp.PopEnum<PerformanceMode>();
         const auto config = rp.PopEnum<PerformanceConfiguration>();
-        LOG_DEBUG(Service_APM, "called mode={} config={}", static_cast<u32>(mode),
-                  static_cast<u32>(config));
+        LOG_DEBUG(Service_APM, "called mode={} config={}", mode, config);
 
         controller.SetPerformanceConfiguration(mode, config);
 
@@ -41,7 +40,7 @@ private:
         IPC::RequestParser rp{ctx};
 
         const auto mode = rp.PopEnum<PerformanceMode>();
-        LOG_DEBUG(Service_APM, "called mode={}", static_cast<u32>(mode));
+        LOG_DEBUG(Service_APM, "called mode={}", mode);
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -111,7 +110,7 @@ void APM_Sys::SetCpuBoostMode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto mode = rp.PopEnum<CpuBoostMode>();
 
-    LOG_DEBUG(Service_APM, "called, mode={:08X}", static_cast<u32>(mode));
+    LOG_DEBUG(Service_APM, "called, mode={:08X}", mode);
 
     controller.SetFromCpuBoostMode(mode);
 

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -111,8 +111,9 @@ static void GenerateErrorReport(Core::System& system, ResultCode error_code,
 
 static void ThrowFatalError(Core::System& system, ResultCode error_code, FatalType fatal_type,
                             const FatalInfo& info) {
-    LOG_ERROR(Service_Fatal, "Threw fatal error type {} with error code 0x{:X}",
-              static_cast<u32>(fatal_type), error_code.raw);
+    LOG_ERROR(Service_Fatal, "Threw fatal error type {} with error code 0x{:X}", fatal_type,
+              error_code.raw);
+
     switch (fatal_type) {
     case FatalType::ErrorReportAndScreen:
         GenerateErrorReport(system, error_code, info);

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -301,7 +301,7 @@ ResultVal<FileSys::VirtualFile> FileSystemController::OpenRomFSCurrentProcess() 
 ResultVal<FileSys::VirtualFile> FileSystemController::OpenRomFS(
     u64 title_id, FileSys::StorageId storage_id, FileSys::ContentRecordType type) const {
     LOG_TRACE(Service_FS, "Opening RomFS for title_id={:016X}, storage_id={:02X}, type={:02X}",
-              title_id, static_cast<u8>(storage_id), static_cast<u8>(type));
+              title_id, storage_id, type);
 
     if (romfs_factory == nullptr) {
         // TODO(bunnei): Find a better error code for this
@@ -313,8 +313,8 @@ ResultVal<FileSys::VirtualFile> FileSystemController::OpenRomFS(
 
 ResultVal<FileSys::VirtualDir> FileSystemController::CreateSaveData(
     FileSys::SaveDataSpaceId space, const FileSys::SaveDataAttribute& save_struct) const {
-    LOG_TRACE(Service_FS, "Creating Save Data for space_id={:01X}, save_struct={}",
-              static_cast<u8>(space), save_struct.DebugInfo());
+    LOG_TRACE(Service_FS, "Creating Save Data for space_id={:01X}, save_struct={}", space,
+              save_struct.DebugInfo());
 
     if (save_data_factory == nullptr) {
         return FileSys::ERROR_ENTITY_NOT_FOUND;
@@ -325,8 +325,8 @@ ResultVal<FileSys::VirtualDir> FileSystemController::CreateSaveData(
 
 ResultVal<FileSys::VirtualDir> FileSystemController::OpenSaveData(
     FileSys::SaveDataSpaceId space, const FileSys::SaveDataAttribute& attribute) const {
-    LOG_TRACE(Service_FS, "Opening Save Data for space_id={:01X}, save_struct={}",
-              static_cast<u8>(space), attribute.DebugInfo());
+    LOG_TRACE(Service_FS, "Opening Save Data for space_id={:01X}, save_struct={}", space,
+              attribute.DebugInfo());
 
     if (save_data_factory == nullptr) {
         return FileSys::ERROR_ENTITY_NOT_FOUND;
@@ -337,7 +337,7 @@ ResultVal<FileSys::VirtualDir> FileSystemController::OpenSaveData(
 
 ResultVal<FileSys::VirtualDir> FileSystemController::OpenSaveDataSpace(
     FileSys::SaveDataSpaceId space) const {
-    LOG_TRACE(Service_FS, "Opening Save Data Space for space_id={:01X}", static_cast<u8>(space));
+    LOG_TRACE(Service_FS, "Opening Save Data Space for space_id={:01X}", space);
 
     if (save_data_factory == nullptr) {
         return FileSys::ERROR_ENTITY_NOT_FOUND;
@@ -358,7 +358,7 @@ ResultVal<FileSys::VirtualDir> FileSystemController::OpenSDMC() const {
 
 ResultVal<FileSys::VirtualDir> FileSystemController::OpenBISPartition(
     FileSys::BisPartitionId id) const {
-    LOG_TRACE(Service_FS, "Opening BIS Partition with id={:08X}", static_cast<u32>(id));
+    LOG_TRACE(Service_FS, "Opening BIS Partition with id={:08X}", id);
 
     if (bis_factory == nullptr) {
         return FileSys::ERROR_ENTITY_NOT_FOUND;
@@ -374,7 +374,7 @@ ResultVal<FileSys::VirtualDir> FileSystemController::OpenBISPartition(
 
 ResultVal<FileSys::VirtualFile> FileSystemController::OpenBISPartitionStorage(
     FileSys::BisPartitionId id) const {
-    LOG_TRACE(Service_FS, "Opening BIS Partition Storage with id={:08X}", static_cast<u32>(id));
+    LOG_TRACE(Service_FS, "Opening BIS Partition Storage with id={:08X}", id);
 
     if (bis_factory == nullptr) {
         return FileSys::ERROR_ENTITY_NOT_FOUND;

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -413,7 +413,7 @@ public:
 
         const auto mode = static_cast<FileSys::Mode>(rp.Pop<u32>());
 
-        LOG_DEBUG(Service_FS, "called. file={}, mode={}", name, static_cast<u32>(mode));
+        LOG_DEBUG(Service_FS, "called. file={}, mode={}", name, mode);
 
         auto result = backend.OpenFile(name, mode);
         if (result.Failed()) {
@@ -553,8 +553,7 @@ private:
         const auto save_root = fsc.OpenSaveDataSpace(space);
 
         if (save_root.Failed() || *save_root == nullptr) {
-            LOG_ERROR(Service_FS, "The save root for the space_id={:02X} was invalid!",
-                      static_cast<u8>(space));
+            LOG_ERROR(Service_FS, "The save root for the space_id={:02X} was invalid!", space);
             return;
         }
 
@@ -795,8 +794,7 @@ void FSP_SRV::OpenFileSystemWithPatch(Kernel::HLERequestContext& ctx) {
 
     const auto type = rp.PopRaw<FileSystemType>();
     const auto title_id = rp.PopRaw<u64>();
-    LOG_WARNING(Service_FS, "(STUBBED) called with type={}, title_id={:016X}",
-                static_cast<u8>(type), title_id);
+    LOG_WARNING(Service_FS, "(STUBBED) called with type={}, title_id={:016X}", type, title_id);
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 0};
     rb.Push(RESULT_UNKNOWN);
@@ -883,7 +881,7 @@ void FSP_SRV::OpenReadOnlySaveDataFileSystem(Kernel::HLERequestContext& ctx) {
 void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto space = rp.PopRaw<FileSys::SaveDataSpaceId>();
-    LOG_INFO(Service_FS, "called, space={}", static_cast<u8>(space));
+    LOG_INFO(Service_FS, "called, space={}", space);
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
@@ -915,10 +913,10 @@ void FSP_SRV::ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(
                 "(STUBBED) called, flags={}, space_id={}, attribute.title_id={:016X}\n"
                 "attribute.user_id={:016X}{:016X}, attribute.save_id={:016X}\n"
                 "attribute.type={}, attribute.rank={}, attribute.index={}",
-                flags, static_cast<u32>(parameters.space_id), parameters.attribute.title_id,
+                flags, parameters.space_id, parameters.attribute.title_id,
                 parameters.attribute.user_id[1], parameters.attribute.user_id[0],
-                parameters.attribute.save_id, static_cast<u32>(parameters.attribute.type),
-                static_cast<u32>(parameters.attribute.rank), parameters.attribute.index);
+                parameters.attribute.save_id, parameters.attribute.type, parameters.attribute.rank,
+                parameters.attribute.index);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -951,7 +949,7 @@ void FSP_SRV::OpenDataStorageByDataId(Kernel::HLERequestContext& ctx) {
     const auto title_id = rp.PopRaw<u64>();
 
     LOG_DEBUG(Service_FS, "called with storage_id={:02X}, unknown={:08X}, title_id={:016X}",
-              static_cast<u8>(storage_id), unknown, title_id);
+              storage_id, unknown, title_id);
 
     auto data = fsc.OpenRomFS(title_id, storage_id, FileSys::ContentRecordType::Data);
 
@@ -968,7 +966,7 @@ void FSP_SRV::OpenDataStorageByDataId(Kernel::HLERequestContext& ctx) {
         // TODO(DarkLordZach): Find the right error code to use here
         LOG_ERROR(Service_FS,
                   "could not open data storage with title_id={:016X}, storage_id={:02X}", title_id,
-                  static_cast<u8>(storage_id));
+                  storage_id);
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_UNKNOWN);
         return;
@@ -987,11 +985,10 @@ void FSP_SRV::OpenDataStorageByDataId(Kernel::HLERequestContext& ctx) {
 void FSP_SRV::OpenPatchDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 
-    auto storage_id = rp.PopRaw<FileSys::StorageId>();
-    auto title_id = rp.PopRaw<u64>();
+    const auto storage_id = rp.PopRaw<FileSys::StorageId>();
+    const auto title_id = rp.PopRaw<u64>();
 
-    LOG_DEBUG(Service_FS, "called with storage_id={:02X}, title_id={:016X}",
-              static_cast<u8>(storage_id), title_id);
+    LOG_DEBUG(Service_FS, "called with storage_id={:02X}, title_id={:016X}", storage_id, title_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(FileSys::ERROR_ENTITY_NOT_FOUND);
@@ -1001,7 +998,7 @@ void FSP_SRV::SetGlobalAccessLogMode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     log_mode = rp.PopEnum<LogMode>();
 
-    LOG_DEBUG(Service_FS, "called, log_mode={:08X}", static_cast<u32>(log_mode));
+    LOG_DEBUG(Service_FS, "called, log_mode={:08X}", log_mode);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -229,8 +229,7 @@ private:
             break;
         default:
             // HOS seems not have an error case for an unknown notification
-            LOG_WARNING(Service_ACC, "Unknown notification {:08X}",
-                        static_cast<u32>(notification.notification_type));
+            LOG_WARNING(Service_ACC, "Unknown notification {:08X}", notification.notification_type);
             break;
         }
 

--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -68,7 +68,7 @@ private:
         IPC::RequestParser rp{ctx};
         const auto destination = rp.PopEnum<DestinationFlag>();
 
-        LOG_DEBUG(Service_LM, "called, destination={:08X}", static_cast<u32>(destination));
+        LOG_DEBUG(Service_LM, "called, destination={:08X}", destination);
 
         manager.SetDestination(destination);
 

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -182,21 +182,18 @@ PL_U::PL_U(Core::System& system_)
         }
 
         if (!romfs) {
-            LOG_ERROR(Service_NS, "Failed to find or synthesize {:016X}! Skipping",
-                      static_cast<u64>(font.first));
+            LOG_ERROR(Service_NS, "Failed to find or synthesize {:016X}! Skipping", font.first);
             continue;
         }
 
         const auto extracted_romfs = FileSys::ExtractRomFS(romfs);
         if (!extracted_romfs) {
-            LOG_ERROR(Service_NS, "Failed to extract RomFS for {:016X}! Skipping",
-                      static_cast<u64>(font.first));
+            LOG_ERROR(Service_NS, "Failed to extract RomFS for {:016X}! Skipping", font.first);
             continue;
         }
         const auto font_fp = extracted_romfs->GetFile(font.second);
         if (!font_fp) {
-            LOG_ERROR(Service_NS, "{:016X} has no file \"{}\"! Skipping",
-                      static_cast<u64>(font.first), font.second);
+            LOG_ERROR(Service_NS, "{:016X} has no file \"{}\"! Skipping", font.first, font.second);
             continue;
         }
         std::vector<u32> font_data_u32(font_fp->GetSize() / sizeof(u32));

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -153,7 +153,7 @@ void BufferQueue::Disconnect() {
 }
 
 u32 BufferQueue::Query(QueryType type) {
-    LOG_WARNING(Service, "(STUBBED) called type={}", static_cast<u32>(type));
+    LOG_WARNING(Service, "(STUBBED) called type={}", type);
 
     switch (type) {
     case QueryType::NativeWindowFormat:

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -65,7 +65,7 @@ private:
         }
 
         LOG_DEBUG(Service_PREPO, "called, type={:02X}, process_id={:016X}, data1_size={:016X}",
-                  static_cast<u8>(Type), process_id, data[0].size());
+                  Type, process_id, data[0].size());
 
         const auto& reporter{system.GetReporter()};
         reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), data, process_id);
@@ -92,7 +92,7 @@ private:
         LOG_DEBUG(
             Service_PREPO,
             "called, type={:02X}, user_id={:016X}{:016X}, process_id={:016X}, data1_size={:016X}",
-            static_cast<u8>(Type), user_id[1], user_id[0], process_id, data[0].size());
+            Type, user_id[1], user_id[0], process_id, data[0].size());
 
         const auto& reporter{system.GetReporter()};
         reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), data, process_id,

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -181,7 +181,7 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
         break;
     }
     default:
-        UNIMPLEMENTED_MSG("command_type={}", static_cast<int>(context.GetCommandType()));
+        UNIMPLEMENTED_MSG("command_type={}", context.GetCommandType());
     }
 
     context.WriteToOutgoingCommandBuffer(context.GetThread());

--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -34,9 +34,9 @@ void GetFirmwareVersionImpl(Kernel::HLERequestContext& ctx, GetFirmwareVersionTy
     // consistence (currently reports as 5.1.0-0.0)
     const auto archive = FileSys::SystemArchive::SystemVersion();
 
-    const auto early_exit_failure = [&ctx](const std::string& desc, ResultCode code) {
+    const auto early_exit_failure = [&ctx](std::string_view desc, ResultCode code) {
         LOG_ERROR(Service_SET, "General failure while attempting to resolve firmware version ({}).",
-                  desc.c_str());
+                  desc);
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(code);
     };

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -30,7 +30,7 @@ bool IsConnectionBased(Type type) {
     case Type::DGRAM:
         return false;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented type={}", static_cast<int>(type));
+        UNIMPLEMENTED_MSG("Unimplemented type={}", type);
         return false;
     }
 }
@@ -636,7 +636,7 @@ std::pair<s32, Errno> BSD::FcntlImpl(s32 fd, FcntlCmd cmd, s32 arg) {
         return {0, Errno::SUCCESS};
     }
     default:
-        UNIMPLEMENTED_MSG("Unimplemented cmd={}", static_cast<int>(cmd));
+        UNIMPLEMENTED_MSG("Unimplemented cmd={}", cmd);
         return {-1, Errno::SUCCESS};
     }
 }
@@ -679,7 +679,7 @@ Errno BSD::SetSockOptImpl(s32 fd, u32 level, OptName optname, size_t optlen, con
     case OptName::RCVTIMEO:
         return Translate(socket->SetRcvTimeo(value));
     default:
-        UNIMPLEMENTED_MSG("Unimplemented optname={}", static_cast<int>(optname));
+        UNIMPLEMENTED_MSG("Unimplemented optname={}", optname);
         return Errno::SUCCESS;
     }
 }

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -27,7 +27,7 @@ Errno Translate(Network::Errno value) {
     case Network::Errno::NOTCONN:
         return Errno::NOTCONN;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented errno={}", static_cast<int>(value));
+        UNIMPLEMENTED_MSG("Unimplemented errno={}", value);
         return Errno::SUCCESS;
     }
 }
@@ -41,7 +41,7 @@ Network::Domain Translate(Domain domain) {
     case Domain::INET:
         return Network::Domain::INET;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented domain={}", static_cast<int>(domain));
+        UNIMPLEMENTED_MSG("Unimplemented domain={}", domain);
         return {};
     }
 }
@@ -51,7 +51,7 @@ Domain Translate(Network::Domain domain) {
     case Network::Domain::INET:
         return Domain::INET;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented domain={}", static_cast<int>(domain));
+        UNIMPLEMENTED_MSG("Unimplemented domain={}", domain);
         return {};
     }
 }
@@ -63,7 +63,7 @@ Network::Type Translate(Type type) {
     case Type::DGRAM:
         return Network::Type::DGRAM;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented type={}", static_cast<int>(type));
+        UNIMPLEMENTED_MSG("Unimplemented type={}", type);
     }
 }
 
@@ -84,7 +84,7 @@ Network::Protocol Translate(Type type, Protocol protocol) {
     case Protocol::UDP:
         return Network::Protocol::UDP;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented protocol={}", static_cast<int>(protocol));
+        UNIMPLEMENTED_MSG("Unimplemented protocol={}", protocol);
         return Network::Protocol::TCP;
     }
 }
@@ -157,7 +157,7 @@ Network::ShutdownHow Translate(ShutdownHow how) {
     case ShutdownHow::RDWR:
         return Network::ShutdownHow::RDWR;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented how={}", static_cast<int>(how));
+        UNIMPLEMENTED_MSG("Unimplemented how={}", how);
         return {};
     }
 }

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -528,7 +528,7 @@ private:
         const u32 flags = rp.Pop<u32>();
 
         LOG_DEBUG(Service_VI, "called. id=0x{:08X} transaction={:X}, flags=0x{:08X}", id,
-                  static_cast<u32>(transaction), flags);
+                  transaction, flags);
 
         const auto guard = nv_flinger.Lock();
         auto& buffer_queue = nv_flinger.FindBufferQueue(id);
@@ -1066,8 +1066,8 @@ private:
         const auto scaling_mode = rp.PopEnum<NintendoScaleMode>();
         const u64 unknown = rp.Pop<u64>();
 
-        LOG_DEBUG(Service_VI, "called. scaling_mode=0x{:08X}, unknown=0x{:016X}",
-                  static_cast<u32>(scaling_mode), unknown);
+        LOG_DEBUG(Service_VI, "called. scaling_mode=0x{:08X}, unknown=0x{:016X}", scaling_mode,
+                  unknown);
 
         IPC::ResponseBuilder rb{ctx, 2};
 
@@ -1210,7 +1210,7 @@ private:
     void ConvertScalingMode(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto mode = rp.PopEnum<NintendoScaleMode>();
-        LOG_DEBUG(Service_VI, "called mode={}", static_cast<u32>(mode));
+        LOG_DEBUG(Service_VI, "called mode={}", mode);
 
         const auto converted_mode = ConvertScalingModeImpl(mode);
 
@@ -1311,7 +1311,7 @@ void detail::GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, Core::System&
     const auto policy = rp.PopEnum<Policy>();
 
     if (!IsValidServiceAccess(permission, policy)) {
-        LOG_ERROR(Service_VI, "Permission denied for policy {}", static_cast<u32>(policy));
+        LOG_ERROR(Service_VI, "Permission denied for policy {}", policy);
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ERR_PERMISSION_DENIED);
         return;

--- a/src/core/network/network.cpp
+++ b/src/core/network/network.cpp
@@ -63,7 +63,7 @@ sockaddr TranslateFromSockAddrIn(SockAddrIn input) {
         result.sin_family = AF_INET;
         break;
     default:
-        UNIMPLEMENTED_MSG("Unhandled sockaddr family={}", static_cast<int>(input.family));
+        UNIMPLEMENTED_MSG("Unhandled sockaddr family={}", input.family);
         result.sin_family = AF_INET;
         break;
     }
@@ -133,7 +133,7 @@ sockaddr TranslateFromSockAddrIn(SockAddrIn input) {
         result.sin_family = AF_INET;
         break;
     default:
-        UNIMPLEMENTED_MSG("Unhandled sockaddr family={}", static_cast<int>(input.family));
+        UNIMPLEMENTED_MSG("Unhandled sockaddr family={}", input.family);
         result.sin_family = AF_INET;
         break;
     }
@@ -186,7 +186,7 @@ int TranslateDomain(Domain domain) {
     case Domain::INET:
         return AF_INET;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented domain={}", static_cast<int>(domain));
+        UNIMPLEMENTED_MSG("Unimplemented domain={}", domain);
         return 0;
     }
 }
@@ -198,7 +198,7 @@ int TranslateType(Type type) {
     case Type::DGRAM:
         return SOCK_DGRAM;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented type={}", static_cast<int>(type));
+        UNIMPLEMENTED_MSG("Unimplemented type={}", type);
         return 0;
     }
 }
@@ -210,7 +210,7 @@ int TranslateProtocol(Protocol protocol) {
     case Protocol::UDP:
         return IPPROTO_UDP;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented protocol={}", static_cast<int>(protocol));
+        UNIMPLEMENTED_MSG("Unimplemented protocol={}", protocol);
         return 0;
     }
 }
@@ -482,7 +482,7 @@ Errno Socket::Shutdown(ShutdownHow how) {
         host_how = SD_BOTH;
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented flag how={}", static_cast<int>(how));
+        UNIMPLEMENTED_MSG("Unimplemented flag how={}", how);
         return Errno::SUCCESS;
     }
     if (shutdown(fd, host_how) != SOCKET_ERROR) {


### PR DESCRIPTION
Follows the video core PR. fmt doesn't require casts for enum classes
anymore, so we can remove quite a few casts.