### PR TITLE
svc: Remove unnecessary casts

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -234,8 +234,7 @@ static ResultCode SetMemoryAttribute(Core::System& system, VAddr address, u64 si
 
 static ResultCode SetMemoryAttribute32(Core::System& system, u32 address, u32 size, u32 mask,
                                        u32 attribute) {
-    return SetMemoryAttribute(system, static_cast<VAddr>(address), static_cast<std::size_t>(size),
-                              mask, attribute);
+    return SetMemoryAttribute(system, address, size, mask, attribute);
 }
 
 /// Maps a memory range into a different range.
@@ -255,8 +254,7 @@ static ResultCode MapMemory(Core::System& system, VAddr dst_addr, VAddr src_addr
 }
 
 static ResultCode MapMemory32(Core::System& system, u32 dst_addr, u32 src_addr, u32 size) {
-    return MapMemory(system, static_cast<VAddr>(dst_addr), static_cast<VAddr>(src_addr),
-                     static_cast<std::size_t>(size));
+    return MapMemory(system, dst_addr, src_addr, size);
 }
 
 /// Unmaps a region that was previously mapped with svcMapMemory
@@ -276,8 +274,7 @@ static ResultCode UnmapMemory(Core::System& system, VAddr dst_addr, VAddr src_ad
 }
 
 static ResultCode UnmapMemory32(Core::System& system, u32 dst_addr, u32 src_addr, u32 size) {
-    return UnmapMemory(system, static_cast<VAddr>(dst_addr), static_cast<VAddr>(src_addr),
-                       static_cast<std::size_t>(size));
+    return UnmapMemory(system, dst_addr, src_addr, size);
 }
 
 /// Connect to an OS service given the port name, returns the handle to the port to out
@@ -531,8 +528,7 @@ static ResultCode ArbitrateLock(Core::System& system, Handle holding_thread_hand
 
 static ResultCode ArbitrateLock32(Core::System& system, Handle holding_thread_handle,
                                   u32 mutex_addr, Handle requesting_thread_handle) {
-    return ArbitrateLock(system, holding_thread_handle, static_cast<VAddr>(mutex_addr),
-                         requesting_thread_handle);
+    return ArbitrateLock(system, holding_thread_handle, mutex_addr, requesting_thread_handle);
 }
 
 /// Unlock a mutex
@@ -555,7 +551,7 @@ static ResultCode ArbitrateUnlock(Core::System& system, VAddr mutex_addr) {
 }
 
 static ResultCode ArbitrateUnlock32(Core::System& system, u32 mutex_addr) {
-    return ArbitrateUnlock(system, static_cast<VAddr>(mutex_addr));
+    return ArbitrateUnlock(system, mutex_addr);
 }
 
 enum class BreakType : u32 {
@@ -677,7 +673,7 @@ static void Break(Core::System& system, u32 reason, u64 info1, u64 info2) {
 }
 
 static void Break32(Core::System& system, u32 reason, u32 info1, u32 info2) {
-    Break(system, reason, static_cast<u64>(info1), static_cast<u64>(info2));
+    Break(system, reason, info1, info2);
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit
@@ -948,7 +944,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
 
 static ResultCode GetInfo32(Core::System& system, u32* result_low, u32* result_high, u32 sub_id_low,
                             u32 info_id, u32 handle, u32 sub_id_high) {
-    const u64 sub_id{static_cast<u64>(sub_id_low | (static_cast<u64>(sub_id_high) << 32))};
+    const u64 sub_id{u64{sub_id_low} | (u64{sub_id_high} << 32)};
     u64 res_value{};
 
     const ResultCode result{GetInfo(system, &res_value, info_id, handle, sub_id)};
@@ -1009,7 +1005,7 @@ static ResultCode MapPhysicalMemory(Core::System& system, VAddr addr, u64 size) 
 }
 
 static ResultCode MapPhysicalMemory32(Core::System& system, u32 addr, u32 size) {
-    return MapPhysicalMemory(system, static_cast<VAddr>(addr), static_cast<std::size_t>(size));
+    return MapPhysicalMemory(system, addr, size);
 }
 
 /// Unmaps memory previously mapped via MapPhysicalMemory
@@ -1063,7 +1059,7 @@ static ResultCode UnmapPhysicalMemory(Core::System& system, VAddr addr, u64 size
 }
 
 static ResultCode UnmapPhysicalMemory32(Core::System& system, u32 addr, u32 size) {
-    return UnmapPhysicalMemory(system, static_cast<VAddr>(addr), static_cast<std::size_t>(size));
+    return UnmapPhysicalMemory(system, addr, size);
 }
 
 /// Sets the thread activity
@@ -1144,7 +1140,7 @@ static ResultCode GetThreadContext(Core::System& system, VAddr thread_context, H
 }
 
 static ResultCode GetThreadContext32(Core::System& system, u32 thread_context, Handle handle) {
-    return GetThreadContext(system, static_cast<VAddr>(thread_context), handle);
+    return GetThreadContext(system, thread_context, handle);
 }
 
 /// Gets the priority for the specified thread
@@ -1281,8 +1277,7 @@ static ResultCode MapSharedMemory(Core::System& system, Handle shared_memory_han
 
 static ResultCode MapSharedMemory32(Core::System& system, Handle shared_memory_handle, u32 addr,
                                     u32 size, u32 permissions) {
-    return MapSharedMemory(system, shared_memory_handle, static_cast<VAddr>(addr),
-                           static_cast<std::size_t>(size), permissions);
+    return MapSharedMemory(system, shared_memory_handle, addr, size, permissions);
 }
 
 static ResultCode QueryProcessMemory(Core::System& system, VAddr memory_info_address,
@@ -1552,8 +1547,7 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
 
 static ResultCode CreateThread32(Core::System& system, Handle* out_handle, u32 priority,
                                  u32 entry_point, u32 arg, u32 stack_top, s32 processor_id) {
-    return CreateThread(system, out_handle, static_cast<VAddr>(entry_point), static_cast<u64>(arg),
-                        static_cast<VAddr>(stack_top), priority, processor_id);
+    return CreateThread(system, out_handle, entry_point, arg, stack_top, priority, processor_id);
 }
 
 /// Starts the thread for the provided handle
@@ -1637,8 +1631,7 @@ static void SleepThread(Core::System& system, s64 nanoseconds) {
 }
 
 static void SleepThread32(Core::System& system, u32 nanoseconds_low, u32 nanoseconds_high) {
-    const s64 nanoseconds = static_cast<s64>(static_cast<u64>(nanoseconds_low) |
-                                             (static_cast<u64>(nanoseconds_high) << 32));
+    const auto nanoseconds = static_cast<s64>(u64{nanoseconds_low} | (u64{nanoseconds_high} << 32));
     SleepThread(system, nanoseconds);
 }
 
@@ -1724,10 +1717,8 @@ static ResultCode WaitProcessWideKeyAtomic(Core::System& system, VAddr mutex_add
 static ResultCode WaitProcessWideKeyAtomic32(Core::System& system, u32 mutex_addr,
                                              u32 condition_variable_addr, Handle thread_handle,
                                              u32 nanoseconds_low, u32 nanoseconds_high) {
-    const s64 nanoseconds =
-        static_cast<s64>(nanoseconds_low | (static_cast<u64>(nanoseconds_high) << 32));
-    return WaitProcessWideKeyAtomic(system, static_cast<VAddr>(mutex_addr),
-                                    static_cast<VAddr>(condition_variable_addr), thread_handle,
+    const auto nanoseconds = static_cast<s64>(nanoseconds_low | (u64{nanoseconds_high} << 32));
+    return WaitProcessWideKeyAtomic(system, mutex_addr, condition_variable_addr, thread_handle,
                                     nanoseconds);
 }
 
@@ -1833,8 +1824,8 @@ static ResultCode WaitForAddress(Core::System& system, VAddr address, u32 type, 
 
 static ResultCode WaitForAddress32(Core::System& system, u32 address, u32 type, s32 value,
                                    u32 timeout_low, u32 timeout_high) {
-    s64 timeout = static_cast<s64>(timeout_low | (static_cast<u64>(timeout_high) << 32));
-    return WaitForAddress(system, static_cast<VAddr>(address), type, value, timeout);
+    const auto timeout = static_cast<s64>(timeout_low | (u64{timeout_high} << 32));
+    return WaitForAddress(system, address, type, value, timeout);
 }
 
 // Signals to an address (via Address Arbiter)
@@ -1862,7 +1853,7 @@ static ResultCode SignalToAddress(Core::System& system, VAddr address, u32 type,
 
 static ResultCode SignalToAddress32(Core::System& system, u32 address, u32 type, s32 value,
                                     s32 num_to_wake) {
-    return SignalToAddress(system, static_cast<VAddr>(address), type, value, num_to_wake);
+    return SignalToAddress(system, address, type, value, num_to_wake);
 }
 
 static void KernelDebug([[maybe_unused]] Core::System& system,
@@ -1893,7 +1884,7 @@ static u64 GetSystemTick(Core::System& system) {
 }
 
 static void GetSystemTick32(Core::System& system, u32* time_low, u32* time_high) {
-    u64 time = GetSystemTick(system);
+    const auto time = GetSystemTick(system);
     *time_low = static_cast<u32>(time);
     *time_high = static_cast<u32>(time >> 32);
 }
@@ -1984,8 +1975,7 @@ static ResultCode CreateTransferMemory(Core::System& system, Handle* handle, VAd
 
 static ResultCode CreateTransferMemory32(Core::System& system, Handle* handle, u32 addr, u32 size,
                                          u32 permissions) {
-    return CreateTransferMemory(system, handle, static_cast<VAddr>(addr),
-                                static_cast<std::size_t>(size), permissions);
+    return CreateTransferMemory(system, handle, addr, size, permissions);
 }
 
 static ResultCode GetThreadCoreMask(Core::System& system, Handle thread_handle, u32* core,
@@ -2075,8 +2065,7 @@ static ResultCode SetThreadCoreMask(Core::System& system, Handle thread_handle, 
 
 static ResultCode SetThreadCoreMask32(Core::System& system, Handle thread_handle, u32 core,
                                       u32 affinity_mask_low, u32 affinity_mask_high) {
-    const u64 affinity_mask =
-        static_cast<u64>(affinity_mask_low) | (static_cast<u64>(affinity_mask_high) << 32);
+    const auto affinity_mask = u64{affinity_mask_low} | (u64{affinity_mask_high} << 32);
     return SetThreadCoreMask(system, thread_handle, core, affinity_mask);
 }
 
@@ -2341,9 +2330,10 @@ static ResultCode GetThreadList(Core::System& system, u32* out_num_threads, VAdd
     return RESULT_SUCCESS;
 }
 
-static ResultCode FlushProcessDataCache32(Core::System& system, Handle handle, u32 address,
-                                          u32 size) {
-    // Note(Blinkhawk): For emulation purposes of the data cache this is mostly a nope
+static ResultCode FlushProcessDataCache32([[maybe_unused]] Core::System& system,
+                                          [[maybe_unused]] Handle handle,
+                                          [[maybe_unused]] u32 address, [[maybe_unused]] u32 size) {
+    // Note(Blinkhawk): For emulation purposes of the data cache this is mostly a no-op,
     // as all emulation is done in the same cache level in host architecture, thus data cache
     // does not need flushing.
     LOG_DEBUG(Kernel_SVC, "called");


### PR DESCRIPTION
Simplifies and removes some casts. In all cases, these were generally
widening from a 32-bit unsigned type to a 64-bit unsigned type, so no
information would be lost from the conversion.