### PR TITLE
common/file_util: Let std::filesystem cast from UTF16 to std::string

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -239,7 +239,7 @@ bool ForeachDirectoryEntry(u64* num_entries_out, const std::string& directory,
     }
     // windows loop
     do {
-        const std::string virtual_name(Common::UTF16ToUTF8(ffd.cFileName));
+        const std::string virtual_name = std::filesystem::path(ffd.cFileName).string();
 #else
     DIR* dirp = opendir(directory.c_str());
     if (!dirp)


### PR DESCRIPTION
Fix invalid encoding paths when iterating over a directory on Windows.