### PR TITLE
vfs: Use existing type aliases consistently

### DIFF
--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -519,15 +519,17 @@ Loader::ResultStatus NCA::GetStatus() const {
     return status;
 }
 
-std::vector<std::shared_ptr<VfsFile>> NCA::GetFiles() const {
-    if (status != Loader::ResultStatus::Success)
+std::vector<VirtualFile> NCA::GetFiles() const {
+    if (status != Loader::ResultStatus::Success) {
         return {};
+    }
     return files;
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> NCA::GetSubdirectories() const {
-    if (status != Loader::ResultStatus::Success)
+std::vector<VirtualDir> NCA::GetSubdirectories() const {
+    if (status != Loader::ResultStatus::Success) {
         return {};
+    }
     return dirs;
 }
 
@@ -535,7 +537,7 @@ std::string NCA::GetName() const {
     return file->GetName();
 }
 
-std::shared_ptr<VfsDirectory> NCA::GetParentDirectory() const {
+VirtualDir NCA::GetParentDirectory() const {
     return file->GetContainingDirectory();
 }
 

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -82,7 +82,7 @@ struct NCAHeader {
 };
 static_assert(sizeof(NCAHeader) == 0x400, "NCAHeader has incorrect size.");
 
-inline bool IsDirectoryExeFS(const std::shared_ptr<VfsDirectory>& pfs) {
+inline bool IsDirectoryExeFS(const VirtualDir& pfs) {
     // According to switchbrew, an exefs must only contain these two files:
     return pfs->GetFile("main") != nullptr && pfs->GetFile("main.npdm") != nullptr;
 }
@@ -104,10 +104,10 @@ public:
 
     Loader::ResultStatus GetStatus() const;
 
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualFile> GetFiles() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
     std::string GetName() const override;
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
+    VirtualDir GetParentDirectory() const override;
 
     NCAContentType GetType() const;
     u64 GetTitleId() const;

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -191,7 +191,7 @@ bool BKTR::Resize(std::size_t new_size) {
     return false;
 }
 
-std::shared_ptr<VfsDirectory> BKTR::GetContainingDirectory() const {
+VirtualDir BKTR::GetContainingDirectory() const {
     return base_romfs->GetContainingDirectory();
 }
 

--- a/src/core/file_sys/nca_patch.h
+++ b/src/core/file_sys/nca_patch.h
@@ -106,7 +106,7 @@ public:
 
     bool Resize(std::size_t new_size) override;
 
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+    VirtualDir GetContainingDirectory() const override;
 
     bool IsWritable() const override;
 

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -203,7 +203,7 @@ std::string VfsFile::GetFullPath() const {
     return GetContainingDirectory()->GetFullPath() + "/" + GetName();
 }
 
-std::shared_ptr<VfsFile> VfsDirectory::GetFileRelative(std::string_view path) const {
+VirtualFile VfsDirectory::GetFileRelative(std::string_view path) const {
     auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
@@ -231,7 +231,7 @@ std::shared_ptr<VfsFile> VfsDirectory::GetFileRelative(std::string_view path) co
     return dir->GetFile(vec.back());
 }
 
-std::shared_ptr<VfsFile> VfsDirectory::GetFileAbsolute(std::string_view path) const {
+VirtualFile VfsDirectory::GetFileAbsolute(std::string_view path) const {
     if (IsRoot()) {
         return GetFileRelative(path);
     }
@@ -239,7 +239,7 @@ std::shared_ptr<VfsFile> VfsDirectory::GetFileAbsolute(std::string_view path) co
     return GetParentDirectory()->GetFileAbsolute(path);
 }
 
-std::shared_ptr<VfsDirectory> VfsDirectory::GetDirectoryRelative(std::string_view path) const {
+VirtualDir VfsDirectory::GetDirectoryRelative(std::string_view path) const {
     auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
@@ -261,7 +261,7 @@ std::shared_ptr<VfsDirectory> VfsDirectory::GetDirectoryRelative(std::string_vie
     return dir;
 }
 
-std::shared_ptr<VfsDirectory> VfsDirectory::GetDirectoryAbsolute(std::string_view path) const {
+VirtualDir VfsDirectory::GetDirectoryAbsolute(std::string_view path) const {
     if (IsRoot()) {
         return GetDirectoryRelative(path);
     }
@@ -269,14 +269,14 @@ std::shared_ptr<VfsDirectory> VfsDirectory::GetDirectoryAbsolute(std::string_vie
     return GetParentDirectory()->GetDirectoryAbsolute(path);
 }
 
-std::shared_ptr<VfsFile> VfsDirectory::GetFile(std::string_view name) const {
+VirtualFile VfsDirectory::GetFile(std::string_view name) const {
     const auto& files = GetFiles();
     const auto iter = std::find_if(files.begin(), files.end(),
                                    [&name](const auto& file1) { return name == file1->GetName(); });
     return iter == files.end() ? nullptr : *iter;
 }
 
-std::shared_ptr<VfsDirectory> VfsDirectory::GetSubdirectory(std::string_view name) const {
+VirtualDir VfsDirectory::GetSubdirectory(std::string_view name) const {
     const auto& subs = GetSubdirectories();
     const auto iter = std::find_if(subs.begin(), subs.end(),
                                    [&name](const auto& file1) { return name == file1->GetName(); });
@@ -301,7 +301,7 @@ std::size_t VfsDirectory::GetSize() const {
     return file_total + subdir_total;
 }
 
-std::shared_ptr<VfsFile> VfsDirectory::CreateFileRelative(std::string_view path) {
+VirtualFile VfsDirectory::CreateFileRelative(std::string_view path) {
     auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
@@ -324,7 +324,7 @@ std::shared_ptr<VfsFile> VfsDirectory::CreateFileRelative(std::string_view path)
     return dir->CreateFileRelative(Common::FS::GetPathWithoutTop(path));
 }
 
-std::shared_ptr<VfsFile> VfsDirectory::CreateFileAbsolute(std::string_view path) {
+VirtualFile VfsDirectory::CreateFileAbsolute(std::string_view path) {
     if (IsRoot()) {
         return CreateFileRelative(path);
     }
@@ -332,7 +332,7 @@ std::shared_ptr<VfsFile> VfsDirectory::CreateFileAbsolute(std::string_view path)
     return GetParentDirectory()->CreateFileAbsolute(path);
 }
 
-std::shared_ptr<VfsDirectory> VfsDirectory::CreateDirectoryRelative(std::string_view path) {
+VirtualDir VfsDirectory::CreateDirectoryRelative(std::string_view path) {
     auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
@@ -355,7 +355,7 @@ std::shared_ptr<VfsDirectory> VfsDirectory::CreateDirectoryRelative(std::string_
     return dir->CreateDirectoryRelative(Common::FS::GetPathWithoutTop(path));
 }
 
-std::shared_ptr<VfsDirectory> VfsDirectory::CreateDirectoryAbsolute(std::string_view path) {
+VirtualDir VfsDirectory::CreateDirectoryAbsolute(std::string_view path) {
     if (IsRoot()) {
         return CreateDirectoryRelative(path);
     }
@@ -446,27 +446,27 @@ bool ReadOnlyVfsDirectory::IsReadable() const {
     return true;
 }
 
-std::shared_ptr<VfsDirectory> ReadOnlyVfsDirectory::CreateSubdirectory(std::string_view name) {
+VirtualDir ReadOnlyVfsDirectory::CreateSubdirectory(std::string_view name) {
     return nullptr;
 }
 
-std::shared_ptr<VfsFile> ReadOnlyVfsDirectory::CreateFile(std::string_view name) {
+VirtualFile ReadOnlyVfsDirectory::CreateFile(std::string_view name) {
     return nullptr;
 }
 
-std::shared_ptr<VfsFile> ReadOnlyVfsDirectory::CreateFileAbsolute(std::string_view path) {
+VirtualFile ReadOnlyVfsDirectory::CreateFileAbsolute(std::string_view path) {
     return nullptr;
 }
 
-std::shared_ptr<VfsFile> ReadOnlyVfsDirectory::CreateFileRelative(std::string_view path) {
+VirtualFile ReadOnlyVfsDirectory::CreateFileRelative(std::string_view path) {
     return nullptr;
 }
 
-std::shared_ptr<VfsDirectory> ReadOnlyVfsDirectory::CreateDirectoryAbsolute(std::string_view path) {
+VirtualDir ReadOnlyVfsDirectory::CreateDirectoryAbsolute(std::string_view path) {
     return nullptr;
 }
 
-std::shared_ptr<VfsDirectory> ReadOnlyVfsDirectory::CreateDirectoryRelative(std::string_view path) {
+VirtualDir ReadOnlyVfsDirectory::CreateDirectoryRelative(std::string_view path) {
     return nullptr;
 }
 

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -91,7 +91,7 @@ public:
     // Resizes the file to new_size. Returns whether or not the operation was successful.
     virtual bool Resize(std::size_t new_size) = 0;
     // Gets a pointer to the directory containing this file, returning nullptr if there is none.
-    virtual std::shared_ptr<VfsDirectory> GetContainingDirectory() const = 0;
+    virtual VirtualDir GetContainingDirectory() const = 0;
 
     // Returns whether or not the file can be written to.
     virtual bool IsWritable() const = 0;
@@ -183,27 +183,27 @@ public:
 
     // Retrives the file located at path as if the current directory was root. Returns nullptr if
     // not found.
-    virtual std::shared_ptr<VfsFile> GetFileRelative(std::string_view path) const;
+    virtual VirtualFile GetFileRelative(std::string_view path) const;
     // Calls GetFileRelative(path) on the root of the current directory.
-    virtual std::shared_ptr<VfsFile> GetFileAbsolute(std::string_view path) const;
+    virtual VirtualFile GetFileAbsolute(std::string_view path) const;
 
     // Retrives the directory located at path as if the current directory was root. Returns nullptr
     // if not found.
-    virtual std::shared_ptr<VfsDirectory> GetDirectoryRelative(std::string_view path) const;
+    virtual VirtualDir GetDirectoryRelative(std::string_view path) const;
     // Calls GetDirectoryRelative(path) on the root of the current directory.
-    virtual std::shared_ptr<VfsDirectory> GetDirectoryAbsolute(std::string_view path) const;
+    virtual VirtualDir GetDirectoryAbsolute(std::string_view path) const;
 
     // Returns a vector containing all of the files in this directory.
-    virtual std::vector<std::shared_ptr<VfsFile>> GetFiles() const = 0;
+    virtual std::vector<VirtualFile> GetFiles() const = 0;
     // Returns the file with filename matching name. Returns nullptr if directory dosen't have a
     // file with name.
-    virtual std::shared_ptr<VfsFile> GetFile(std::string_view name) const;
+    virtual VirtualFile GetFile(std::string_view name) const;
 
     // Returns a vector containing all of the subdirectories in this directory.
-    virtual std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const = 0;
+    virtual std::vector<VirtualDir> GetSubdirectories() const = 0;
     // Returns the directory with name matching name. Returns nullptr if directory dosen't have a
     // directory with name.
-    virtual std::shared_ptr<VfsDirectory> GetSubdirectory(std::string_view name) const;
+    virtual VirtualDir GetSubdirectory(std::string_view name) const;
 
     // Returns whether or not the directory can be written to.
     virtual bool IsWritable() const = 0;
@@ -219,31 +219,31 @@ public:
     virtual std::size_t GetSize() const;
     // Returns the parent directory of this directory. Returns nullptr if this directory is root or
     // has no parent.
-    virtual std::shared_ptr<VfsDirectory> GetParentDirectory() const = 0;
+    virtual VirtualDir GetParentDirectory() const = 0;
 
     // Creates a new subdirectory with name name. Returns a pointer to the new directory or nullptr
     // if the operation failed.
-    virtual std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) = 0;
+    virtual VirtualDir CreateSubdirectory(std::string_view name) = 0;
     // Creates a new file with name name. Returns a pointer to the new file or nullptr if the
     // operation failed.
-    virtual std::shared_ptr<VfsFile> CreateFile(std::string_view name) = 0;
+    virtual VirtualFile CreateFile(std::string_view name) = 0;
 
     // Creates a new file at the path relative to this directory. Also creates directories if
     // they do not exist and is supported by this implementation. Returns nullptr on any failure.
-    virtual std::shared_ptr<VfsFile> CreateFileRelative(std::string_view path);
+    virtual VirtualFile CreateFileRelative(std::string_view path);
 
     // Creates a new file at the path relative to root of this directory. Also creates directories
     // if they do not exist and is supported by this implementation. Returns nullptr on any failure.
-    virtual std::shared_ptr<VfsFile> CreateFileAbsolute(std::string_view path);
+    virtual VirtualFile CreateFileAbsolute(std::string_view path);
 
     // Creates a new directory at the path relative to this directory. Also creates directories if
     // they do not exist and is supported by this implementation. Returns nullptr on any failure.
-    virtual std::shared_ptr<VfsDirectory> CreateDirectoryRelative(std::string_view path);
+    virtual VirtualDir CreateDirectoryRelative(std::string_view path);
 
     // Creates a new directory at the path relative to root of this directory. Also creates
     // directories if they do not exist and is supported by this implementation. Returns nullptr on
     // any failure.
-    virtual std::shared_ptr<VfsDirectory> CreateDirectoryAbsolute(std::string_view path);
+    virtual VirtualDir CreateDirectoryAbsolute(std::string_view path);
 
     // Deletes the subdirectory with the given name and returns true on success.
     virtual bool DeleteSubdirectory(std::string_view name) = 0;
@@ -280,12 +280,12 @@ class ReadOnlyVfsDirectory : public VfsDirectory {
 public:
     bool IsWritable() const override;
     bool IsReadable() const override;
-    std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) override;
-    std::shared_ptr<VfsFile> CreateFile(std::string_view name) override;
-    std::shared_ptr<VfsFile> CreateFileAbsolute(std::string_view path) override;
-    std::shared_ptr<VfsFile> CreateFileRelative(std::string_view path) override;
-    std::shared_ptr<VfsDirectory> CreateDirectoryAbsolute(std::string_view path) override;
-    std::shared_ptr<VfsDirectory> CreateDirectoryRelative(std::string_view path) override;
+    VirtualDir CreateSubdirectory(std::string_view name) override;
+    VirtualFile CreateFile(std::string_view name) override;
+    VirtualFile CreateFileAbsolute(std::string_view path) override;
+    VirtualFile CreateFileRelative(std::string_view path) override;
+    VirtualDir CreateDirectoryAbsolute(std::string_view path) override;
+    VirtualDir CreateDirectoryRelative(std::string_view path) override;
     bool DeleteSubdirectory(std::string_view name) override;
     bool DeleteSubdirectoryRecursive(std::string_view name) override;
     bool CleanSubdirectoryRecursive(std::string_view name) override;

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -46,7 +46,7 @@ VirtualFile ConcatenatedVfsFile::MakeConcatenatedFile(std::vector<VirtualFile> f
     if (files.size() == 1)
         return files[0];
 
-    return std::shared_ptr<VfsFile>(new ConcatenatedVfsFile(std::move(files), std::move(name)));
+    return VirtualFile(new ConcatenatedVfsFile(std::move(files), std::move(name)));
 }
 
 VirtualFile ConcatenatedVfsFile::MakeConcatenatedFile(u8 filler_byte,
@@ -71,20 +71,23 @@ VirtualFile ConcatenatedVfsFile::MakeConcatenatedFile(u8 filler_byte,
     if (files.begin()->first != 0)
         files.emplace(0, std::make_shared<StaticVfsFile>(filler_byte, files.begin()->first));
 
-    return std::shared_ptr<VfsFile>(new ConcatenatedVfsFile(std::move(files), std::move(name)));
+    return VirtualFile(new ConcatenatedVfsFile(std::move(files), std::move(name)));
 }
 
 std::string ConcatenatedVfsFile::GetName() const {
-    if (files.empty())
+    if (files.empty()) {
         return "";
-    if (!name.empty())
+    }
+    if (!name.empty()) {
         return name;
+    }
     return files.begin()->second->GetName();
 }
 
 std::size_t ConcatenatedVfsFile::GetSize() const {
-    if (files.empty())
+    if (files.empty()) {
         return 0;
+    }
     return files.rbegin()->first + files.rbegin()->second->GetSize();
 }
 
@@ -92,9 +95,10 @@ bool ConcatenatedVfsFile::Resize(std::size_t new_size) {
     return false;
 }
 
-std::shared_ptr<VfsDirectory> ConcatenatedVfsFile::GetContainingDirectory() const {
-    if (files.empty())
+VirtualDir ConcatenatedVfsFile::GetContainingDirectory() const {
+    if (files.empty()) {
         return nullptr;
+    }
     return files.begin()->second->GetContainingDirectory();
 }
 

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -31,7 +31,7 @@ public:
     std::string GetName() const override;
     std::size_t GetSize() const override;
     bool Resize(std::size_t new_size) override;
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+    VirtualDir GetContainingDirectory() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::size_t Read(u8* data, std::size_t length, std::size_t offset) const override;

--- a/src/core/file_sys/vfs_layered.cpp
+++ b/src/core/file_sys/vfs_layered.cpp
@@ -20,10 +20,10 @@ VirtualDir LayeredVfsDirectory::MakeLayeredDirectory(std::vector<VirtualDir> dir
     if (dirs.size() == 1)
         return dirs[0];
 
-    return std::shared_ptr<VfsDirectory>(new LayeredVfsDirectory(std::move(dirs), std::move(name)));
+    return VirtualDir(new LayeredVfsDirectory(std::move(dirs), std::move(name)));
 }
 
-std::shared_ptr<VfsFile> LayeredVfsDirectory::GetFileRelative(std::string_view path) const {
+VirtualFile LayeredVfsDirectory::GetFileRelative(std::string_view path) const {
     for (const auto& layer : dirs) {
         const auto file = layer->GetFileRelative(path);
         if (file != nullptr)
@@ -33,23 +33,23 @@ std::shared_ptr<VfsFile> LayeredVfsDirectory::GetFileRelative(std::string_view p
     return nullptr;
 }
 
-std::shared_ptr<VfsDirectory> LayeredVfsDirectory::GetDirectoryRelative(
-    std::string_view path) const {
+VirtualDir LayeredVfsDirectory::GetDirectoryRelative(std::string_view path) const {
     std::vector<VirtualDir> out;
     for (const auto& layer : dirs) {
         auto dir = layer->GetDirectoryRelative(path);
-        if (dir != nullptr)
+        if (dir != nullptr) {
             out.push_back(std::move(dir));
+        }
     }
 
     return MakeLayeredDirectory(std::move(out));
 }
 
-std::shared_ptr<VfsFile> LayeredVfsDirectory::GetFile(std::string_view name) const {
+VirtualFile LayeredVfsDirectory::GetFile(std::string_view name) const {
     return GetFileRelative(name);
 }
 
-std::shared_ptr<VfsDirectory> LayeredVfsDirectory::GetSubdirectory(std::string_view name) const {
+VirtualDir LayeredVfsDirectory::GetSubdirectory(std::string_view name) const {
     return GetDirectoryRelative(name);
 }
 
@@ -57,7 +57,7 @@ std::string LayeredVfsDirectory::GetFullPath() const {
     return dirs[0]->GetFullPath();
 }
 
-std::vector<std::shared_ptr<VfsFile>> LayeredVfsDirectory::GetFiles() const {
+std::vector<VirtualFile> LayeredVfsDirectory::GetFiles() const {
     std::vector<VirtualFile> out;
     for (const auto& layer : dirs) {
         for (const auto& file : layer->GetFiles()) {
@@ -72,7 +72,7 @@ std::vector<std::shared_ptr<VfsFile>> LayeredVfsDirectory::GetFiles() const {
     return out;
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> LayeredVfsDirectory::GetSubdirectories() const {
+std::vector<VirtualDir> LayeredVfsDirectory::GetSubdirectories() const {
     std::vector<std::string> names;
     for (const auto& layer : dirs) {
         for (const auto& sd : layer->GetSubdirectories()) {
@@ -101,15 +101,15 @@ std::string LayeredVfsDirectory::GetName() const {
     return name.empty() ? dirs[0]->GetName() : name;
 }
 
-std::shared_ptr<VfsDirectory> LayeredVfsDirectory::GetParentDirectory() const {
+VirtualDir LayeredVfsDirectory::GetParentDirectory() const {
     return dirs[0]->GetParentDirectory();
 }
 
-std::shared_ptr<VfsDirectory> LayeredVfsDirectory::CreateSubdirectory(std::string_view name) {
+VirtualDir LayeredVfsDirectory::CreateSubdirectory(std::string_view name) {
     return nullptr;
 }
 
-std::shared_ptr<VfsFile> LayeredVfsDirectory::CreateFile(std::string_view name) {
+VirtualFile LayeredVfsDirectory::CreateFile(std::string_view name) {
     return nullptr;
 }
 

--- a/src/core/file_sys/vfs_layered.h
+++ b/src/core/file_sys/vfs_layered.h
@@ -21,20 +21,20 @@ public:
     /// Wrapper function to allow for more efficient handling of dirs.size() == 0, 1 cases.
     static VirtualDir MakeLayeredDirectory(std::vector<VirtualDir> dirs, std::string name = "");
 
-    std::shared_ptr<VfsFile> GetFileRelative(std::string_view path) const override;
-    std::shared_ptr<VfsDirectory> GetDirectoryRelative(std::string_view path) const override;
-    std::shared_ptr<VfsFile> GetFile(std::string_view name) const override;
-    std::shared_ptr<VfsDirectory> GetSubdirectory(std::string_view name) const override;
+    VirtualFile GetFileRelative(std::string_view path) const override;
+    VirtualDir GetDirectoryRelative(std::string_view path) const override;
+    VirtualFile GetFile(std::string_view name) const override;
+    VirtualDir GetSubdirectory(std::string_view name) const override;
     std::string GetFullPath() const override;
 
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualFile> GetFiles() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::string GetName() const override;
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
-    std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) override;
-    std::shared_ptr<VfsFile> CreateFile(std::string_view name) override;
+    VirtualDir GetParentDirectory() const override;
+    VirtualDir CreateSubdirectory(std::string_view name) override;
+    VirtualFile CreateFile(std::string_view name) override;
     bool DeleteSubdirectory(std::string_view name) override;
     bool DeleteFile(std::string_view name) override;
     bool Rename(std::string_view name) override;

--- a/src/core/file_sys/vfs_offset.cpp
+++ b/src/core/file_sys/vfs_offset.cpp
@@ -9,7 +9,7 @@
 
 namespace FileSys {
 
-OffsetVfsFile::OffsetVfsFile(std::shared_ptr<VfsFile> file_, std::size_t size_, std::size_t offset_,
+OffsetVfsFile::OffsetVfsFile(VirtualFile file_, std::size_t size_, std::size_t offset_,
                              std::string name_, VirtualDir parent_)
     : file(file_), offset(offset_), size(size_), name(std::move(name_)),
       parent(parent_ == nullptr ? file->GetContainingDirectory() : std::move(parent_)) {}
@@ -37,7 +37,7 @@ bool OffsetVfsFile::Resize(std::size_t new_size) {
     return true;
 }
 
-std::shared_ptr<VfsDirectory> OffsetVfsFile::GetContainingDirectory() const {
+VirtualDir OffsetVfsFile::GetContainingDirectory() const {
     return parent;
 }
 

--- a/src/core/file_sys/vfs_offset.h
+++ b/src/core/file_sys/vfs_offset.h
@@ -17,14 +17,14 @@ namespace FileSys {
 // the size of this wrapper.
 class OffsetVfsFile : public VfsFile {
 public:
-    OffsetVfsFile(std::shared_ptr<VfsFile> file, std::size_t size, std::size_t offset = 0,
+    OffsetVfsFile(VirtualFile file, std::size_t size, std::size_t offset = 0,
                   std::string new_name = "", VirtualDir new_parent = nullptr);
     ~OffsetVfsFile() override;
 
     std::string GetName() const override;
     std::size_t GetSize() const override;
     bool Resize(std::size_t new_size) override;
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+    VirtualDir GetContainingDirectory() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::size_t Read(u8* data, std::size_t length, std::size_t offset) const override;
@@ -42,7 +42,7 @@ public:
 private:
     std::size_t TrimToFit(std::size_t r_size, std::size_t r_offset) const;
 
-    std::shared_ptr<VfsFile> file;
+    VirtualFile file;
     std::size_t offset;
     std::size_t size;
     std::string name;

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -267,7 +267,7 @@ bool RealVfsFile::Resize(std::size_t new_size) {
     return backing->Resize(new_size);
 }
 
-std::shared_ptr<VfsDirectory> RealVfsFile::GetContainingDirectory() const {
+VirtualDir RealVfsFile::GetContainingDirectory() const {
     return base.OpenDirectory(parent_path, perms);
 }
 
@@ -356,7 +356,7 @@ RealVfsDirectory::RealVfsDirectory(RealVfsFilesystem& base_, const std::string& 
 
 RealVfsDirectory::~RealVfsDirectory() = default;
 
-std::shared_ptr<VfsFile> RealVfsDirectory::GetFileRelative(std::string_view path) const {
+VirtualFile RealVfsDirectory::GetFileRelative(std::string_view path) const {
     const auto full_path = FS::SanitizePath(this->path + DIR_SEP + std::string(path));
     if (!FS::Exists(full_path) || FS::IsDirectory(full_path)) {
         return nullptr;
@@ -364,7 +364,7 @@ std::shared_ptr<VfsFile> RealVfsDirectory::GetFileRelative(std::string_view path
     return base.OpenFile(full_path, perms);
 }
 
-std::shared_ptr<VfsDirectory> RealVfsDirectory::GetDirectoryRelative(std::string_view path) const {
+VirtualDir RealVfsDirectory::GetDirectoryRelative(std::string_view path) const {
     const auto full_path = FS::SanitizePath(this->path + DIR_SEP + std::string(path));
     if (!FS::Exists(full_path) || !FS::IsDirectory(full_path)) {
         return nullptr;
@@ -372,20 +372,20 @@ std::shared_ptr<VfsDirectory> RealVfsDirectory::GetDirectoryRelative(std::string
     return base.OpenDirectory(full_path, perms);
 }
 
-std::shared_ptr<VfsFile> RealVfsDirectory::GetFile(std::string_view name) const {
+VirtualFile RealVfsDirectory::GetFile(std::string_view name) const {
     return GetFileRelative(name);
 }
 
-std::shared_ptr<VfsDirectory> RealVfsDirectory::GetSubdirectory(std::string_view name) const {
+VirtualDir RealVfsDirectory::GetSubdirectory(std::string_view name) const {
     return GetDirectoryRelative(name);
 }
 
-std::shared_ptr<VfsFile> RealVfsDirectory::CreateFileRelative(std::string_view path) {
+VirtualFile RealVfsDirectory::CreateFileRelative(std::string_view path) {
     const auto full_path = FS::SanitizePath(this->path + DIR_SEP + std::string(path));
     return base.CreateFile(full_path, perms);
 }
 
-std::shared_ptr<VfsDirectory> RealVfsDirectory::CreateDirectoryRelative(std::string_view path) {
+VirtualDir RealVfsDirectory::CreateDirectoryRelative(std::string_view path) {
     const auto full_path = FS::SanitizePath(this->path + DIR_SEP + std::string(path));
     return base.CreateDirectory(full_path, perms);
 }
@@ -395,11 +395,11 @@ bool RealVfsDirectory::DeleteSubdirectoryRecursive(std::string_view name) {
     return base.DeleteDirectory(full_path);
 }
 
-std::vector<std::shared_ptr<VfsFile>> RealVfsDirectory::GetFiles() const {
+std::vector<VirtualFile> RealVfsDirectory::GetFiles() const {
     return IterateEntries<RealVfsFile, VfsFile>();
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> RealVfsDirectory::GetSubdirectories() const {
+std::vector<VirtualDir> RealVfsDirectory::GetSubdirectories() const {
     return IterateEntries<RealVfsDirectory, VfsDirectory>();
 }
 
@@ -415,7 +415,7 @@ std::string RealVfsDirectory::GetName() const {
     return path_components.back();
 }
 
-std::shared_ptr<VfsDirectory> RealVfsDirectory::GetParentDirectory() const {
+VirtualDir RealVfsDirectory::GetParentDirectory() const {
     if (path_components.size() <= 1) {
         return nullptr;
     }
@@ -423,12 +423,12 @@ std::shared_ptr<VfsDirectory> RealVfsDirectory::GetParentDirectory() const {
     return base.OpenDirectory(parent_path, perms);
 }
 
-std::shared_ptr<VfsDirectory> RealVfsDirectory::CreateSubdirectory(std::string_view name) {
+VirtualDir RealVfsDirectory::CreateSubdirectory(std::string_view name) {
     const std::string subdir_path = (path + DIR_SEP).append(name);
     return base.CreateDirectory(subdir_path, perms);
 }
 
-std::shared_ptr<VfsFile> RealVfsDirectory::CreateFile(std::string_view name) {
+VirtualFile RealVfsDirectory::CreateFile(std::string_view name) {
     const std::string file_path = (path + DIR_SEP).append(name);
     return base.CreateFile(file_path, perms);
 }

--- a/src/core/file_sys/vfs_real.h
+++ b/src/core/file_sys/vfs_real.h
@@ -50,7 +50,7 @@ public:
     std::string GetName() const override;
     std::size_t GetSize() const override;
     bool Resize(std::size_t new_size) override;
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+    VirtualDir GetContainingDirectory() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::size_t Read(u8* data, std::size_t length, std::size_t offset) const override;
@@ -79,21 +79,21 @@ class RealVfsDirectory : public VfsDirectory {
 public:
     ~RealVfsDirectory() override;
 
-    std::shared_ptr<VfsFile> GetFileRelative(std::string_view path) const override;
-    std::shared_ptr<VfsDirectory> GetDirectoryRelative(std::string_view path) const override;
-    std::shared_ptr<VfsFile> GetFile(std::string_view name) const override;
-    std::shared_ptr<VfsDirectory> GetSubdirectory(std::string_view name) const override;
-    std::shared_ptr<VfsFile> CreateFileRelative(std::string_view path) override;
-    std::shared_ptr<VfsDirectory> CreateDirectoryRelative(std::string_view path) override;
+    VirtualFile GetFileRelative(std::string_view path) const override;
+    VirtualDir GetDirectoryRelative(std::string_view path) const override;
+    VirtualFile GetFile(std::string_view name) const override;
+    VirtualDir GetSubdirectory(std::string_view name) const override;
+    VirtualFile CreateFileRelative(std::string_view path) override;
+    VirtualDir CreateDirectoryRelative(std::string_view path) override;
     bool DeleteSubdirectoryRecursive(std::string_view name) override;
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualFile> GetFiles() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::string GetName() const override;
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
-    std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) override;
-    std::shared_ptr<VfsFile> CreateFile(std::string_view name) override;
+    VirtualDir GetParentDirectory() const override;
+    VirtualDir CreateSubdirectory(std::string_view name) override;
+    VirtualFile CreateFile(std::string_view name) override;
     bool DeleteSubdirectory(std::string_view name) override;
     bool DeleteFile(std::string_view name) override;
     bool Rename(std::string_view name) override;

--- a/src/core/file_sys/vfs_static.h
+++ b/src/core/file_sys/vfs_static.h
@@ -31,7 +31,7 @@ public:
         return true;
     }
 
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override {
+    VirtualDir GetContainingDirectory() const override {
         return parent;
     }
 

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -25,7 +25,7 @@ bool VectorVfsFile::Resize(size_t new_size) {
     return true;
 }
 
-std::shared_ptr<VfsDirectory> VectorVfsFile::GetContainingDirectory() const {
+VirtualDir VectorVfsFile::GetContainingDirectory() const {
     return parent;
 }
 
@@ -68,11 +68,11 @@ VectorVfsDirectory::VectorVfsDirectory(std::vector<VirtualFile> files_,
 
 VectorVfsDirectory::~VectorVfsDirectory() = default;
 
-std::vector<std::shared_ptr<VfsFile>> VectorVfsDirectory::GetFiles() const {
+std::vector<VirtualFile> VectorVfsDirectory::GetFiles() const {
     return files;
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> VectorVfsDirectory::GetSubdirectories() const {
+std::vector<VirtualDir> VectorVfsDirectory::GetSubdirectories() const {
     return dirs;
 }
 
@@ -88,7 +88,7 @@ std::string VectorVfsDirectory::GetName() const {
     return name;
 }
 
-std::shared_ptr<VfsDirectory> VectorVfsDirectory::GetParentDirectory() const {
+VirtualDir VectorVfsDirectory::GetParentDirectory() const {
     return parent;
 }
 
@@ -116,11 +116,11 @@ bool VectorVfsDirectory::Rename(std::string_view name_) {
     return true;
 }
 
-std::shared_ptr<VfsDirectory> VectorVfsDirectory::CreateSubdirectory(std::string_view name) {
+VirtualDir VectorVfsDirectory::CreateSubdirectory(std::string_view name) {
     return nullptr;
 }
 
-std::shared_ptr<VfsFile> VectorVfsDirectory::CreateFile(std::string_view name) {
+VirtualFile VectorVfsDirectory::CreateFile(std::string_view name) {
     return nullptr;
 }
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -33,7 +33,7 @@ public:
         return false;
     }
 
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override {
+    VirtualDir GetContainingDirectory() const override {
         return parent;
     }
 
@@ -82,7 +82,7 @@ public:
     std::string GetName() const override;
     std::size_t GetSize() const override;
     bool Resize(std::size_t new_size) override;
-    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+    VirtualDir GetContainingDirectory() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::size_t Read(u8* data, std::size_t length, std::size_t offset) const override;
@@ -106,17 +106,17 @@ public:
                                 VirtualDir parent = nullptr);
     ~VectorVfsDirectory() override;
 
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualFile> GetFiles() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::string GetName() const override;
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
+    VirtualDir GetParentDirectory() const override;
     bool DeleteSubdirectory(std::string_view name) override;
     bool DeleteFile(std::string_view name) override;
     bool Rename(std::string_view name) override;
-    std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) override;
-    std::shared_ptr<VfsFile> CreateFile(std::string_view name) override;
+    VirtualDir CreateSubdirectory(std::string_view name) override;
+    VirtualFile CreateFile(std::string_view name) override;
 
     virtual void AddFile(VirtualFile file);
     virtual void AddDirectory(VirtualDir dir);

--- a/src/core/file_sys/xts_archive.cpp
+++ b/src/core/file_sys/xts_archive.cpp
@@ -152,11 +152,11 @@ NAXContentType NAX::GetContentType() const {
     return type;
 }
 
-std::vector<std::shared_ptr<VfsFile>> NAX::GetFiles() const {
+std::vector<VirtualFile> NAX::GetFiles() const {
     return {dec_file};
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> NAX::GetSubdirectories() const {
+std::vector<VirtualDir> NAX::GetSubdirectories() const {
     return {};
 }
 
@@ -164,7 +164,7 @@ std::string NAX::GetName() const {
     return file->GetName();
 }
 
-std::shared_ptr<VfsDirectory> NAX::GetParentDirectory() const {
+VirtualDir NAX::GetParentDirectory() const {
     return file->GetContainingDirectory();
 }
 

--- a/src/core/file_sys/xts_archive.h
+++ b/src/core/file_sys/xts_archive.h
@@ -47,13 +47,13 @@ public:
 
     NAXContentType GetContentType() const;
 
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
+    std::vector<VirtualFile> GetFiles() const override;
 
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
 
     std::string GetName() const override;
 
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
+    VirtualDir GetParentDirectory() const override;
 
 private:
     Loader::ResultStatus Parse(std::string_view path);

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -32,7 +32,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -21,7 +21,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/kip.h
+++ b/src/core/loader/kip.h
@@ -23,7 +23,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/nax.h
+++ b/src/core/loader/nax.h
@@ -28,7 +28,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -28,7 +28,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -32,7 +32,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -75,7 +75,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -34,7 +34,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -34,7 +34,7 @@ public:
 
     /**
      * Returns the type of the file
-     * @param file std::shared_ptr<VfsFile> open file
+     * @param file open file
      * @return FileType found, or FileType::Error if this loader doesn't know it
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);


### PR DESCRIPTION
Makes use of the VirtualDir and VirtualFile aliases across the board
instead of having a few isolated places that don't use it.