### PR TITLE
input_interpreter: Add method to check for a button press state

### DIFF
--- a/src/core/frontend/input_interpreter.cpp
+++ b/src/core/frontend/input_interpreter.cpp
@@ -25,6 +25,10 @@ void InputInterpreter::PollInput() {
     button_states[current_index] = button_state;
 }
 
+bool InputInterpreter::IsButtonPressed(HIDButton button) const {
+    return (button_states[current_index] & (1U << static_cast<u8>(button))) != 0;
+}
+
 bool InputInterpreter::IsButtonPressedOnce(HIDButton button) const {
     const bool current_press =
         (button_states[current_index] & (1U << static_cast<u8>(button))) != 0;

--- a/src/core/frontend/input_interpreter.h
+++ b/src/core/frontend/input_interpreter.h
@@ -67,6 +67,27 @@ public:
     void PollInput();
 
     /**
+     * Checks whether the button is pressed.
+     *
+     * @param button The button to check.
+     *
+     * @returns True when the button is pressed.
+     */
+    [[nodiscard]] bool IsButtonPressed(HIDButton button) const;
+
+    /**
+     * Checks whether any of the buttons in the parameter list is pressed.
+     *
+     * @tparam HIDButton The buttons to check.
+     *
+     * @returns True when at least one of the buttons is pressed.
+     */
+    template <HIDButton... T>
+    [[nodiscard]] bool IsAnyButtonPressed() {
+        return (IsButtonPressed(T) || ...);
+    }
+
+    /**
      * The specified button is considered to be pressed once
      * if it is currently pressed and not pressed previously.
      *


### PR DESCRIPTION
This allows to check for continuous input for the duration of a button press/hold