### PR TITLE
renderer_vulkan: Fix Nvidia Nsight Aftermath Integration

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -286,6 +286,8 @@ target_include_directories(video_core PRIVATE ${HOST_SHADERS_INCLUDE})
 target_include_directories(video_core PRIVATE sirit ../../externals/Vulkan-Headers/include)
 target_link_libraries(video_core PRIVATE sirit)
 
+option(ENABLE_NSIGHT_AFTERMATH "Enable Nvidia Nsight Aftermath" OFF)
+
 if (ENABLE_NSIGHT_AFTERMATH)
     if (NOT DEFINED ENV{NSIGHT_AFTERMATH_SDK})
         message(ERROR "Environment variable NSIGHT_AFTERMATH_SDK has to be provided")

--- a/src/video_core/vulkan_common/nsight_aftermath_tracker.cpp
+++ b/src/video_core/vulkan_common/nsight_aftermath_tracker.cpp
@@ -26,7 +26,7 @@
 #include "common/logging/log.h"
 #include "common/scope_exit.h"
 
-#include "video_core/renderer_vulkan/nsight_aftermath_tracker.h"
+#include "video_core/vulkan_common/nsight_aftermath_tracker.h"
 
 namespace Vulkan {
 
@@ -53,7 +53,7 @@ NsightAftermathTracker::NsightAftermathTracker() {
         !dl.GetSymbol("GFSDK_Aftermath_GpuCrashDump_GetJSON",
                       &GFSDK_Aftermath_GpuCrashDump_GetJSON)) {
         LOG_ERROR(Render_Vulkan, "Failed to load Nsight Aftermath function pointers");
-        return false;
+        return;
     }
     dump_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir) + "gpucrash";
 


### PR DESCRIPTION
This commit fixes an error after a recent refactor, where enabling Aftermath Integration failed to compile.

This commit also adds a formal CMAKE option to enable Aftermath.