### PR TITLE
Bump conan SDL2 version to 2.0.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ if(ENABLE_SDL2)
     find_package(SDL2)
     if (NOT SDL2_FOUND)
         # otherwise add this to the list of libraries to install
-        list(APPEND CONAN_REQUIRED_LIBS "sdl2/2.0.12@bincrafters/stable")
+        list(APPEND CONAN_REQUIRED_LIBS "sdl2/2.0.14@bincrafters/stable")
     endif()
 endif()
 


### PR DESCRIPTION
Update conan package version used for building.

A couple of new joystick-related functions might pose interest to yuzu's input system. Some sort of LED management have been added, but it doesn't seem to support leds used for player number indication JoyCons/ProCons use.