### PR TITLE
vulkan_device: Blacklist Intel from float16 math

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -444,6 +444,11 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
             "Blacklisting AMD proprietary on RDNA devices from VK_EXT_extended_dynamic_state");
         ext_extended_dynamic_state = false;
     }
+    if (is_float16_supported && driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS) {
+        // Intel's compiler crashes when using fp16 on Astral Chain, disable it for the time being.
+        LOG_WARNING(Render_Vulkan, "Blacklisting Intel proprietary from float16 math");
+        is_float16_supported = false;
+    }
 
     graphics_queue = logical.GetQueue(graphics_family);
     present_queue = logical.GetQueue(present_family);


### PR DESCRIPTION
Astral Chain crashes Intel's SPIR-V compiler when using fp16.
Disable this while the vendor works on a fix.