### PR TITLE
core: Switch to unique_ptr for usage of Common::Fiber.

### DIFF
--- a/src/common/fiber.cpp
+++ b/src/common/fiber.cpp
@@ -24,7 +24,7 @@ struct Fiber::FiberImpl {
     std::function<void(void*)> rewind_point;
     void* rewind_parameter{};
     void* start_parameter{};
-    std::shared_ptr<Fiber> previous_fiber;
+    Fiber* previous_fiber;
     bool is_thread_fiber{};
     bool released{};
 
@@ -47,7 +47,7 @@ void Fiber::Start(boost::context::detail::transfer_t& transfer) {
     ASSERT(impl->previous_fiber != nullptr);
     impl->previous_fiber->impl->context = transfer.fctx;
     impl->previous_fiber->impl->guard.unlock();
-    impl->previous_fiber.reset();
+    impl->previous_fiber = nullptr;
     impl->entry_point(impl->start_parameter);
     UNREACHABLE();
 }
@@ -116,20 +116,20 @@ void Fiber::Rewind() {
     boost::context::detail::jump_fcontext(impl->rewind_context, this);
 }
 
-void Fiber::YieldTo(std::shared_ptr<Fiber> from, std::shared_ptr<Fiber> to) {
+void Fiber::YieldTo(Fiber* from, Fiber* to) {
     ASSERT_MSG(from != nullptr, "Yielding fiber is null!");
     ASSERT_MSG(to != nullptr, "Next fiber is null!");
     to->impl->guard.lock();
     to->impl->previous_fiber = from;
-    auto transfer = boost::context::detail::jump_fcontext(to->impl->context, to.get());
+    auto transfer = boost::context::detail::jump_fcontext(to->impl->context, to);
     ASSERT(from->impl->previous_fiber != nullptr);
     from->impl->previous_fiber->impl->context = transfer.fctx;
     from->impl->previous_fiber->impl->guard.unlock();
-    from->impl->previous_fiber.reset();
+    from->impl->previous_fiber = nullptr;
 }
 
-std::shared_ptr<Fiber> Fiber::ThreadToFiber() {
-    std::shared_ptr<Fiber> fiber = std::shared_ptr<Fiber>{new Fiber()};
+std::unique_ptr<Fiber> Fiber::ThreadToFiber() {
+    std::unique_ptr<Fiber> fiber = std::unique_ptr<Fiber>{new Fiber()};
     fiber->impl->guard.lock();
     fiber->impl->is_thread_fiber = true;
     return fiber;

--- a/src/common/fiber.h
+++ b/src/common/fiber.h
@@ -41,8 +41,8 @@ public:
 
     /// Yields control from Fiber 'from' to Fiber 'to'
     /// Fiber 'from' must be the currently running fiber.
-    static void YieldTo(std::shared_ptr<Fiber> from, std::shared_ptr<Fiber> to);
-    [[nodiscard]] static std::shared_ptr<Fiber> ThreadToFiber();
+    static void YieldTo(Fiber* from, Fiber* to);
+    [[nodiscard]] static std::unique_ptr<Fiber> ThreadToFiber();
 
     void SetRewindPoint(std::function<void(void*)>&& rewind_func, void* rewind_param);
 

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -111,7 +111,7 @@ void CpuManager::MultiCoreRunGuestThread() {
     auto& kernel = system.Kernel();
     kernel.CurrentScheduler()->OnThreadStart();
     auto* thread = kernel.CurrentScheduler()->GetCurrentThread();
-    auto& host_context = thread->GetHostContext();
+    auto host_context = thread->GetHostContext();
     host_context->SetRewindPoint(GuestRewindFunction, this);
     MultiCoreRunGuestLoop();
 }
@@ -148,7 +148,8 @@ void CpuManager::MultiCoreRunSuspendThread() {
         auto core = kernel.GetCurrentHostThreadID();
         auto& scheduler = *kernel.CurrentScheduler();
         Kernel::KThread* current_thread = scheduler.GetCurrentThread();
-        Common::Fiber::YieldTo(current_thread->GetHostContext(), core_data[core].host_context);
+        Common::Fiber::YieldTo(current_thread->GetHostContext(),
+                               core_data[core].host_context.get());
         ASSERT(scheduler.ContextSwitchPending());
         ASSERT(core == kernel.GetCurrentHostThreadID());
         scheduler.RescheduleCurrentCore();
@@ -201,7 +202,7 @@ void CpuManager::SingleCoreRunGuestThread() {
     auto& kernel = system.Kernel();
     kernel.CurrentScheduler()->OnThreadStart();
     auto* thread = kernel.CurrentScheduler()->GetCurrentThread();
-    auto& host_context = thread->GetHostContext();
+    auto host_context = thread->GetHostContext();
     host_context->SetRewindPoint(GuestRewindFunction, this);
     SingleCoreRunGuestLoop();
 }
@@ -245,7 +246,7 @@ void CpuManager::SingleCoreRunSuspendThread() {
         auto core = kernel.GetCurrentHostThreadID();
         auto& scheduler = *kernel.CurrentScheduler();
         Kernel::KThread* current_thread = scheduler.GetCurrentThread();
-        Common::Fiber::YieldTo(current_thread->GetHostContext(), core_data[0].host_context);
+        Common::Fiber::YieldTo(current_thread->GetHostContext(), core_data[0].host_context.get());
         ASSERT(scheduler.ContextSwitchPending());
         ASSERT(core == kernel.GetCurrentHostThreadID());
         scheduler.RescheduleCurrentCore();
@@ -363,7 +364,7 @@ void CpuManager::RunThread(std::size_t core) {
 
         auto current_thread = system.Kernel().CurrentScheduler()->GetCurrentThread();
         data.is_running = true;
-        Common::Fiber::YieldTo(data.host_context, current_thread->GetHostContext());
+        Common::Fiber::YieldTo(data.host_context.get(), current_thread->GetHostContext());
         data.is_running = false;
         data.is_paused = true;
         data.exit_barrier->Wait();

--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -83,7 +83,7 @@ private:
     void RunThread(std::size_t core);
 
     struct CoreData {
-        std::shared_ptr<Common::Fiber> host_context;
+        std::unique_ptr<Common::Fiber> host_context;
         std::unique_ptr<Common::Event> enter_barrier;
         std::unique_ptr<Common::Event> exit_barrier;
         std::atomic<bool> is_running;

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -68,12 +68,12 @@ public:
 
     void OnThreadStart();
 
-    [[nodiscard]] std::shared_ptr<Common::Fiber>& ControlContext() {
-        return switch_fiber;
+    [[nodiscard]] Common::Fiber* ControlContext() {
+        return switch_fiber.get();
     }
 
-    [[nodiscard]] const std::shared_ptr<Common::Fiber>& ControlContext() const {
-        return switch_fiber;
+    [[nodiscard]] const Common::Fiber* ControlContext() const {
+        return switch_fiber.get();
     }
 
     [[nodiscard]] u64 UpdateHighestPriorityThread(KThread* highest_thread);
@@ -178,7 +178,7 @@ private:
 
     KThread* idle_thread;
 
-    std::shared_ptr<Common::Fiber> switch_fiber{};
+    std::unique_ptr<Common::Fiber> switch_fiber{};
 
     struct SchedulingState {
         std::atomic<bool> needs_scheduling;

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -991,10 +991,6 @@ void KThread::SetState(ThreadState state) {
     }
 }
 
-std::shared_ptr<Common::Fiber>& KThread::GetHostContext() {
-    return host_context;
-}
-
 ResultVal<std::shared_ptr<KThread>> KThread::Create(Core::System& system, ThreadType type_flags,
                                                     std::string name, VAddr entry_point,
                                                     u32 priority, u64 arg, s32 processor_id,
@@ -1028,7 +1024,7 @@ ResultVal<std::shared_ptr<KThread>> KThread::Create(Core::System& system, Thread
     scheduler.AddThread(thread);
 
     thread->host_context =
-        std::make_shared<Common::Fiber>(std::move(thread_start_func), thread_start_parameter);
+        std::make_unique<Common::Fiber>(std::move(thread_start_func), thread_start_parameter);
 
     return MakeResult<std::shared_ptr<KThread>>(std::move(thread));
 }

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -293,7 +293,13 @@ public:
         return thread_context_64;
     }
 
-    [[nodiscard]] std::shared_ptr<Common::Fiber>& GetHostContext();
+    [[nodiscard]] Common::Fiber* GetHostContext() {
+        return host_context.get();
+    }
+
+    [[nodiscard]] const Common::Fiber* GetHostContext() const {
+        return host_context.get();
+    }
 
     [[nodiscard]] ThreadState GetState() const {
         return thread_state & ThreadState::Mask;
@@ -719,7 +725,7 @@ private:
     Common::SpinLock context_guard{};
 
     // For emulation
-    std::shared_ptr<Common::Fiber> host_context{};
+    std::unique_ptr<Common::Fiber> host_context{};
 
     // For debugging
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -2626,8 +2626,7 @@ void Call(Core::System& system, u32 immediate) {
     kernel.ExitSVCProfile();
 
     if (!thread->IsCallingSvc()) {
-        auto* host_context = thread->GetHostContext().get();
-        host_context->Rewind();
+        thread->GetHostContext()->Rewind();
     }
 
     system.EnterDynarmicProfile();


### PR DESCRIPTION
- With using unique_ptr instead of shared_ptr, we have more explicit ownership of the context.
- Fixes a memory leak due to circular reference of the shared pointer.