### PR TITLE
hle: kernel: Initialize preemption task after schedulers.

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -68,9 +68,9 @@ struct KernelCore::Impl {
         InitializePhysicalCores();
         InitializeSystemResourceLimit(kernel, system);
         InitializeMemoryLayout();
-        InitializePreemption(kernel);
         InitializeSchedulers();
         InitializeSuspendThreads();
+        InitializePreemption(kernel);
     }
 
     void InitializeCores() {


### PR DESCRIPTION
- Fixes a startup crash that occurs if CoreTiming tries to preempt before kernel initialization completes.