### PR TITLE
buffer_base: Avoid shift with large exponent

### DIFF
--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -478,7 +478,7 @@ private:
                 }
                 page += empty_bits;
 
-                const int continuous_bits = std::countr_one(word >> page);
+                const int continuous_bits = std::countr_one(word >> (page % 64));
                 if (!on_going && continuous_bits != 0) {
                     current_base = word_index * PAGES_PER_WORD + page;
                     on_going = true;


### PR DESCRIPTION
Undefined Behaviour Sanitizer reports a shift with an exponent larger
than 64 on a 64-bit integer (cannot recall the actual size reported.)
Use modulus to restrict it instead.