### PR TITLE
service: time: Setup the network clock with the local clock context

### DIFF
--- a/src/core/hle/service/time/clock_types.h
+++ b/src/core/hle/service/time/clock_types.h
@@ -12,6 +12,12 @@
 
 namespace Service::Time::Clock {
 
+enum class TimeType : u8 {
+    UserSystemClock,
+    NetworkSystemClock,
+    LocalSystemClock,
+};
+
 /// https://switchbrew.org/wiki/Glue_services#SteadyClockTimePoint
 struct SteadyClockTimePoint {
     s64 time_point;
@@ -84,7 +90,7 @@ struct ClockSnapshot {
     SteadyClockTimePoint steady_clock_time_point;
     TimeZone::LocationName location_name;
     u8 is_automatic_correction_enabled;
-    u8 type;
+    TimeType type;
     INSERT_PADDING_BYTES_NOINIT(0x2);
 
     static ResultCode GetCurrentTime(s64& current_time,

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -40,7 +40,7 @@ public:
     private:
         ResultCode GetClockSnapshotFromSystemClockContextInternal(
             Kernel::KThread* thread, Clock::SystemClockContext user_context,
-            Clock::SystemClockContext network_context, u8 type,
+            Clock::SystemClockContext network_context, Clock::TimeType type,
             Clock::ClockSnapshot& cloc_snapshot);
 
     protected:

--- a/src/core/hle/service/time/time_manager.cpp
+++ b/src/core/hle/service/time/time_manager.cpp
@@ -44,7 +44,11 @@ struct TimeManager::Impl final {
         const auto system_time{Clock::TimeSpanType::FromSeconds(GetExternalRtcValue())};
         SetupStandardSteadyClock(system, Common::UUID::Generate(), system_time, {}, {});
         SetupStandardLocalSystemClock(system, {}, system_time.ToSeconds());
-        SetupStandardNetworkSystemClock({}, standard_network_clock_accuracy);
+
+        Clock::SystemClockContext clock_context{};
+        standard_local_system_clock_core.GetClockContext(system, clock_context);
+
+        SetupStandardNetworkSystemClock(clock_context, standard_network_clock_accuracy);
         SetupStandardUserSystemClock(system, {}, Clock::SteadyClockTimePoint::GetRandom());
         SetupEphemeralNetworkSystemClock();
     }

--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -818,7 +818,7 @@ static ResultCode ToCalendarTimeInternal(const TimeZoneRule& rules, s64 time,
 static ResultCode ToCalendarTimeImpl(const TimeZoneRule& rules, s64 time, CalendarInfo& calendar) {
     CalendarTimeInternal calendar_time{};
     const ResultCode result{
-        ToCalendarTimeInternal(rules, time, calendar_time, calendar.additiona_info)};
+        ToCalendarTimeInternal(rules, time, calendar_time, calendar.additional_info)};
     calendar.time.year = static_cast<s16>(calendar_time.year);
 
     // Internal impl. uses 0-indexed month

--- a/src/core/hle/service/time/time_zone_types.h
+++ b/src/core/hle/service/time/time_zone_types.h
@@ -66,8 +66,8 @@ struct CalendarTime {
 static_assert(sizeof(CalendarTime) == 0x8, "CalendarTime is incorrect size");
 
 struct CalendarInfo {
-    CalendarTime time{};
-    CalendarAdditionalInfo additiona_info{};
+    CalendarTime time;
+    CalendarAdditionalInfo additional_info;
 };
 static_assert(sizeof(CalendarInfo) == 0x20, "CalendarInfo is incorrect size");
 


### PR DESCRIPTION
Setting the network time allows some time based events using the network clock to not reset.