### PR TITLE
externals: Search for shared opus installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ macro(yuzu_find_packages)
         "nlohmann_json     3.8         nlohmann_json/3.8.0"
         "ZLIB              1.2         zlib/1.2.11"
         "zstd              1.4         zstd/1.4.8"
+    # can't use opus until AVX check is fixed: https://github.com/yuzu-emu/yuzu/pull/4068
+        #"opus              1.3         opus/1.3.1"
     )
 
     foreach(PACKAGE ${REQUIRED_LIBS})

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -97,4 +97,8 @@ if (ENABLE_WEB_SERVICE)
 endif()
 
 # Opus
-add_subdirectory(opus)
+find_package(opus 1.3)
+if (NOT opus_FOUND)
+    message(STATUS "opus 1.3 or newer not found, falling back to externals")
+    add_subdirectory(opus EXCLUDE_FROM_ALL)
+endif()

--- a/externals/find-modules/Findopus.cmake
+++ b/externals/find-modules/Findopus.cmake
@@ -28,7 +28,7 @@ if(opus_FOUND)
 endif()
 
 if(opus_FOUND AND NOT TARGET Opus::Opus)
-  add_library(Opus::Opus UNKNOWN IMPORTED)
+  add_library(Opus::Opus UNKNOWN IMPORTED GLOBAL)
   set_target_properties(Opus::Opus PROPERTIES
     IMPORTED_LOCATION "${opus_LIBRARY}"
     INTERFACE_COMPILE_OPTIONS "${PC_opus_CFLAGS_OTHER}"

--- a/externals/opus/CMakeLists.txt
+++ b/externals/opus/CMakeLists.txt
@@ -252,3 +252,5 @@ PRIVATE
     opus/silk/float
     opus/src
 )
+
+add_library(Opus::Opus ALIAS opus)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -666,7 +666,7 @@ endif()
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls opus zip)
+target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::Opus zip)
 
 if (YUZU_ENABLE_BOXCAT)
     target_compile_definitions(core PRIVATE -DYUZU_ENABLE_BOXCAT)


### PR DESCRIPTION
We had used conan for opus before, but there was a bug in the AVX detection.
However we still had the Findopus.cmake file within the repository, but not used.

This patch reenables the Findopus helper and prefer the system wide installation of opus.