### PR TITLE
vulkan_device: Enable EXT_robustness2 features

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -294,6 +294,15 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, bit8_storage);
 
+    VkPhysicalDeviceRobustness2FeaturesEXT robustness2{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT,
+        .pNext = nullptr,
+        .robustBufferAccess2 = true,
+        .robustImageAccess2 = true,
+        .nullDescriptor = true,
+    };
+    SetNext(next, robustness2);
+
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset{
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT,
         .pNext = nullptr,


### PR DESCRIPTION
When this was being made mandatory, these enablement of these features was removed, but this is still needed.

Fixes: 757fd1e91716 ("vulkan_device: Require VK_EXT_robustness2")