### PR TITLE
nvidia_flags: Add missing header guard

### DIFF
--- a/src/common/nvidia_flags.h
+++ b/src/common/nvidia_flags.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 namespace Common {
 
 /// Configure platform specific flags for Nvidia's driver


### PR DESCRIPTION
Prevents potential inclusion compilation errors.