### PR TITLE
engine_interface: Add missing virtual destructor

### DIFF
--- a/src/video_core/engines/engine_interface.h
+++ b/src/video_core/engines/engine_interface.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
-#include <type_traits>
 #include "common/common_types.h"
 
 namespace Tegra::Engines {
 
 class EngineInterface {
 public:
+    virtual ~EngineInterface() = default;
+
     /// Write the value to the register identified by method.
     virtual void CallMethod(u32 method, u32 method_argument, bool is_last_call) = 0;
 

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -35,7 +35,7 @@ namespace Tegra::Engines {
 class Fermi2D final : public EngineInterface {
 public:
     explicit Fermi2D();
-    ~Fermi2D();
+    ~Fermi2D() override;
 
     /// Binds a rasterizer to this engine.
     void BindRasterizer(VideoCore::RasterizerInterface* rasterizer);

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -36,7 +36,7 @@ namespace Tegra::Engines {
 class KeplerMemory final : public EngineInterface {
 public:
     explicit KeplerMemory(Core::System& system_, MemoryManager& memory_manager);
-    ~KeplerMemory();
+    ~KeplerMemory() override;
 
     /// Write the value to the register identified by method.
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -188,7 +188,7 @@ public:
     static_assert(sizeof(RemapConst) == 12);
 
     explicit MaxwellDMA(Core::System& system_, MemoryManager& memory_manager_);
-    ~MaxwellDMA();
+    ~MaxwellDMA() override;
 
     /// Write the value to the register identified by method.
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;


### PR DESCRIPTION
Eliminates a potential bug vector related to inheritance. Plus, we
should generally be specifying the destructor as virtual within purely
virtual interfaces to begin with.