### PR TITLE
general: Write buffers before pushing raw arguments

### DIFF
--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -104,9 +104,10 @@ void GetKeyCodeMapImpl(Kernel::HLERequestContext& ctx) {
         layout = key_code->second;
     }
 
+    ctx.WriteBuffer(layout);
+
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    ctx.WriteBuffer(layout);
 }
 } // Anonymous namespace
 

--- a/src/core/hle/service/time/time_zone_service.cpp
+++ b/src/core/hle/service/time/time_zone_service.cpp
@@ -140,11 +140,12 @@ void ITimeZoneService::ToPosixTime(Kernel::HLERequestContext& ctx) {
         return;
     }
 
+    ctx.WriteBuffer(posix_time);
+
     // TODO(bunnei): Handle multiple times
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.PushRaw<u32>(1); // Number of times we're returning
-    ctx.WriteBuffer(posix_time);
 }
 
 void ITimeZoneService::ToPosixTimeWithMyRule(Kernel::HLERequestContext& ctx) {
@@ -163,10 +164,11 @@ void ITimeZoneService::ToPosixTimeWithMyRule(Kernel::HLERequestContext& ctx) {
         return;
     }
 
+    ctx.WriteBuffer(posix_time);
+
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.PushRaw<u32>(1); // Number of times we're returning
-    ctx.WriteBuffer(posix_time);
 }
 
 } // namespace Service::Time

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -1129,9 +1129,11 @@ private:
         }
 
         NativeWindow native_window{*buffer_queue_id};
+        const auto buffer_size = ctx.WriteBuffer(native_window.Serialize());
+
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u64>(ctx.WriteBuffer(native_window.Serialize()));
+        rb.Push<u64>(buffer_size);
     }
 
     void CloseLayer(Kernel::HLERequestContext& ctx) {
@@ -1173,10 +1175,12 @@ private:
         }
 
         NativeWindow native_window{*buffer_queue_id};
+        const auto buffer_size = ctx.WriteBuffer(native_window.Serialize());
+
         IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
         rb.Push(*layer_id);
-        rb.Push<u64>(ctx.WriteBuffer(native_window.Serialize()));
+        rb.Push<u64>(buffer_size);
     }
 
     void DestroyStrayLayer(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
For consistency with the rest of the service implementations