### PR TITLE
texture_cache/util: Fix src being used instead of dst within DeduceBl…

### DIFF
--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -1139,7 +1139,7 @@ void DeduceBlitImages(ImageInfo& dst_info, ImageInfo& src_info, const ImageBase*
         dst_info.format = src->info.format;
     }
     if (!src && dst && GetFormatType(dst->info.format) != SurfaceType::ColorTexture) {
-        src_info.format = src->info.format;
+        src_info.format = dst->info.format;
     }
 }
 


### PR DESCRIPTION
…itImages

This line can only ever be reached if src is null, so dereferencing it
here is a logic bug that slipped through.

Instead, we dereference dst instead which is guaranteed to be valid.