### PR TITLE
nvhost_vic: Fix device closure

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
@@ -31,9 +31,8 @@ NvResult nvhost_nvdec::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>&
             return SetSubmitTimeout(input, output);
         case 0x9:
             return MapBuffer(input, output);
-        case 0xa: {
+        case 0xa:
             return UnmapBuffer(input, output);
-        }
         default:
             break;
         }
@@ -67,7 +66,8 @@ NvResult nvhost_nvdec::Ioctl3(DeviceFD fd, Ioctl command, const std::vector<u8>&
 void nvhost_nvdec::OnOpen(DeviceFD fd) {}
 
 void nvhost_nvdec::OnClose(DeviceFD fd) {
-    system.GPU().ClearCommandBuffer();
+    LOG_INFO(Service_NVDRV, "NVDEC video stream ended");
+    system.GPU().ClearCdmaInstance();
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvdrv/devices/nvhost_vic.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_vic.cpp
@@ -29,13 +29,8 @@ NvResult nvhost_vic::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& i
             return GetWaitbase(input, output);
         case 0x9:
             return MapBuffer(input, output);
-        case 0xa: {
-            if (command.length == 0x1c) {
-                Tegra::ChCommandHeaderList cmdlist{{0xDEADB33F}};
-                system.GPU().PushCommandBuffer(cmdlist);
-            }
+        case 0xa:
             return UnmapBuffer(input, output);
-        }
         default:
             break;
         }
@@ -69,6 +64,9 @@ NvResult nvhost_vic::Ioctl3(DeviceFD fd, Ioctl command, const std::vector<u8>& i
 }
 
 void nvhost_vic::OnOpen(DeviceFD fd) {}
-void nvhost_vic::OnClose(DeviceFD fd) {}
+
+void nvhost_vic::OnClose(DeviceFD fd) {
+    system.GPU().ClearCdmaInstance();
+}
 
 } // namespace Service::Nvidia::Devices

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -492,10 +492,8 @@ void GPU::PushCommandBuffer(Tegra::ChCommandHeaderList& entries) {
     cdma_pusher->ProcessEntries(std::move(entries));
 }
 
-void GPU::ClearCommandBuffer() {
-    // This condition fires when a video stream ends, clear all intermediary data
+void GPU::ClearCdmaInstance() {
     cdma_pusher.reset();
-    LOG_INFO(Service_NVDRV, "NVDEC video stream ended");
 }
 
 void GPU::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -324,8 +324,8 @@ public:
     /// Push GPU command buffer entries to be processed
     void PushCommandBuffer(Tegra::ChCommandHeaderList& entries);
 
-    /// Frees the CDMAPusher to free up resources
-    void ClearCommandBuffer();
+    /// Frees the CDMAPusher instance to free up resources
+    void ClearCdmaInstance();
 
     /// Swap buffers (render frame)
     void SwapBuffers(const Tegra::FramebufferConfig* framebuffer);


### PR DESCRIPTION
Implements the OnClose method of the nvhost_vic device, and removes the remnants of an older implementation.

Also cleans up some of the surrounding code.