### PR TITLE
loader: Resolve instances of variable shadowing

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -43,13 +43,13 @@ public:
 
     LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
-    ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
-    ResultStatus ReadIcon(std::vector<u8>& buffer) override;
+    ResultStatus ReadRomFS(FileSys::VirtualFile& out_dir) override;
+    ResultStatus ReadIcon(std::vector<u8>& out_buffer) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadTitle(std::string& title) override;
     bool IsRomFSUpdatable() const override;
 
-    ResultStatus ReadNSOModules(Modules& modules) override;
+    ResultStatus ReadNSOModules(Modules& out_modules) override;
 
 private:
     FileSys::ProgramMetadata metadata;

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -364,21 +364,24 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const 
 
 namespace Loader {
 
-AppLoader_ELF::AppLoader_ELF(FileSys::VirtualFile file) : AppLoader(std::move(file)) {}
+AppLoader_ELF::AppLoader_ELF(FileSys::VirtualFile file_) : AppLoader(std::move(file_)) {}
 
-FileType AppLoader_ELF::IdentifyType(const FileSys::VirtualFile& file) {
+FileType AppLoader_ELF::IdentifyType(const FileSys::VirtualFile& elf_file) {
     static constexpr u16 ELF_MACHINE_ARM{0x28};
 
     u32 magic = 0;
-    if (4 != file->ReadObject(&magic))
+    if (4 != elf_file->ReadObject(&magic)) {
         return FileType::Error;
+    }
 
     u16 machine = 0;
-    if (2 != file->ReadObject(&machine, 18))
+    if (2 != elf_file->ReadObject(&machine, 18)) {
         return FileType::Error;
+    }
 
-    if (Common::MakeMagic('\x7f', 'E', 'L', 'F') == magic && ELF_MACHINE_ARM == machine)
+    if (Common::MakeMagic('\x7f', 'E', 'L', 'F') == magic && ELF_MACHINE_ARM == machine) {
         return FileType::ELF;
+    }
 
     return FileType::Error;
 }

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -20,11 +20,13 @@ public:
     explicit AppLoader_ELF(FileSys::VirtualFile file);
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is an ELF file.
+     *
+     * @param elf_file The file to identify.
+     *
+     * @return FileType::ELF, or FileType::Error if the file is not an ELF file.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& elf_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);

--- a/src/core/loader/kip.cpp
+++ b/src/core/loader/kip.cpp
@@ -24,9 +24,9 @@ AppLoader_KIP::AppLoader_KIP(FileSys::VirtualFile file_)
 
 AppLoader_KIP::~AppLoader_KIP() = default;
 
-FileType AppLoader_KIP::IdentifyType(const FileSys::VirtualFile& file) {
+FileType AppLoader_KIP::IdentifyType(const FileSys::VirtualFile& in_file) {
     u32_le magic{};
-    if (file->GetSize() < sizeof(u32) || file->ReadObject(&magic) != sizeof(u32)) {
+    if (in_file->GetSize() < sizeof(u32) || in_file->ReadObject(&magic) != sizeof(u32)) {
         return FileType::Error;
     }
 
@@ -56,10 +56,10 @@ AppLoader::LoadResult AppLoader_KIP::Load(Kernel::Process& process,
         return {kip->GetStatus(), {}};
     }
 
-    const auto get_kip_address_space_type = [](const auto& kip) {
-        return kip.Is64Bit()
-                   ? (kip.Is39BitAddressSpace() ? FileSys::ProgramAddressSpaceType::Is39Bit
-                                                : FileSys::ProgramAddressSpaceType::Is36Bit)
+    const auto get_kip_address_space_type = [](const auto& kip_type) {
+        return kip_type.Is64Bit()
+                   ? (kip_type.Is39BitAddressSpace() ? FileSys::ProgramAddressSpaceType::Is39Bit
+                                                     : FileSys::ProgramAddressSpaceType::Is36Bit)
                    : FileSys::ProgramAddressSpaceType::Is32Bit;
     };
 

--- a/src/core/loader/kip.h
+++ b/src/core/loader/kip.h
@@ -22,11 +22,13 @@ public:
     ~AppLoader_KIP() override;
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is a KIP.
+     *
+     * @param in_file The file to identify.
+     *
+     * @return FileType::KIP if found, or FileType::Error if unknown.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& in_file);
 
     FileType GetFileType() const override;
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -152,21 +152,26 @@ public:
 
     /**
      * Returns the type of this file
+     *
      * @return FileType corresponding to the loaded file
      */
     virtual FileType GetFileType() const = 0;
 
     /**
      * Load the application and return the created Process instance
+     *
      * @param process The newly created process.
      * @param system  The system that this process is being loaded under.
+     *
      * @return The status result of the operation.
      */
     virtual LoadResult Load(Kernel::Process& process, Core::System& system) = 0;
 
     /**
      * Get the code (typically .code section) of the application
-     * @param buffer Reference to buffer to store data
+     *
+     * @param[out] buffer Reference to buffer to store data
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadCode(std::vector<u8>& buffer) {
@@ -175,7 +180,9 @@ public:
 
     /**
      * Get the icon (typically icon section) of the application
-     * @param buffer Reference to buffer to store data
+     *
+     * @param[out] buffer Reference to buffer to store data
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadIcon(std::vector<u8>& buffer) {
@@ -186,7 +193,9 @@ public:
      * Get the banner (typically banner section) of the application
      * In the context of NX, this is the animation that displays in the bottom right of the screen
      * when a game boots. Stored in GIF format.
-     * @param buffer Reference to buffer to store data
+     *
+     * @param[out] buffer Reference to buffer to store data
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadBanner(std::vector<u8>& buffer) {
@@ -197,7 +206,9 @@ public:
      * Get the logo (typically logo section) of the application
      * In the context of NX, this is the static image that displays in the top left of the screen
      * when a game boots. Stored in JPEG format.
-     * @param buffer Reference to buffer to store data
+     *
+     * @param[out] buffer Reference to buffer to store data
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadLogo(std::vector<u8>& buffer) {
@@ -206,7 +217,9 @@ public:
 
     /**
      * Get the program id of the application
-     * @param out_program_id Reference to store program id into
+     *
+     * @param[out] out_program_id Reference to store program id into
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadProgramId(u64& out_program_id) {
@@ -216,19 +229,23 @@ public:
     /**
      * Get the RomFS of the application
      * Since the RomFS can be huge, we return a file reference instead of copying to a buffer
-     * @param file The directory containing the RomFS
+     *
+     * @param[out] out_file The directory containing the RomFS
+     *
      * @return ResultStatus result of function
      */
-    virtual ResultStatus ReadRomFS(FileSys::VirtualFile& file) {
+    virtual ResultStatus ReadRomFS(FileSys::VirtualFile& out_file) {
         return ResultStatus::ErrorNotImplemented;
     }
 
     /**
      * Get the raw update of the application, should it come packed with one
-     * @param file The raw update NCA file (Program-type
+     *
+     * @param[out] out_file The raw update NCA file (Program-type)
+     *
      * @return ResultStatus result of function
      */
-    virtual ResultStatus ReadUpdateRaw(FileSys::VirtualFile& file) {
+    virtual ResultStatus ReadUpdateRaw(FileSys::VirtualFile& out_file) {
         return ResultStatus::ErrorNotImplemented;
     }
 
@@ -236,7 +253,8 @@ public:
      * Get whether or not updates can be applied to the RomFS.
      * By default, this is true, however for formats where it cannot be guaranteed that the RomFS is
      * the base game it should be set to false.
-     * @return bool whether or not updatable.
+     *
+     * @return bool indicating whether or not the RomFS is updatable.
      */
     virtual bool IsRomFSUpdatable() const {
         return true;
@@ -244,8 +262,9 @@ public:
 
     /**
      * Gets the difference between the start of the IVFC header and the start of level 6 (RomFS)
-     * data. Needed for bktr patching.
-     * @return IVFC offset for romfs.
+     * data. Needed for BKTR patching.
+     *
+     * @return IVFC offset for RomFS.
      */
     virtual u64 ReadRomFSIVFCOffset() const {
         return 0;
@@ -253,7 +272,9 @@ public:
 
     /**
      * Get the title of the application
-     * @param title Reference to store the application title into
+     *
+     * @param[out] title Reference to store the application title into
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadTitle(std::string& title) {
@@ -262,7 +283,9 @@ public:
 
     /**
      * Get the control data (CNMT) of the application
-     * @param control Reference to store the application control data into
+     *
+     * @param[out] control Reference to store the application control data into
+     *
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadControlData(FileSys::NACP& control) {
@@ -271,10 +294,12 @@ public:
 
     /**
      * Get the RomFS of the manual of the application
-     * @param file The raw manual RomFS of the game
+     *
+     * @param[out] out_file The raw manual RomFS of the game
+     *
      * @return ResultStatus result of function
      */
-    virtual ResultStatus ReadManualRomFS(FileSys::VirtualFile& file) {
+    virtual ResultStatus ReadManualRomFS(FileSys::VirtualFile& out_file) {
         return ResultStatus::ErrorNotImplemented;
     }
 

--- a/src/core/loader/nax.cpp
+++ b/src/core/loader/nax.cpp
@@ -26,14 +26,14 @@ FileType IdentifyTypeImpl(const FileSys::NAX& nax) {
 }
 } // Anonymous namespace
 
-AppLoader_NAX::AppLoader_NAX(FileSys::VirtualFile file)
-    : AppLoader(file), nax(std::make_unique<FileSys::NAX>(file)),
+AppLoader_NAX::AppLoader_NAX(FileSys::VirtualFile file_)
+    : AppLoader(file_), nax(std::make_unique<FileSys::NAX>(file_)),
       nca_loader(std::make_unique<AppLoader_NCA>(nax->GetDecrypted())) {}
 
 AppLoader_NAX::~AppLoader_NAX() = default;
 
-FileType AppLoader_NAX::IdentifyType(const FileSys::VirtualFile& file) {
-    const FileSys::NAX nax(file);
+FileType AppLoader_NAX::IdentifyType(const FileSys::VirtualFile& nax_file) {
+    const FileSys::NAX nax(nax_file);
     return IdentifyTypeImpl(nax);
 }
 
@@ -41,8 +41,7 @@ FileType AppLoader_NAX::GetFileType() const {
     return IdentifyTypeImpl(*nax);
 }
 
-AppLoader_NAX::LoadResult AppLoader_NAX::Load(Kernel::Process& process,
-                                              [[maybe_unused]] Core::System& system) {
+AppLoader_NAX::LoadResult AppLoader_NAX::Load(Kernel::Process& process, Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }

--- a/src/core/loader/nax.h
+++ b/src/core/loader/nax.h
@@ -23,15 +23,17 @@ class AppLoader_NCA;
 /// Loads a NAX file
 class AppLoader_NAX final : public AppLoader {
 public:
-    explicit AppLoader_NAX(FileSys::VirtualFile file);
+    explicit AppLoader_NAX(FileSys::VirtualFile file_);
     ~AppLoader_NAX() override;
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is a NAX file.
+     *
+     * @param nax_file The file to identify.
+     *
+     * @return FileType::NAX, or FileType::Error if the file is not a NAX file.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& nax_file);
 
     FileType GetFileType() const override;
 

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -21,12 +21,13 @@ AppLoader_NCA::AppLoader_NCA(FileSys::VirtualFile file_)
 
 AppLoader_NCA::~AppLoader_NCA() = default;
 
-FileType AppLoader_NCA::IdentifyType(const FileSys::VirtualFile& file) {
-    FileSys::NCA nca(file);
+FileType AppLoader_NCA::IdentifyType(const FileSys::VirtualFile& nca_file) {
+    const FileSys::NCA nca(nca_file);
 
     if (nca.GetStatus() == ResultStatus::Success &&
-        nca.GetType() == FileSys::NCAContentType::Program)
+        nca.GetType() == FileSys::NCAContentType::Program) {
         return FileType::NCA;
+    }
 
     return FileType::Error;
 }
@@ -67,43 +68,59 @@ AppLoader_NCA::LoadResult AppLoader_NCA::Load(Kernel::Process& process, Core::Sy
 }
 
 ResultStatus AppLoader_NCA::ReadRomFS(FileSys::VirtualFile& dir) {
-    if (nca == nullptr)
+    if (nca == nullptr) {
         return ResultStatus::ErrorNotInitialized;
-    if (nca->GetRomFS() == nullptr || nca->GetRomFS()->GetSize() == 0)
+    }
+
+    if (nca->GetRomFS() == nullptr || nca->GetRomFS()->GetSize() == 0) {
         return ResultStatus::ErrorNoRomFS;
+    }
+
     dir = nca->GetRomFS();
     return ResultStatus::Success;
 }
 
 u64 AppLoader_NCA::ReadRomFSIVFCOffset() const {
-    if (nca == nullptr)
+    if (nca == nullptr) {
         return 0;
+    }
+
     return nca->GetBaseIVFCOffset();
 }
 
 ResultStatus AppLoader_NCA::ReadProgramId(u64& out_program_id) {
-    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
+    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success) {
         return ResultStatus::ErrorNotInitialized;
+    }
+
     out_program_id = nca->GetTitleId();
     return ResultStatus::Success;
 }
 
 ResultStatus AppLoader_NCA::ReadBanner(std::vector<u8>& buffer) {
-    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
+    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success) {
         return ResultStatus::ErrorNotInitialized;
+    }
+
     const auto logo = nca->GetLogoPartition();
-    if (logo == nullptr)
+    if (logo == nullptr) {
         return ResultStatus::ErrorNoIcon;
+    }
+
     buffer = logo->GetFile("StartupMovie.gif")->ReadAllBytes();
     return ResultStatus::Success;
 }
 
 ResultStatus AppLoader_NCA::ReadLogo(std::vector<u8>& buffer) {
-    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
+    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success) {
         return ResultStatus::ErrorNotInitialized;
+    }
+
     const auto logo = nca->GetLogoPartition();
-    if (logo == nullptr)
+    if (logo == nullptr) {
         return ResultStatus::ErrorNoIcon;
+    }
+
     buffer = logo->GetFile("NintendoLogo.png")->ReadAllBytes();
     return ResultStatus::Success;
 }

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -23,15 +23,17 @@ class AppLoader_DeconstructedRomDirectory;
 /// Loads an NCA file
 class AppLoader_NCA final : public AppLoader {
 public:
-    explicit AppLoader_NCA(FileSys::VirtualFile file);
+    explicit AppLoader_NCA(FileSys::VirtualFile file_);
     ~AppLoader_NCA() override;
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is an NCA file.
+     *
+     * @param nca_file The file to identify.
+     *
+     * @return FileType::NCA, or FileType::Error if the file is not an NCA file.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& nca_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -27,15 +27,17 @@ namespace Loader {
 /// Loads an NRO file
 class AppLoader_NRO final : public AppLoader {
 public:
-    explicit AppLoader_NRO(FileSys::VirtualFile file);
+    explicit AppLoader_NRO(FileSys::VirtualFile file_);
     ~AppLoader_NRO() override;
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is an NRO file.
+     *
+     * @param nro_file The file to identify.
+     *
+     * @return FileType::NRO, or FileType::Error if the file is not an NRO file.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& nro_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);
@@ -51,7 +53,7 @@ public:
     bool IsRomFSUpdatable() const override;
 
 private:
-    bool LoadNro(Kernel::Process& process, const FileSys::VfsFile& file);
+    bool LoadNro(Kernel::Process& process, const FileSys::VfsFile& nro_file);
 
     std::vector<u8> icon_data;
     std::unique_ptr<FileSys::NACP> nacp;

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -71,27 +71,29 @@ static_assert(sizeof(NSOArgumentHeader) == 0x20, "NSOArgumentHeader has incorrec
 /// Loads an NSO file
 class AppLoader_NSO final : public AppLoader {
 public:
-    explicit AppLoader_NSO(FileSys::VirtualFile file);
+    explicit AppLoader_NSO(FileSys::VirtualFile file_);
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is a form of NSO file.
+     *
+     * @param in_file The file to be identified.
+     *
+     * @return FileType::NSO if found, or FileType::Error if some other type of file.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& in_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);
     }
 
     static std::optional<VAddr> LoadModule(Kernel::Process& process, Core::System& system,
-                                           const FileSys::VfsFile& file, VAddr load_base,
+                                           const FileSys::VfsFile& nso_file, VAddr load_base,
                                            bool should_pass_arguments, bool load_into_process,
                                            std::optional<FileSys::PatchManager> pm = {});
 
     LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
-    ResultStatus ReadNSOModules(Modules& modules) override;
+    ResultStatus ReadNSOModules(Modules& out_modules) override;
 
 private:
     Modules modules;

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -26,18 +26,20 @@ class AppLoader_NCA;
 /// Loads an XCI file
 class AppLoader_NSP final : public AppLoader {
 public:
-    explicit AppLoader_NSP(FileSys::VirtualFile file,
+    explicit AppLoader_NSP(FileSys::VirtualFile file_,
                            const Service::FileSystem::FileSystemController& fsc,
                            const FileSys::ContentProvider& content_provider,
                            std::size_t program_index);
     ~AppLoader_NSP() override;
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is an NSP file.
+     *
+     * @param nsp_file The file to identify.
+     *
+     * @return FileType::NSP, or FileType::Error if the file is not an NSP.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& nsp_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);
@@ -45,14 +47,14 @@ public:
 
     LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
-    ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
+    ResultStatus ReadRomFS(FileSys::VirtualFile& out_file) override;
     u64 ReadRomFSIVFCOffset() const override;
-    ResultStatus ReadUpdateRaw(FileSys::VirtualFile& file) override;
+    ResultStatus ReadUpdateRaw(FileSys::VirtualFile& out_file) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;
     ResultStatus ReadControlData(FileSys::NACP& nacp) override;
-    ResultStatus ReadManualRomFS(FileSys::VirtualFile& file) override;
+    ResultStatus ReadManualRomFS(FileSys::VirtualFile& out_file) override;
 
     ResultStatus ReadBanner(std::vector<u8>& buffer) override;
     ResultStatus ReadLogo(std::vector<u8>& buffer) override;

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -26,18 +26,20 @@ class AppLoader_NCA;
 /// Loads an XCI file
 class AppLoader_XCI final : public AppLoader {
 public:
-    explicit AppLoader_XCI(FileSys::VirtualFile file,
+    explicit AppLoader_XCI(FileSys::VirtualFile file_,
                            const Service::FileSystem::FileSystemController& fsc,
                            const FileSys::ContentProvider& content_provider,
                            std::size_t program_index);
     ~AppLoader_XCI() override;
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is an XCI file.
+     *
+     * @param xci_file The file to identify.
+     *
+     * @return FileType::XCI, or FileType::Error if the file is not an XCI file.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& xci_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);
@@ -45,14 +47,14 @@ public:
 
     LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
-    ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
+    ResultStatus ReadRomFS(FileSys::VirtualFile& out_file) override;
     u64 ReadRomFSIVFCOffset() const override;
-    ResultStatus ReadUpdateRaw(FileSys::VirtualFile& file) override;
+    ResultStatus ReadUpdateRaw(FileSys::VirtualFile& out_file) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;
     ResultStatus ReadControlData(FileSys::NACP& control) override;
-    ResultStatus ReadManualRomFS(FileSys::VirtualFile& file) override;
+    ResultStatus ReadManualRomFS(FileSys::VirtualFile& out_file) override;
 
     ResultStatus ReadBanner(std::vector<u8>& buffer) override;
     ResultStatus ReadLogo(std::vector<u8>& buffer) override;


### PR DESCRIPTION
Eliminates variable shadowing cases across all the loaders to bring us
closer to enabling variable shadowing as an error in core.