### PR TITLE
kernel: Eliminate variable shadowing

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -180,12 +180,12 @@ ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(const KHandleTab
     return RESULT_SUCCESS;
 }
 
-ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(KThread& thread) {
-    auto& owner_process = *thread.GetOwnerProcess();
+ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(KThread& requesting_thread) {
+    auto& owner_process = *requesting_thread.GetOwnerProcess();
     auto& handle_table = owner_process.GetHandleTable();
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH> dst_cmdbuf;
-    memory.ReadBlock(owner_process, thread.GetTLSAddress(), dst_cmdbuf.data(),
+    memory.ReadBlock(owner_process, requesting_thread.GetTLSAddress(), dst_cmdbuf.data(),
                      dst_cmdbuf.size() * sizeof(u32));
 
     // The header was already built in the internal command buffer. Attempt to parse it to verify
@@ -242,7 +242,7 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(KThread& thread) {
     }
 
     // Copy the translated command buffer back into the thread's command buffer area.
-    memory.WriteBlock(owner_process, thread.GetTLSAddress(), dst_cmdbuf.data(),
+    memory.WriteBlock(owner_process, requesting_thread.GetTLSAddress(), dst_cmdbuf.data(),
                       dst_cmdbuf.size() * sizeof(u32));
 
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -126,7 +126,7 @@ public:
                                                  u32_le* src_cmdbuf);
 
     /// Writes data from this context back to the requesting process/thread.
-    ResultCode WriteToOutgoingCommandBuffer(KThread& thread);
+    ResultCode WriteToOutgoingCommandBuffer(KThread& requesting_thread);
 
     u32_le GetCommand() const {
         return command;

--- a/src/core/hle/kernel/k_auto_object.h
+++ b/src/core/hle/kernel/k_auto_object.h
@@ -177,7 +177,7 @@ class KAutoObjectWithListContainer;
 
 class KAutoObjectWithList : public KAutoObject {
 public:
-    explicit KAutoObjectWithList(KernelCore& kernel_) : KAutoObject(kernel_), kernel(kernel_) {}
+    explicit KAutoObjectWithList(KernelCore& kernel_) : KAutoObject(kernel_) {}
 
     static int Compare(const KAutoObjectWithList& lhs, const KAutoObjectWithList& rhs) {
         const u64 lid = lhs.GetId();
@@ -204,11 +204,7 @@ public:
 private:
     friend class KAutoObjectWithListContainer;
 
-private:
     Common::IntrusiveRedBlackTreeNode list_node;
-
-protected:
-    KernelCore& kernel;
 };
 
 template <typename T>

--- a/src/core/hle/kernel/k_client_port.cpp
+++ b/src/core/hle/kernel/k_client_port.cpp
@@ -13,7 +13,7 @@
 
 namespace Kernel {
 
-KClientPort::KClientPort(KernelCore& kernel) : KSynchronizationObject{kernel} {}
+KClientPort::KClientPort(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
 KClientPort::~KClientPort() = default;
 
 void KClientPort::Initialize(KPort* parent_, s32 max_sessions_, std::string&& name_) {

--- a/src/core/hle/kernel/k_client_port.h
+++ b/src/core/hle/kernel/k_client_port.h
@@ -21,7 +21,7 @@ class KClientPort final : public KSynchronizationObject {
     KERNEL_AUTOOBJECT_TRAITS(KClientPort, KSynchronizationObject);
 
 public:
-    explicit KClientPort(KernelCore& kernel);
+    explicit KClientPort(KernelCore& kernel_);
     virtual ~KClientPort() override;
 
     void Initialize(KPort* parent_, s32 max_sessions_, std::string&& name_);

--- a/src/core/hle/kernel/k_client_session.cpp
+++ b/src/core/hle/kernel/k_client_session.cpp
@@ -12,7 +12,8 @@
 
 namespace Kernel {
 
-KClientSession::KClientSession(KernelCore& kernel) : KAutoObjectWithSlabHeapAndContainer{kernel} {}
+KClientSession::KClientSession(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_} {}
 KClientSession::~KClientSession() = default;
 
 void KClientSession::Destroy() {

--- a/src/core/hle/kernel/k_client_session.h
+++ b/src/core/hle/kernel/k_client_session.h
@@ -33,7 +33,7 @@ class KClientSession final
     KERNEL_AUTOOBJECT_TRAITS(KClientSession, KAutoObject);
 
 public:
-    explicit KClientSession(KernelCore& kernel);
+    explicit KClientSession(KernelCore& kernel_);
     virtual ~KClientSession();
 
     void Initialize(KSession* parent_, std::string&& name_) {

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -254,8 +254,7 @@ void KConditionVariable::Signal(u64 cv_key, s32 count) {
     }
 
     // Close threads in the list.
-    for (auto it = thread_list.begin(); it != thread_list.end();
-         it = thread_list.erase(kernel, it)) {
+    for (auto it = thread_list.begin(); it != thread_list.end(); it = thread_list.erase(it)) {
         (*it).Close();
     }
 }

--- a/src/core/hle/kernel/k_event.cpp
+++ b/src/core/hle/kernel/k_event.cpp
@@ -8,8 +8,9 @@
 
 namespace Kernel {
 
-KEvent::KEvent(KernelCore& kernel)
-    : KAutoObjectWithSlabHeapAndContainer{kernel}, readable_event{kernel}, writable_event{kernel} {}
+KEvent::KEvent(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_}, readable_event{kernel_}, writable_event{
+                                                                                 kernel_} {}
 
 KEvent::~KEvent() = default;
 

--- a/src/core/hle/kernel/k_event.h
+++ b/src/core/hle/kernel/k_event.h
@@ -19,7 +19,7 @@ class KEvent final : public KAutoObjectWithSlabHeapAndContainer<KEvent, KAutoObj
     KERNEL_AUTOOBJECT_TRAITS(KEvent, KAutoObject);
 
 public:
-    explicit KEvent(KernelCore& kernel);
+    explicit KEvent(KernelCore& kernel_);
     virtual ~KEvent();
 
     void Initialize(std::string&& name);

--- a/src/core/hle/kernel/k_linked_list.h
+++ b/src/core/hle/kernel/k_linked_list.h
@@ -124,7 +124,7 @@ public:
 
     ~KLinkedList() {
         // Erase all elements.
-        for (auto it = this->begin(); it != this->end(); it = this->erase(kernel, it)) {
+        for (auto it = begin(); it != end(); it = erase(it)) {
         }
 
         // Ensure we succeeded.
@@ -223,7 +223,7 @@ public:
         this->erase(this->begin());
     }
 
-    iterator erase(KernelCore& kernel, const iterator pos) {
+    iterator erase(const iterator pos) {
         KLinkedListNode* freed_node = std::addressof(*pos.m_base_it);
         iterator ret = iterator(BaseList::erase(pos.m_base_it));
         KLinkedListNode::Free(kernel, freed_node);

--- a/src/core/hle/kernel/k_memory_region.h
+++ b/src/core/hle/kernel/k_memory_region.h
@@ -82,9 +82,9 @@ public:
         type_id = type;
     }
 
-    constexpr bool Contains(u64 address) const {
+    constexpr bool Contains(u64 addr) const {
         ASSERT(this->GetEndAddress() != 0);
-        return this->GetAddress() <= address && address <= this->GetLastAddress();
+        return this->GetAddress() <= addr && addr <= this->GetLastAddress();
     }
 
     constexpr bool IsDerivedFrom(u32 type) const {

--- a/src/core/hle/kernel/k_port.cpp
+++ b/src/core/hle/kernel/k_port.cpp
@@ -9,8 +9,8 @@
 
 namespace Kernel {
 
-KPort::KPort(KernelCore& kernel)
-    : KAutoObjectWithSlabHeapAndContainer{kernel}, server{kernel}, client{kernel} {}
+KPort::KPort(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_}, server{kernel_}, client{kernel_} {}
 
 KPort::~KPort() = default;
 

--- a/src/core/hle/kernel/k_port.h
+++ b/src/core/hle/kernel/k_port.h
@@ -21,7 +21,7 @@ class KPort final : public KAutoObjectWithSlabHeapAndContainer<KPort, KAutoObjec
     KERNEL_AUTOOBJECT_TRAITS(KPort, KAutoObject);
 
 public:
-    explicit KPort(KernelCore& kernel);
+    explicit KPort(KernelCore& kernel_);
     virtual ~KPort();
 
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -118,11 +118,11 @@ private:
     std::bitset<num_slot_entries> is_slot_used;
 };
 
-ResultCode KProcess::Initialize(KProcess* process, Core::System& system, std::string name,
+ResultCode KProcess::Initialize(KProcess* process, Core::System& system, std::string process_name,
                                 ProcessType type) {
     auto& kernel = system.Kernel();
 
-    process->name = std::move(name);
+    process->name = std::move(process_name);
 
     process->resource_limit = kernel.GetSystemResourceLimit();
     process->status = ProcessStatus::Created;
@@ -373,8 +373,8 @@ void KProcess::Run(s32 main_thread_priority, u64 stack_size) {
 void KProcess::PrepareForTermination() {
     ChangeStatus(ProcessStatus::Exiting);
 
-    const auto stop_threads = [this](const std::vector<KThread*>& thread_list) {
-        for (auto& thread : thread_list) {
+    const auto stop_threads = [this](const std::vector<KThread*>& in_thread_list) {
+        for (auto& thread : in_thread_list) {
             if (thread->GetOwnerProcess() != this)
                 continue;
 
@@ -491,10 +491,10 @@ bool KProcess::IsSignaled() const {
     return is_signaled;
 }
 
-KProcess::KProcess(KernelCore& kernel)
-    : KAutoObjectWithSlabHeapAndContainer{kernel},
-      page_table{std::make_unique<KPageTable>(kernel.System())}, handle_table{kernel},
-      address_arbiter{kernel.System()}, condition_var{kernel.System()}, state_lock{kernel} {}
+KProcess::KProcess(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_},
+      page_table{std::make_unique<KPageTable>(kernel_.System())}, handle_table{kernel_},
+      address_arbiter{kernel_.System()}, condition_var{kernel_.System()}, state_lock{kernel_} {}
 
 KProcess::~KProcess() = default;
 

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -67,7 +67,7 @@ class KProcess final
     KERNEL_AUTOOBJECT_TRAITS(KProcess, KSynchronizationObject);
 
 public:
-    explicit KProcess(KernelCore& kernel);
+    explicit KProcess(KernelCore& kernel_);
     ~KProcess() override;
 
     enum : u64 {
@@ -90,7 +90,7 @@ public:
 
     static constexpr std::size_t RANDOM_ENTROPY_SIZE = 4;
 
-    static ResultCode Initialize(KProcess* process, Core::System& system, std::string name,
+    static ResultCode Initialize(KProcess* process, Core::System& system, std::string process_name,
                                  ProcessType type);
 
     /// Gets a reference to the process' page table.

--- a/src/core/hle/kernel/k_readable_event.cpp
+++ b/src/core/hle/kernel/k_readable_event.cpp
@@ -12,7 +12,7 @@
 
 namespace Kernel {
 
-KReadableEvent::KReadableEvent(KernelCore& kernel) : KSynchronizationObject{kernel} {}
+KReadableEvent::KReadableEvent(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
 
 KReadableEvent::~KReadableEvent() = default;
 

--- a/src/core/hle/kernel/k_readable_event.h
+++ b/src/core/hle/kernel/k_readable_event.h
@@ -18,7 +18,7 @@ class KReadableEvent : public KSynchronizationObject {
     KERNEL_AUTOOBJECT_TRAITS(KReadableEvent, KSynchronizationObject);
 
 public:
-    explicit KReadableEvent(KernelCore& kernel);
+    explicit KReadableEvent(KernelCore& kernel_);
     ~KReadableEvent() override;
 
     void Initialize(KEvent* parent_, std::string&& name_) {

--- a/src/core/hle/kernel/k_resource_limit.cpp
+++ b/src/core/hle/kernel/k_resource_limit.cpp
@@ -10,8 +10,8 @@
 namespace Kernel {
 constexpr s64 DefaultTimeout = 10000000000; // 10 seconds
 
-KResourceLimit::KResourceLimit(KernelCore& kernel)
-    : KAutoObjectWithSlabHeapAndContainer{kernel}, lock{kernel}, cond_var{kernel} {}
+KResourceLimit::KResourceLimit(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_}, lock{kernel_}, cond_var{kernel_} {}
 KResourceLimit::~KResourceLimit() = default;
 
 void KResourceLimit::Initialize(const Core::Timing::CoreTiming* core_timing_) {

--- a/src/core/hle/kernel/k_resource_limit.h
+++ b/src/core/hle/kernel/k_resource_limit.h
@@ -36,7 +36,7 @@ class KResourceLimit final
     KERNEL_AUTOOBJECT_TRAITS(KResourceLimit, KAutoObject);
 
 public:
-    explicit KResourceLimit(KernelCore& kernel);
+    explicit KResourceLimit(KernelCore& kernel_);
     virtual ~KResourceLimit();
 
     void Initialize(const Core::Timing::CoreTiming* core_timing_);

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -141,7 +141,7 @@ private:
 
     [[nodiscard]] static KSchedulerPriorityQueue& GetPriorityQueue(KernelCore& kernel);
 
-    void RotateScheduledQueue(s32 core_id, s32 priority);
+    void RotateScheduledQueue(s32 cpu_core_id, s32 priority);
 
     void Schedule() {
         ASSERT(GetCurrentThread()->GetDisableDispatchCount() == 1);

--- a/src/core/hle/kernel/k_server_port.cpp
+++ b/src/core/hle/kernel/k_server_port.cpp
@@ -14,7 +14,7 @@
 
 namespace Kernel {
 
-KServerPort::KServerPort(KernelCore& kernel) : KSynchronizationObject{kernel} {}
+KServerPort::KServerPort(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
 KServerPort::~KServerPort() = default;
 
 void KServerPort::Initialize(KPort* parent_, std::string&& name_) {

--- a/src/core/hle/kernel/k_server_port.h
+++ b/src/core/hle/kernel/k_server_port.h
@@ -29,7 +29,7 @@ private:
     using SessionList = boost::intrusive::list<KServerSession>;
 
 public:
-    explicit KServerPort(KernelCore& kernel);
+    explicit KServerPort(KernelCore& kernel_);
     virtual ~KServerPort() override;
 
     using HLEHandler = std::shared_ptr<SessionRequestHandler>;

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -23,7 +23,7 @@
 
 namespace Kernel {
 
-KServerSession::KServerSession(KernelCore& kernel) : KSynchronizationObject{kernel} {}
+KServerSession::KServerSession(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
 
 KServerSession::~KServerSession() {
     kernel.ReleaseServiceThread(service_thread);

--- a/src/core/hle/kernel/k_server_session.h
+++ b/src/core/hle/kernel/k_server_session.h
@@ -40,7 +40,7 @@ class KServerSession final : public KSynchronizationObject,
     friend class ServiceThread;
 
 public:
-    explicit KServerSession(KernelCore& kernel);
+    explicit KServerSession(KernelCore& kernel_);
     virtual ~KServerSession() override;
 
     virtual void Destroy() override;

--- a/src/core/hle/kernel/k_session.cpp
+++ b/src/core/hle/kernel/k_session.cpp
@@ -11,8 +11,8 @@
 
 namespace Kernel {
 
-KSession::KSession(KernelCore& kernel)
-    : KAutoObjectWithSlabHeapAndContainer{kernel}, server{kernel}, client{kernel} {}
+KSession::KSession(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_}, server{kernel_}, client{kernel_} {}
 KSession::~KSession() = default;
 
 void KSession::Initialize(KClientPort* port_, const std::string& name_) {

--- a/src/core/hle/kernel/k_session.h
+++ b/src/core/hle/kernel/k_session.h
@@ -17,7 +17,7 @@ class KSession final : public KAutoObjectWithSlabHeapAndContainer<KSession, KAut
     KERNEL_AUTOOBJECT_TRAITS(KSession, KAutoObject);
 
 public:
-    explicit KSession(KernelCore& kernel);
+    explicit KSession(KernelCore& kernel_);
     virtual ~KSession() override;
 
     void Initialize(KClientPort* port_, const std::string& name_);

--- a/src/core/hle/kernel/k_shared_memory.h
+++ b/src/core/hle/kernel/k_shared_memory.h
@@ -24,12 +24,11 @@ class KSharedMemory final
     KERNEL_AUTOOBJECT_TRAITS(KSharedMemory, KAutoObject);
 
 public:
-    explicit KSharedMemory(KernelCore& kernel);
+    explicit KSharedMemory(KernelCore& kernel_);
     ~KSharedMemory() override;
 
-    ResultCode Initialize(KernelCore& kernel_, Core::DeviceMemory& device_memory_,
-                          KProcess* owner_process_, KPageLinkedList&& page_list_,
-                          Svc::MemoryPermission owner_permission_,
+    ResultCode Initialize(Core::DeviceMemory& device_memory_, KProcess* owner_process_,
+                          KPageLinkedList&& page_list_, Svc::MemoryPermission owner_permission_,
                           Svc::MemoryPermission user_permission_, PAddr physical_address_,
                           std::size_t size_, std::string name_);
 
@@ -37,19 +36,19 @@ public:
      * Maps a shared memory block to an address in the target process' address space
      * @param target_process Process on which to map the memory block
      * @param address Address in system memory to map shared memory block to
-     * @param size Size of the shared memory block to map
+     * @param map_size Size of the shared memory block to map
      * @param permissions Memory block map permissions (specified by SVC field)
      */
-    ResultCode Map(KProcess& target_process, VAddr address, std::size_t size,
+    ResultCode Map(KProcess& target_process, VAddr address, std::size_t map_size,
                    Svc::MemoryPermission permissions);
 
     /**
      * Unmaps a shared memory block from an address in the target process' address space
      * @param target_process Process on which to unmap the memory block
      * @param address Address in system memory to unmap shared memory block
-     * @param size Size of the shared memory block to unmap
+     * @param unmap_size Size of the shared memory block to unmap
      */
-    ResultCode Unmap(KProcess& target_process, VAddr address, std::size_t size);
+    ResultCode Unmap(KProcess& target_process, VAddr address, std::size_t unmap_size);
 
     /**
      * Gets a pointer to the shared memory block

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -111,7 +111,7 @@ public:
     static constexpr s32 DefaultThreadPriority = 44;
     static constexpr s32 IdleThreadPriority = Svc::LowestThreadPriority + 1;
 
-    explicit KThread(KernelCore& kernel);
+    explicit KThread(KernelCore& kernel_);
     ~KThread() override;
 
 public:
@@ -318,7 +318,7 @@ public:
 
     [[nodiscard]] ResultCode GetPhysicalCoreMask(s32* out_ideal_core, u64* out_affinity_mask);
 
-    [[nodiscard]] ResultCode SetCoreMask(s32 core_id, u64 v_affinity_mask);
+    [[nodiscard]] ResultCode SetCoreMask(s32 cpu_core_id, u64 v_affinity_mask);
 
     [[nodiscard]] ResultCode SetActivity(Svc::ThreadActivity activity);
 
@@ -649,7 +649,7 @@ private:
                                                      std::function<void(void*)>&& init_func,
                                                      void* init_func_parameter);
 
-    static void RestorePriority(KernelCore& kernel, KThread* thread);
+    static void RestorePriority(KernelCore& kernel_ctx, KThread* thread);
 
     // For core KThread implementation
     ThreadContext32 thread_context_32{};

--- a/src/core/hle/kernel/k_transfer_memory.cpp
+++ b/src/core/hle/kernel/k_transfer_memory.cpp
@@ -9,8 +9,8 @@
 
 namespace Kernel {
 
-KTransferMemory::KTransferMemory(KernelCore& kernel)
-    : KAutoObjectWithSlabHeapAndContainer{kernel} {}
+KTransferMemory::KTransferMemory(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_} {}
 
 KTransferMemory::~KTransferMemory() = default;
 

--- a/src/core/hle/kernel/k_transfer_memory.h
+++ b/src/core/hle/kernel/k_transfer_memory.h
@@ -26,7 +26,7 @@ class KTransferMemory final
     KERNEL_AUTOOBJECT_TRAITS(KTransferMemory, KAutoObject);
 
 public:
-    explicit KTransferMemory(KernelCore& kernel);
+    explicit KTransferMemory(KernelCore& kernel_);
     virtual ~KTransferMemory() override;
 
     ResultCode Initialize(VAddr address_, std::size_t size_, Svc::MemoryPermission owner_perm_);

--- a/src/core/hle/kernel/k_writable_event.cpp
+++ b/src/core/hle/kernel/k_writable_event.cpp
@@ -8,7 +8,8 @@
 
 namespace Kernel {
 
-KWritableEvent::KWritableEvent(KernelCore& kernel) : KAutoObjectWithSlabHeapAndContainer{kernel} {}
+KWritableEvent::KWritableEvent(KernelCore& kernel_)
+    : KAutoObjectWithSlabHeapAndContainer{kernel_} {}
 
 KWritableEvent::~KWritableEvent() = default;
 

--- a/src/core/hle/kernel/k_writable_event.h
+++ b/src/core/hle/kernel/k_writable_event.h
@@ -18,7 +18,7 @@ class KWritableEvent final
     KERNEL_AUTOOBJECT_TRAITS(KWritableEvent, KAutoObject);
 
 public:
-    explicit KWritableEvent(KernelCore& kernel);
+    explicit KWritableEvent(KernelCore& kernel_);
     ~KWritableEvent() override;
 
     virtual void Destroy() override;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -51,11 +51,11 @@ MICROPROFILE_DEFINE(Kernel_SVC, "Kernel", "SVC", MP_RGB(70, 200, 70));
 namespace Kernel {
 
 struct KernelCore::Impl {
-    explicit Impl(Core::System& system, KernelCore& kernel)
-        : time_manager{system}, object_list_container{kernel}, system{system} {}
+    explicit Impl(Core::System& system_, KernelCore& kernel_)
+        : time_manager{system_}, object_list_container{kernel_}, system{system_} {}
 
-    void SetMulticore(bool is_multicore) {
-        this->is_multicore = is_multicore;
+    void SetMulticore(bool is_multi) {
+        is_multicore = is_multi;
     }
 
     void Initialize(KernelCore& kernel) {
@@ -599,19 +599,19 @@ struct KernelCore::Impl {
         irs_shared_mem = KSharedMemory::Create(system.Kernel());
         time_shared_mem = KSharedMemory::Create(system.Kernel());
 
-        hid_shared_mem->Initialize(system.Kernel(), system.DeviceMemory(), nullptr,
+        hid_shared_mem->Initialize(system.DeviceMemory(), nullptr,
                                    {hid_phys_addr, hid_size / PageSize},
                                    Svc::MemoryPermission::None, Svc::MemoryPermission::Read,
                                    hid_phys_addr, hid_size, "HID:SharedMemory");
-        font_shared_mem->Initialize(system.Kernel(), system.DeviceMemory(), nullptr,
+        font_shared_mem->Initialize(system.DeviceMemory(), nullptr,
                                     {font_phys_addr, font_size / PageSize},
                                     Svc::MemoryPermission::None, Svc::MemoryPermission::Read,
                                     font_phys_addr, font_size, "Font:SharedMemory");
-        irs_shared_mem->Initialize(system.Kernel(), system.DeviceMemory(), nullptr,
+        irs_shared_mem->Initialize(system.DeviceMemory(), nullptr,
                                    {irs_phys_addr, irs_size / PageSize},
                                    Svc::MemoryPermission::None, Svc::MemoryPermission::Read,
                                    irs_phys_addr, irs_size, "IRS:SharedMemory");
-        time_shared_mem->Initialize(system.Kernel(), system.DeviceMemory(), nullptr,
+        time_shared_mem->Initialize(system.DeviceMemory(), nullptr,
                                     {time_phys_addr, time_size / PageSize},
                                     Svc::MemoryPermission::None, Svc::MemoryPermission::Read,
                                     time_phys_addr, time_size, "Time:SharedMemory");


### PR DESCRIPTION
Now that the large kernel refactor is merged, we can eliminate the
remaining variable shadowing cases.