### PR TITLE
parent_of_member: Make sign conversion explicit in OffsetOfImpl()

### DIFF
--- a/src/common/parent_of_member.h
+++ b/src/common/parent_of_member.h
@@ -109,7 +109,8 @@ struct OffsetOfCalculator {
             }
         }
 
-        return (next - start) * sizeof(MemberType) + Offset;
+        return static_cast<ptrdiff_t>(static_cast<size_t>(next - start) * sizeof(MemberType) +
+                                      Offset);
     }
 
     static constexpr std::ptrdiff_t OffsetOf(MemberType ParentType::*member) {


### PR DESCRIPTION
Previously these conversions were implicit and causing quite a few
warnings on clang.