### PR TITLE
npad: Fix data race when updating devices

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -314,6 +314,8 @@ void Controller_NPad::OnInit() {
 
 void Controller_NPad::OnLoadInputDevices() {
     const auto& players = Settings::values.players.GetValue();
+
+    std::lock_guard lock{mutex};
     for (std::size_t i = 0; i < players.size(); ++i) {
         std::transform(players[i].buttons.begin() + Settings::NativeButton::BUTTON_HID_BEGIN,
                        players[i].buttons.begin() + Settings::NativeButton::BUTTON_HID_END,
@@ -348,6 +350,8 @@ void Controller_NPad::OnRelease() {
 }
 
 void Controller_NPad::RequestPadStateUpdate(u32 npad_id) {
+    std::lock_guard lock{mutex};
+
     const auto controller_idx = NPadIdToIndex(npad_id);
     const auto controller_type = connected_controllers[controller_idx].type;
     if (!connected_controllers[controller_idx].is_connected) {

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <atomic>
+#include <mutex>
+
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/quaternion.h"
@@ -563,6 +565,8 @@ private:
     using MotionArray = std::array<
         std::array<std::unique_ptr<Input::MotionDevice>, Settings::NativeMotion::NUM_MOTIONS_HID>,
         10>;
+
+    std::mutex mutex;
     ButtonArray buttons;
     StickArray sticks;
     VibrationArray vibrations;


### PR DESCRIPTION
Add a lock to avoid data races.
This reduces the number of -fsanitize=thread errors significantly.