### PR TITLE
common/detached_tasks: Wait for tasks before shutting down

### DIFF
--- a/src/common/detached_tasks.cpp
+++ b/src/common/detached_tasks.cpp
@@ -21,6 +21,8 @@ void DetachedTasks::WaitForAllTasks() {
 }
 
 DetachedTasks::~DetachedTasks() {
+    WaitForAllTasks();
+
     std::unique_lock lock{mutex};
     ASSERT(count == 0);
     instance = nullptr;


### PR DESCRIPTION
If this is not waited on, the synchronization primitives are destroyed
whe main exits and the detached task ends up signalling garbage and not
properly finishing.