### PR TITLE
vk_buffer_cache: Use emulated null buffers for transform feedback

### DIFF
--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -92,7 +92,7 @@ private:
 
     void ReserveQuadArrayLUT(u32 num_indices, bool wait_for_idle);
 
-    void ReserveNullIndexBuffer();
+    void ReserveNullBuffer();
 
     const Device& device;
     MemoryAllocator& memory_allocator;
@@ -105,8 +105,8 @@ private:
     VkIndexType quad_array_lut_index_type{};
     u32 current_num_indices = 0;
 
-    vk::Buffer null_index_buffer;
-    MemoryCommit null_index_buffer_commit;
+    vk::Buffer null_buffer;
+    MemoryCommit null_buffer_commit;
 
     Uint8Pass uint8_pass;
     QuadIndexedPass quad_index_pass;


### PR DESCRIPTION
Vulkan does not support null buffers on transform feedback bindings.
Emulate these using the same null buffer we were using for index
buffers.