### PR TITLE
common: fs: fs_util: Add BufferToUTF8String

### DIFF
--- a/src/common/fs/fs_util.cpp
+++ b/src/common/fs/fs_util.cpp
@@ -20,6 +20,10 @@ std::string ToUTF8String(std::u8string_view u8_string) {
     return std::string{u8_string.begin(), u8_string.end()};
 }
 
+std::string BufferToUTF8String(std::span<const u8> buffer) {
+    return std::string{buffer.begin(), std::ranges::find(buffer, u8{0})};
+}
+
 std::string PathToUTF8String(const std::filesystem::path& path) {
     return ToUTF8String(path.u8string());
 }

--- a/src/common/fs/fs_util.h
+++ b/src/common/fs/fs_util.h
@@ -47,6 +47,17 @@ concept IsChar = std::same_as<T, char>;
 [[nodiscard]] std::string ToUTF8String(std::u8string_view u8_string);
 
 /**
+ * Converts a buffer of bytes to a UTF8-encoded std::string.
+ * This converts from the start of the buffer until the first encountered null-terminator.
+ * If no null-terminator is found, this converts the entire buffer instead.
+ *
+ * @param buffer Buffer of bytes
+ *
+ * @returns UTF-8 encoded std::string.
+ */
+[[nodiscard]] std::string BufferToUTF8String(std::span<const u8> buffer);
+
+/**
  * Converts a filesystem path to a UTF-8 encoded std::string.
  *
  * @param path Filesystem path


### PR DESCRIPTION
Allows for direct conversion to std::string without having to convert std::u8string to std::string