### PR TITLE
video_core/engine: Consistently initialize rasterizer pointers

### DIFF
--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -299,7 +299,7 @@ public:
     };
 
 private:
-    VideoCore::RasterizerInterface* rasterizer;
+    VideoCore::RasterizerInterface* rasterizer = nullptr;
 
     /// Performs the copy from the source surface to the destination surface as configured in the
     /// registers.

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -227,7 +227,7 @@ private:
     Core::System& system;
 
     MemoryManager& memory_manager;
-    VideoCore::RasterizerInterface* rasterizer;
+    VideoCore::RasterizerInterface* rasterizer = nullptr;
 
     std::vector<u8> read_buffer;
     std::vector<u8> write_buffer;


### PR DESCRIPTION
Ensures all of the engines have consistent and deterministic
initialization of the rasterizer pointers.