### PR TITLE
render_target: Add missing initializer for size extent

### DIFF
--- a/src/video_core/texture_cache/render_targets.h
+++ b/src/video_core/texture_cache/render_targets.h
@@ -24,10 +24,10 @@ struct RenderTargets {
         return std::ranges::any_of(color_buffer_ids, contains) || contains(depth_buffer_id);
     }
 
-    std::array<ImageViewId, NUM_RT> color_buffer_ids;
-    ImageViewId depth_buffer_id;
+    std::array<ImageViewId, NUM_RT> color_buffer_ids{};
+    ImageViewId depth_buffer_id{};
     std::array<u8, NUM_RT> draw_buffers{};
-    Extent2D size;
+    Extent2D size{};
 };
 
 } // namespace VideoCommon


### PR DESCRIPTION
Everything else has a default constructor that does the straightforward
thing of initializing most members to a default value, except for the
size.

We explicitly initialize the size (and others, for consistency), to
prevent potential uninitialized reads from occurring. Particularly given
the largeish surface area that this struct is used in.