### PR TITLE
shader: Mark ConvertF16F32 and ConvertF32F16 as fp16 instructions

### DIFF
--- a/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
+++ b/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
@@ -111,6 +111,8 @@ void VisitUsages(Info& info, IR::Inst& inst) {
     case IR::Opcode::ConvertF16U16:
     case IR::Opcode::ConvertF16U32:
     case IR::Opcode::ConvertF16U64:
+    case IR::Opcode::ConvertF16F32:
+    case IR::Opcode::ConvertF32F16:
     case IR::Opcode::FPAbs16:
     case IR::Opcode::FPAdd16:
     case IR::Opcode::FPCeil16:


### PR DESCRIPTION
Fixes instances where fp16 types are not declared on SPIR-V but they are
used. This shouldn't happen on master, as it's been uncovered by an
additional optimization pass.