### PR TITLE
configuration: use tr instead of QStringLiteral for "None" item in

### DIFF
--- a/src/yuzu/configuration/configure_network.cpp
+++ b/src/yuzu/configuration/configure_network.cpp
@@ -48,7 +48,7 @@ ConfigureNetwork::ConfigureNetwork(QWidget* parent)
     ui->bcat_source->addItem(QStringLiteral("Boxcat"), QStringLiteral("boxcat"));
 #endif
 
-    ui->network_interface->addItem(QStringLiteral("None"));
+    ui->network_interface->addItem(tr("None"));
     for (const auto& interface : Network::GetAvailableNetworkInterfaces()) {
         ui->network_interface->addItem(QString::fromStdString(interface.name));
     }


### PR DESCRIPTION
network interface combobox