### PR TITLE
Implement Prevent/AllowOSSleep for Linux

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -285,6 +285,11 @@ if (USE_DISCORD_PRESENCE)
     target_compile_definitions(yuzu PRIVATE -DUSE_DISCORD_PRESENCE)
 endif()
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    find_package(Qt5 ${QT_VERSION} REQUIRED COMPONENTS DBus ${QT_PREFIX_HINT} ${YUZU_QT_NO_CMAKE_SYSTEM_PATH} REQUIRED)
+    target_link_libraries(yuzu PRIVATE Qt5::DBus)
+endif()
+
 if (YUZU_USE_QT_WEB_ENGINE)
     target_link_libraries(yuzu PRIVATE Qt5::WebEngineCore Qt5::WebEngineWidgets)
     target_compile_definitions(yuzu PRIVATE -DYUZU_USE_QT_WEB_ENGINE)

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -342,6 +342,11 @@ private:
     bool auto_paused = false;
     QTimer mouse_hide_timer;
 
+#ifdef __linux__
+    bool screensaver_inhibited = false;
+    uint32_t screensaver_dbus_cookie;
+#endif
+
     // FS
     std::shared_ptr<FileSys::VfsFilesystem> vfs;
     std::unique_ptr<FileSys::ManualContentProvider> provider;


### PR DESCRIPTION
It uses the org.freedesktop.ScreenSaver DBus service and call
Inhibit/UnInhibit to respectively prevent/allow OS to got to sleep.