### PR TITLE
configure_graphics_advanced: Hide input compute toggle a little later

### DIFF
--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -12,11 +12,11 @@ ConfigureGraphicsAdvanced::ConfigureGraphicsAdvanced(const Core::System& system_
 
     ui->setupUi(this);
 
-    ui->enable_compute_pipelines_checkbox->setVisible(false);
-
     SetupPerGameUI();
 
     SetConfiguration();
+
+    ui->enable_compute_pipelines_checkbox->setVisible(false);
 }
 
 ConfigureGraphicsAdvanced::~ConfigureGraphicsAdvanced() = default;


### PR DESCRIPTION
SetColoredTristate causes the setting to become visible as it calls `show()` on it.